### PR TITLE
fix: 설정 렌더링 에러 상세 원인 표시

### DIFF
--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -99,7 +99,8 @@ function loadSettings() {
         try {
           renderSettingsView(data.config);
         } catch (renderError) {
-          showErrorMessage('설정을 렌더링하는데 실패했습니다.');
+          console.error('Settings render error:', renderError);
+          showErrorMessage('설정을 렌더링하는데 실패했습니다: ' + renderError.message);
         }
       } else {
         showErrorMessage('설정 데이터가 없습니다.');


### PR DESCRIPTION
## Summary

- 설정 뷰 렌더링 실패 시 에러 메시지에 상세 원인(error.message) 추가
- 브라우저 콘솔에도 console.error 출력으로 디버깅 용이

## Test plan

- [x] 기존 테스트 통과