### PR TITLE
feat: CI에 커버리지 threshold 체크 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npx eslint src/ tests/
-      - run: npm test
+      - run: npx vitest run --coverage


### PR DESCRIPTION
## Summary
- ci.yml의 `npm test` → `npx vitest run --coverage`로 교체
- vitest.config.ts의 threshold 70% 설정이 CI에서 자동 적용됨

Closes #183

## Test plan
- [ ] CI 실행 시 커버리지 리포트 출력 확인
- [ ] 70% 미달 시 CI 실패하는지 확인