### PR TITLE
[AQ-#109] test: simplify-runner.ts + dependency-installer.ts 테스트 추가

### DIFF
--- a/tests/pipeline/dependency-installer.test.ts
+++ b/tests/pipeline/dependency-installer.test.ts
@@ -3,9 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../../src/utils/cli-runner.js", () => ({
   runShell: vi.fn(),
 }));
-vi.mock("../../src/utils/logger.js", () => ({
-  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-}));
 
 import { installDependencies } from "../../src/pipeline/dependency-installer.js";
 import { runShell } from "../../src/utils/cli-runner.js";
@@ -28,7 +25,7 @@ describe("installDependencies", () => {
       stdout: "Dependencies installed",
       stderr: "",
       exitCode: 0,
-    });
+    } as any);
 
     await installDependencies("   ", { cwd: "/test/dir" });
 

--- a/tests/review/simplify-runner.test.ts
+++ b/tests/review/simplify-runner.test.ts
@@ -100,7 +100,7 @@ describe("runSimplify", () => {
       durationMs: 100,
     });
     mockRunCli.mockResolvedValue({
-      stdout: "", // Empty diff means no changes
+      stdout: "",
       stderr: "",
       exitCode: 0,
     });
@@ -128,14 +128,14 @@ describe("runSimplify", () => {
       durationMs: 100,
     });
     mockRunCli.mockResolvedValue({
-      stdout: "2\t1\tsrc/test.ts\n", // Has changes
+      stdout: "2\t1\tsrc/test.ts\n",
       stderr: "",
       exitCode: 0,
     });
     mockRunShell.mockResolvedValue({
       stdout: "Test failed",
       stderr: "Error in tests",
-      exitCode: 1, // Test failure
+      exitCode: 1,
     });
 
     const result = await runSimplify(mockContext);
@@ -168,14 +168,14 @@ describe("runSimplify", () => {
       durationMs: 100,
     });
     mockRunCli.mockResolvedValue({
-      stdout: "3\t5\tsrc/test.ts\n2\t1\tsrc/utils.ts\n", // Has changes
+      stdout: "3\t5\tsrc/test.ts\n2\t1\tsrc/utils.ts\n",
       stderr: "",
       exitCode: 0,
     });
     mockRunShell.mockResolvedValue({
       stdout: "All tests passed",
       stderr: "",
-      exitCode: 0, // Test success
+      exitCode: 0,
     });
     mockParseNumstat.mockReturnValue({
       insertions: 5,
@@ -210,7 +210,7 @@ describe("runSimplify", () => {
       durationMs: 100,
     });
     mockRunCli.mockResolvedValue({
-      stdout: "", // No changes
+      stdout: "",
       stderr: "",
       exitCode: 0,
     });
@@ -252,7 +252,7 @@ describe("runSimplify", () => {
       durationMs: 100,
     });
     mockRunCli.mockResolvedValue({
-      stdout: "0\t0\t\n", // Empty file changes
+      stdout: "0\t0\t\n",
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
## Summary

Resolves #109 — test: simplify-runner.ts + dependency-installer.ts 테스트 추가

simplify-runner.ts와 dependency-installer.ts 모듈에 대한 테스트가 전혀 없어서 코드 변경 시 회귀 버그를 감지할 수 없는 상태입니다. 두 모듈의 핵심 기능(간소화 실행/롤백, 의존성 설치 성공/실패)에 대한 유닛 테스트를 추가하여 코드 품질을 보장해야 합니다.

## Requirements

- tests/review/simplify-runner.test.ts 생성: runSimplify 함수의 간소화 실행, 롤백, 실패 처리 테스트
- tests/pipeline/dependency-installer.test.ts 생성: installDependencies 함수의 설치 성공/실패, 빈 명령어 처리 테스트
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: simplify-runner 테스트 작성 — SUCCESS (7f21fe59)
- Phase 1: dependency-installer 테스트 작성 — SUCCESS (7f21fe59)

## Risks

- mock 설정 오류로 인한 테스트 실패
- 비동기 처리 순서 관련 flaky 테스트 가능성

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/109-test-simplify-runner-ts-dependency-installer-ts` → `develop`


Closes #109