### PR TITLE
[AQ-#25] feat: aqm update에 --clean 옵션 추가 (브랜치 전환 시 고아파일 정리)

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -16,29 +16,25 @@ is_running() {
 
 case "${1:-}" in
   update)
-    # Parse arguments
     BRANCH="main"
     CLEAN_FLAG=false
 
-    # Process all arguments
     while [ $# -gt 1 ]; do
-      case "$2" in
+      shift
+      case "$1" in
         --branch)
-          BRANCH="${3:-main}"
-          shift 2
+          BRANCH="${2:-main}"
+          shift
           ;;
         --clean)
           CLEAN_FLAG=true
-          shift
           ;;
         --*)
-          echo "Unknown option: $2"
+          echo "Unknown option: $1"
           exit 1
           ;;
         *)
-          # Positional argument (e.g., aqm update develop)
-          BRANCH="$2"
-          shift
+          BRANCH="$1"
           ;;
       esac
     done


### PR DESCRIPTION
## Summary

Resolves #25 — feat: aqm update에 --clean 옵션 추가 (브랜치 전환 시 고아파일 정리)

브랜치 전환 시(예: develop → main) 이전 브랜치에서 추가된 파일이 untracked 고아파일로 남는 문제가 있다. 현재 `aqm update`는 `git checkout` + `git pull`만 수행하므로 이러한 파일을 정리하지 않는다. `--clean` 옵션을 추가하여 사용자가 명시적으로 요청할 때만 `git clean -fd`로 untracked 파일을 제거하도록 한다.

## Requirements

- --clean 플래그 파싱 로직 추가 (기본값 OFF)
- --clean 지정 시 git clean -fd 실행
- 실행 전 삭제 대상 파일 목록 출력 (git clean -fd --dry-run)
- .gitignore에 포함된 파일은 영향 없음 확인 (-fd는 ignored 파일 미삭제)
- --clean 없이 실행 시 기존 동작 유지

## Implementation Phases

- Phase 0: bin/aqm update에 --clean 옵션 구현 — SUCCESS (60a16da3)

## Risks

- 사용자가 의도치 않게 --clean을 사용할 경우 중요한 untracked 파일 삭제 가능 (안전장치: 기본값 OFF, dry-run 미리보기)
- git clean -fd는 되돌릴 수 없으므로 명확한 경고 메시지 필요

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/25-feat-aqm-update-clean` → `develop`


Closes #25