### PR TITLE
fix: 잘못된 Claude CLI 플래그 제거

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -64,18 +64,11 @@ export async function runClaude(options: ClaudeRunOptions): Promise<ClaudeRunRes
     ...config.additionalArgs,
   ];
 
-  if (options.enableAgents) {
-    args.push("--allow-tools");
-  }
-
   if (systemPrompt) {
     args.push("--system-prompt", systemPrompt);
   }
   if (options.jsonSchema) {
     args.push("--json-schema", options.jsonSchema);
-  }
-  if (options.enableAgents) {
-    args.push("--allow-agents");
   }
 
   const startTime = Date.now();


### PR DESCRIPTION
## Summary

- `--allow-tools`, `--allow-agents`는 존재하지 않는 Claude CLI 플래그
- `bypassPermissions` 모드에서 이미 모든 도구가 허용되므로 불필요
- 프롬프트 프리픽스(에이전트 활용 안내)는 유지

## Verification

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 30파일 229개 테스트 통과