### PR TITLE
fix: 대시보드 설정 탭 i18n 키 누락 수정

### DIFF
--- a/src/server/public/js/i18n.js
+++ b/src/server/public/js/i18n.js
@@ -9,7 +9,7 @@ var i18n = {
     logs: "로그",
     repositories: "저장소",
     automations: "자동화",
-    settings: "설정",
+    settings: { _: "설정", general: "일반", safety: "안전", review: "리뷰" },
     totalJobs: "전체 작업",
     successRate: "성공률",
     active: "실행 중",
@@ -62,7 +62,7 @@ var i18n = {
     logs: "Logs",
     repositories: "Repositories",
     automations: "Automations",
-    settings: "Settings",
+    settings: { _: "Settings", general: "General", safety: "Safety", review: "Review" },
     totalJobs: "Total Jobs",
     successRate: "Success Rate",
     active: "Active",
@@ -118,6 +118,7 @@ function t(key) {
   var keys = key.split('.');
   var val = i18n[currentLang];
   for (var i = 0; i < keys.length; i++) val = val ? val[keys[i]] : undefined;
+  if (val !== undefined && val !== null && typeof val === 'object' && val._) return val._;
   return val !== undefined && val !== null ? val : key;
 }
 


### PR DESCRIPTION
## Summary

- settings i18n 키를 문자열→객체로 변경 (settings.general/safety/review 지원)
- t() 함수에 객체 fallback (_키) 처리 추가

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 통과