### PR TITLE
fix: 대시보드 설정 뷰 버그 전수 수정

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -361,29 +361,28 @@
       <div class="p-6">
         <form id="add-project-form" class="space-y-4">
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <!-- Repository Path Field -->
+            <!-- GitHub Repository Field -->
             <div class="space-y-2">
-              <label for="repo-path" class="text-sm font-bold text-on-surface/80" data-i18n="repositoryPath">저장소 경로</label>
+              <label for="project-repo" class="text-sm font-bold text-on-surface/80" data-i18n="repository">저장소</label>
               <input
                 type="text"
-                id="repo-path"
+                id="project-repo"
                 name="repo"
                 class="w-full px-4 py-3 rounded-lg border border-outline-variant/30 bg-surface-container-lowest text-on-surface outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50 transition-colors font-mono text-sm"
-                data-i18n-placeholder="repositoryPlaceholder"
-                placeholder="예: /home/user/my-project"
+                placeholder="owner/repo"
                 required
               />
             </div>
-            <!-- Trigger Label Field -->
+            <!-- Local Path Field -->
             <div class="space-y-2">
-              <label for="trigger-label" class="text-sm font-bold text-on-surface/80" data-i18n="triggerLabel">트리거 라벨</label>
+              <label for="project-path" class="text-sm font-bold text-on-surface/80" data-i18n="repositoryPath">로컬 경로</label>
               <input
                 type="text"
-                id="trigger-label"
-                name="label"
+                id="project-path"
+                name="path"
                 class="w-full px-4 py-3 rounded-lg border border-outline-variant/30 bg-surface-container-lowest text-on-surface outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50 transition-colors font-mono text-sm"
-                data-i18n-placeholder="labelPlaceholder"
-                placeholder="예: implement"
+                data-i18n-placeholder="repositoryPlaceholder"
+                placeholder="예: /home/user/my-project"
                 required
               />
             </div>

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -150,7 +150,7 @@ function saveSettings() {
   apiFetch('/api/config', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ config: collectFormData() })
+    body: JSON.stringify(collectFormData())
   })
     .then(function(r) {
       if (r.ok) {
@@ -270,12 +270,12 @@ function addProject() {
   var formData = new FormData(form);
   var projectData = {
     repo: formData.get('repo'),
-    label: formData.get('label')
+    path: formData.get('path')
   };
 
   // Validate form data
-  if (!projectData.repo || !projectData.label) {
-    showProjectMessage('저장소 경로와 트리거 라벨을 모두 입력해주세요.', 'error');
+  if (!projectData.repo || !projectData.path) {
+    showProjectMessage('저장소(owner/repo)와 로컬 경로를 모두 입력해주세요.', 'error');
     return;
   }
 


### PR DESCRIPTION
## Summary

- 프로젝트 추가 폼: label → path 필드로 교체 (API 계약 일치)
- 프로젝트 추가 JS: repo + path 전송으로 수정
- 설정 저장: config wrapper 제거
- 설정 렌더링 에러 상세 원인 표시
- setSettingsTab classList.toggle 공백 토큰 에러 수정

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 통과