### PR TITLE
[AQ-#41] bug: concurrency 2 설정에서 동시 실행이 안 되는 버그

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -23,6 +23,8 @@ export class JobQueue {
   private stuckTimeoutMs: number;
   private shuttingDown: boolean = false;
   private stuckAborted: Set<string> = new Set();
+  private isProcessing: boolean = false;
+  private needsReprocess: boolean = false;
 
   constructor(store: JobStore, concurrency: number, handler: JobHandler, stuckTimeoutMs: number = 600000) {
     this.store = store;
@@ -247,63 +249,81 @@ export class JobQueue {
   }
 
   private async processNext(): Promise<void> {
-    // Collect job IDs that are skipped due to unmet dependencies (put back at end)
-    const deferred: string[] = [];
-
-    while (this.running.size < this.concurrency && this.pending.length > 0) {
-      const jobId = this.pending.shift()!;
-
-      if (this.cancelled.has(jobId)) {
-        this.cancelled.delete(jobId);
-        continue;
-      }
-
-      const job = this.store.get(jobId);
-      if (!job) {
-        continue;
-      }
-
-      // Check dependency readiness
-      if (job.dependencies && job.dependencies.length > 0) {
-        const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.store);
-        if (!met) {
-          // Check if any dependency has permanently failed — fail the dependent job immediately
-          let depFailed = false;
-          for (const depNum of job.dependencies) {
-            const depJob = this.store.findAnyByIssue(depNum, job.repo);
-            if (depJob && (depJob.status === "failure" || depJob.status === "cancelled")) {
-              logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
-              this.store.update(jobId, {
-                status: "failure",
-                completedAt: new Date().toISOString(),
-                error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
-              });
-              depFailed = true;
-              break;
-            }
-          }
-          if (!depFailed) {
-            logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
-            deferred.push(jobId);
-          }
-          continue;
-        }
-      }
-
-      this.running.add(jobId);
-      this.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
-
-      logger.info(`Job started: ${jobId}`);
-
-      // Run async - don't await, let it run in background
-      this.executeJob(job).catch(err => {
-        logger.error(`Job ${jobId} unexpected error: ${err}`);
-      });
+    // Prevent re-entrancy
+    if (this.isProcessing) {
+      this.needsReprocess = true;
+      return;
     }
 
-    // Re-append deferred jobs so they are retried on the next processNext() call
-    for (const jobId of deferred) {
-      this.pending.push(jobId);
+    this.isProcessing = true;
+    this.needsReprocess = false;
+
+    try {
+      // Collect job IDs that are skipped due to unmet dependencies (put back at end)
+      const deferred: string[] = [];
+
+      while (this.running.size < this.concurrency && this.pending.length > 0) {
+        const jobId = this.pending.shift()!;
+
+        if (this.cancelled.has(jobId)) {
+          this.cancelled.delete(jobId);
+          continue;
+        }
+
+        const job = this.store.get(jobId);
+        if (!job) {
+          continue;
+        }
+
+        // Check dependency readiness
+        if (job.dependencies && job.dependencies.length > 0) {
+          const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.store);
+          if (!met) {
+            // Check if any dependency has permanently failed — fail the dependent job immediately
+            let depFailed = false;
+            for (const depNum of job.dependencies) {
+              const depJob = this.store.findAnyByIssue(depNum, job.repo);
+              if (depJob && (depJob.status === "failure" || depJob.status === "cancelled")) {
+                logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
+                this.store.update(jobId, {
+                  status: "failure",
+                  completedAt: new Date().toISOString(),
+                  error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
+                });
+                depFailed = true;
+                break;
+              }
+            }
+            if (!depFailed) {
+              logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
+              deferred.push(jobId);
+            }
+            continue;
+          }
+        }
+
+        this.running.add(jobId);
+        this.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
+
+        logger.info(`Job started: ${jobId}`);
+
+        // Run async - don't await, let it run in background
+        this.executeJob(job).catch(err => {
+          logger.error(`Job ${jobId} unexpected error: ${err}`);
+        });
+      }
+
+      // Re-append deferred jobs so they are retried on the next processNext() call
+      for (const jobId of deferred) {
+        this.pending.push(jobId);
+      }
+    } finally {
+      this.isProcessing = false;
+
+      // If another call was made while processing, handle it now
+      if (this.needsReprocess) {
+        setTimeout(() => this.processNext(), 0);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Resolves #41 — bug: concurrency 2 설정에서 동시 실행이 안 되는 버그

concurrency 2로 설정했을 때, running job이 1개인 상태에서 새 job이 enqueue되어도 즉시 시작되지 않고 기존 job이 완료된 후에야 시작됩니다. 근본 원인은 processNext() 메서드에 재진입 방지 로직이 없어서, 여러 호출이 동시에 발생할 때 pending에서 job을 shift하고 running에 add하는 과정에서 race condition이 발생하기 때문입니다.

## Requirements

- config.general.concurrency: 2 설정 시 실제로 2개 job이 동시 실행되어야 함
- addJob → processNext() 호출 시 running.size < concurrency면 즉시 다음 job 시작
- 기존 동작(의존성 체크, 취소, stuck 처리 등)을 깨뜨리지 않을 것
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase 0: processNext() 재진입 방지 로직 추가 — SUCCESS (36e36e41)

## Risks

- 재진입 방지 로직 추가 시 기존 호출 흐름에 영향을 줄 수 있음
- 테스트에서 타이밍 의존적인 동작을 검증해야 하므로 flaky test 가능성
- processNext() 변경이 stuck checker, recover, executeJob finally 등 여러 호출 지점에 영향

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/41-bug-concurrency-2` → `develop`


Closes #41