### PR TITLE
[AQ-#101] refactor: PipelineContext 타입 및 상수 추출

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -52,9 +52,6 @@ import {
 } from "./pipeline-context.js";
 
 
-
-
-
 export async function runPipeline(input: OrchestratorInput): Promise<OrchestratorResult> {
   const { issueNumber, repo, config, aqRoot } = input;
   const logger = getLogger();
@@ -902,7 +899,3 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     return { success: false, state: "FAILED", error: rollbackInfo ? `${errMsg}. ${rollbackInfo}` : errMsg };
   }
 }
-
-
-// Re-export for backward compatibility
-export { type OrchestratorInput, type OrchestratorResult } from "./pipeline-context.js";

--- a/src/pipeline/pipeline-context.ts
+++ b/src/pipeline/pipeline-context.ts
@@ -4,6 +4,7 @@ import type { PipelineState } from "../types/pipeline.js";
 import type { AQConfig } from "../types/config.js";
 import type { PipelineReport } from "./result-reporter.js";
 import type { JobLogger } from "../queue/job-logger.js";
+import type { PipelineCheckpoint } from "./checkpoint.js";
 
 export interface OrchestratorInput {
   issueNumber: number;
@@ -12,7 +13,7 @@ export interface OrchestratorInput {
   projectRoot?: string;  // optional override; falls back to project config
   aqRoot?: string;       // AI Quartermaster root (where prompts/ lives)
   jobLogger?: JobLogger;
-  resumeFrom?: import("./checkpoint.js").PipelineCheckpoint;
+  resumeFrom?: PipelineCheckpoint;
   isRetry?: boolean;     // true if this is a retry of a previously failed job
 }
 


### PR DESCRIPTION
## Summary

Resolves #101 — refactor: PipelineContext 타입 및 상수 추출

orchestrator.ts가 947줄의 God Function으로, 타입/상수/유틸 함수가 함께 섞여 있어 유지보수가 어렵다. PipelineContext 관련 타입(OrchestratorInput, OrchestratorResult), 상수(STATE_ORDER), 유틸 함수(isPastState, saveResult)를 별도 파일로 추출하여 모듈화 및 재사용성을 개선한다.

## Requirements

- src/pipeline/pipeline-context.ts 생성: OrchestratorInput, OrchestratorResult 인터페이스, STATE_ORDER 상수, isPastState(), saveResult() 함수 추출
- src/pipeline/orchestrator.ts에서 해당 코드 제거 후 pipeline-context.ts에서 import로 교체
- 기존 동작 변경 없이 타입만 추출 (순수 리팩터링)
- npx tsc --noEmit 통과 필수
- npx vitest run 통과 필수

## Implementation Phases

- Phase 0: pipeline-context.ts 생성 — SUCCESS (503dd682)
- Phase 1: orchestrator.ts import 교체 — SUCCESS (0b27927e)

## Risks

- 순환 의존성 발생 가능 - pipeline-context.ts가 orchestrator.ts의 다른 타입을 참조하지 않도록 주의
- 테스트 파일에서 직접 import하는 경우 경로 수정 필요할 수 있음

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/101-refactor-pipelinecontext` → `develop`


Closes #101