### PR TITLE
[AQ-#59] feat: npm 글로벌 패키지 배포 (npm install -g ai-quartermaster)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "tsx src/cli.ts",
     "build": "tsc",
-    "postbuild": "node -e \"const fs = require('fs'); const path = 'dist/cli.js'; const content = fs.readFileSync(path, 'utf8'); if (!content.startsWith('#!/usr/bin/env node')) { fs.writeFileSync(path, '#!/usr/bin/env node\\n' + content); console.log('Shebang added to dist/cli.js'); } else { console.log('Shebang already present in dist/cli.js'); }\"",
+    "postbuild": "node scripts/add-shebang.cjs",
     "prepublishOnly": "npm run typecheck && npm run lint && npm run test && npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/add-shebang.cjs
+++ b/scripts/add-shebang.cjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+const filepath = 'dist/cli.js';
+const shebang = '#!/usr/bin/env node\n';
+const content = fs.readFileSync(filepath, 'utf8');
+
+if (!content.startsWith(shebang)) {
+  fs.writeFileSync(filepath, shebang + content);
+}


### PR DESCRIPTION
## Summary

Resolves #59 — feat: npm 글로벌 패키지 배포 (npm install -g ai-quartermaster)

현재 ai-quartermaster는 git clone + install.sh 방식으로만 설치 가능하다. npm install -g ai-quartermaster로 간편하게 설치하고 aqm 명령어를 글로벌로 사용할 수 있도록 package.json 설정과 빌드 파이프라인을 구성해야 한다.

## Requirements

- package.json에 bin 필드 설정 (aqm -> dist/cli.js 매핑)
- package.json에 files 필드 설정 (배포 대상 파일만 포함)
- npm install -g ai-quartermaster로 설치 가능하도록 구성
- 설치 후 aqm 명령어가 글로벌로 사용 가능
- 기존 git clone 설치 방식(bin/aqm bash 스크립트)은 개발용으로 유지
- prepublishOnly 스크립트로 빌드 자동 실행
- 빌드 결과물(dist/cli.js)에 Node.js shebang 추가

## Implementation Phases

- Phase 0: package.json 설정 및 빌드 파이프라인 — SUCCESS (9df9f45f)

## Risks

- 빌드 후 shebang이 누락되면 npm 글로벌 설치 후 실행 불가
- files 필드 설정 오류 시 필요한 파일 누락 가능
- 기존 bin/aqm bash 스크립트와 npm bin 설정 충돌 가능성

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/59-feat-npm-npm-install-g-ai-quartermaster` → `develop`


Closes #59