### PR TITLE
[AQ-#154] feat: 대시보드 다크/라이트 테마 설정 저장

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -81,13 +81,9 @@
 </script>
 <!-- Theme restoration script - prevents FOUC by applying theme before render -->
 <script>
-(function() {
-  var saved = localStorage.getItem('aqm-theme');
-  if (saved === 'light') {
-    document.documentElement.classList.remove('dark');
-  }
-  // If no saved theme or saved theme is 'dark', html already has class="dark"
-})();
+if (localStorage.getItem('aqm-theme') === 'light') {
+  document.documentElement.classList.remove('dark');
+}
 </script>
 <style>
     .material-symbols-outlined {

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -405,12 +405,10 @@ applyTranslations();
 
 // Update theme button icon based on current theme
 (function() {
-  var isDark = document.documentElement.classList.contains('dark');
   var themeBtn = document.getElementById('btn-theme');
   if (themeBtn) {
-    themeBtn.textContent = isDark ? 'dark_mode' : 'light_mode';
+    themeBtn.textContent = document.documentElement.classList.contains('dark') ? 'dark_mode' : 'light_mode';
   }
-  // Restore archived toggle
   initArchivedToggle();
 })();
 

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -49,24 +49,24 @@ const ctx = {
 };
 
 describe("createDraftPR", () => {
+  const options = { cwd: "/tmp", promptsDir: "/prompts" };
+
   beforeEach(() => vi.clearAllMocks());
 
   it("should create PR with correct arguments", async () => {
     mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/1", stderr: "", exitCode: 0 });
-    const result = await createDraftPR(prConfig, ghConfig, ctx, { cwd: "/tmp", promptsDir: "/prompts" });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
     expect(result).toEqual({ url: "https://github.com/test/repo/pull/1", number: 1 });
     expect(mockRunCli).toHaveBeenCalled();
   });
 
   it("should throw on failure", async () => {
     mockRunCli.mockResolvedValue({ stdout: "", stderr: "error", exitCode: 1 });
-    await expect(createDraftPR(prConfig, ghConfig, ctx, { cwd: "/tmp", promptsDir: "/prompts" })).rejects.toThrow("Failed to create PR: error");
+    await expect(createDraftPR(prConfig, ghConfig, ctx, options)).rejects.toThrow("Failed to create PR: error");
   });
 
   it("should skip in dry run mode", async () => {
-    const dryConfig = { ...prConfig };
-    const dryGh = { ...ghConfig };
-    const result = await createDraftPR(dryConfig, dryGh, ctx, { cwd: "/tmp", promptsDir: "/prompts", dryRun: true });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, { ...options, dryRun: true });
     expect(result).toEqual({ url: "https://github.com/dry-run", number: 0 });
   });
 });

--- a/tests/pipeline/core-loop.test.ts
+++ b/tests/pipeline/core-loop.test.ts
@@ -791,14 +791,11 @@ describe("runCoreLoop", () => {
       mockGeneratePlan.mockResolvedValue(plan);
       mockSchedulePhases.mockReturnValue({
         success: true,
-        groups: [{ level: 0, phases: phases }],
+        groups: [{ level: 0, phases }],
       });
 
-      const frontendResult = makeSuccessResult(0, "Frontend");
-      frontendResult.costUsd = 0.035;
-
-      const backendResult = makeSuccessResult(1, "Backend");
-      backendResult.costUsd = 0.030;
+      const frontendResult = { ...makeSuccessResult(0, "Frontend"), costUsd: 0.035 };
+      const backendResult = { ...makeSuccessResult(1, "Backend"), costUsd: 0.030 };
 
       mockExecutePhase
         .mockResolvedValueOnce(frontendResult)


### PR DESCRIPTION
## Summary

Resolves #154 — feat: 대시보드 다크/라이트 테마 설정 저장

현재 대시보드의 테마 전환 기능은 localStorage에 저장하고 복원하는 로직이 app.js Boot 섹션에 있어 body 끝에서 실행됩니다. 이로 인해 페이지 로드 시 HTML이 먼저 렌더링된 후 테마가 적용되어 깜빡임(FOUC)이 발생합니다. head에 인라인 스크립트를 추가하여 렌더링 전에 테마를 즉시 적용해야 합니다.

## Requirements

- 테마 선택을 localStorage에 저장하여 새로고침 후에도 유지
- 페이지 로드 시 저장된 테마 즉시 적용 (깜빡임 방지)

## Implementation Phases

- Phase 0: 테마 복원 인라인 스크립트 추가 — SUCCESS (f3933e31)

## Risks

- 인라인 스크립트와 app.js Boot 섹션 간 로직 중복/불일치 가능성
- localStorage 키 이름(aqm-theme)이 변경되면 기존 사용자 설정 손실

---

> Generated by AI 병참부 (AI Quartermaster)
> Branch: `aq/154-feat` → `develop`


Closes #154