### PR TITLE
[AQ-#76] fix: 대시보드 상단 통계 카운트 불일치 및 로딩 깜빡임

### DIFF
--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -201,5 +201,4 @@ apiFetch('/api/jobs')
   .then(handleData)
   .catch(function() {});
 
-fetchStats();
 connectSSE();

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -287,7 +287,7 @@ function renderFromState() {
   var filtered = filterJobs(allJobs);
 
   // Update filter counts
-  document.getElementById('cnt-all').textContent = allJobs.length;
+  document.getElementById('cnt-all').textContent = allJobs.filter(function(j) { return j.status !== 'archived'; }).length;
   document.getElementById('cnt-running').textContent = allJobs.filter(function(j) { return j.status === 'running'; }).length;
   document.getElementById('cnt-success').textContent = allJobs.filter(function(j) { return j.status === 'success'; }).length;
   document.getElementById('cnt-failure').textContent = allJobs.filter(function(j) { return j.status === 'failure'; }).length;


### PR DESCRIPTION
## Summary

Resolves #76 — fix: 대시보드 상단 통계 카운트 불일치 및 로딩 깜빡임

대시보드에서 상단 stat-total 값과 사이드바 cnt-all 값이 archived 작업 제외 기준이 다르게 적용되어 불일치한다. 또한 Boot 시 fetchStats()와 /api/jobs가 동시에 호출되어 stat 값이 두 번 갱신되면서 UI 깜빡임이 발생한다.

## Requirements

- 상단 stat-total과 사이드바 cnt-all이 동일하게 archived를 제외한 값으로 표시
- fetchStats()와 /api/jobs 응답 경합으로 인한 수치 깜빡임 해소
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: cnt-all archived 제외 기준 통일 — SUCCESS (bcd5dced)
- Phase 1: Boot 시 fetchStats() 중복 호출 제거 — SUCCESS (bcd5dced)

## Risks

- cnt-all 기준 변경 시 필터 탭의 'All' 표시 의미가 달라질 수 있음 (전체 → 활성 전체)
- fetchStats() 제거 시 /api/stats 엔드포인트를 사용하던 다른 기능에 영향 가능 (확인 결과 Boot 시에만 호출됨)

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/76-fix` → `develop`


Closes #76