### PR TITLE
[AQ-#238] feat: 파이프라인 훅 타입 정의 + config.yml 스키마 확장

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -153,7 +153,4 @@ export const DEFAULT_CONFIG: AQConfig = {
     },
   },
   executionMode: "standard",
-  hooks: {
-    // No hooks configured by default - users can add them in config.yml
-  },
 };

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -153,4 +153,7 @@ export const DEFAULT_CONFIG: AQConfig = {
     },
   },
   executionMode: "standard",
+  hooks: {
+    // No hooks configured by default - users can add them in config.yml
+  },
 };

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -296,6 +296,28 @@ const projectConfigSchema = z.object({
   }).partial().optional(),
 }).strict();
 
+// Hook validation schemas
+const hookDefinitionSchema = z.object({
+  command: z.string().min(1),
+  timeout: z.number().int().positive().optional(),
+});
+
+const hookTimingSchema = z.enum([
+  "pre-plan",
+  "post-plan",
+  "pre-phase",
+  "post-phase",
+  "pre-review",
+  "post-review",
+  "pre-pr",
+  "post-pr",
+]);
+
+const hooksConfigSchema = z.record(
+  hookTimingSchema,
+  z.array(hookDefinitionSchema)
+).optional();
+
 const aqConfigSchema = z.object({
   general: generalConfigSchema,
   git: gitConfigSchema,
@@ -304,6 +326,7 @@ const aqConfigSchema = z.object({
   review: reviewConfigSchema,
   pr: prConfigSchema,
   safety: safetyConfigSchema,
+  hooks: hooksConfigSchema,
   projects: z.array(projectConfigSchema).optional(),
 }).superRefine((data, ctx) => {
   const hasAllowedRepos = data.git.allowedRepos.length > 0;

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -296,26 +296,21 @@ const projectConfigSchema = z.object({
   }).partial().optional(),
 }).strict();
 
-// Hook validation schemas
-const hookDefinitionSchema = z.object({
-  command: z.string().min(1),
-  timeout: z.number().int().positive().optional(),
-});
-
-const hookTimingSchema = z.enum([
-  "pre-plan",
-  "post-plan",
-  "pre-phase",
-  "post-phase",
-  "pre-review",
-  "post-review",
-  "pre-pr",
-  "post-pr",
-]);
-
 const hooksConfigSchema = z.record(
-  hookTimingSchema,
-  z.array(hookDefinitionSchema)
+  z.enum([
+    "pre-plan",
+    "post-plan",
+    "pre-phase",
+    "post-phase",
+    "pre-review",
+    "post-review",
+    "pre-pr",
+    "post-pr",
+  ]),
+  z.array(z.object({
+    command: z.string().min(1),
+    timeout: z.number().int().positive().optional(),
+  }))
 ).optional();
 
 const aqConfigSchema = z.object({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,3 +1,5 @@
+import { HooksConfig } from "./hooks.js";
+
 export type LogLevel = "debug" | "info" | "warn" | "error";
 export type Locale = "ko" | "en";
 export type ReviewFailAction = "block" | "warn" | "retry";
@@ -220,5 +222,6 @@ export interface AQConfig {
   pr: PrConfig;
   safety: SafetyConfig;
   executionMode: ExecutionMode;
+  hooks?: HooksConfig;        // pipeline hooks configuration
   projects?: ProjectConfig[];  // per-project overrides
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,6 +1,3 @@
-/**
- * Hook timing definitions for pipeline execution stages
- */
 export type HookTiming =
   | "pre-plan"
   | "post-plan"
@@ -11,39 +8,9 @@ export type HookTiming =
   | "pre-pr"
   | "post-pr";
 
-/**
- * Hook definition with command and optional timeout
- */
 export interface HookDefinition {
-  /** Command to execute */
   command: string;
-  /** Timeout in milliseconds (optional) */
   timeout?: number;
 }
 
-/**
- * Configuration for hooks at different pipeline stages
- */
 export type HooksConfig = Partial<Record<HookTiming, HookDefinition[]>>;
-
-/**
- * Context information passed to hooks during execution
- */
-export interface HookContext {
-  /** Current pipeline stage */
-  timing: HookTiming;
-  /** Issue number being processed */
-  issueNumber: number;
-  /** Repository name (owner/repo) */
-  repo: string;
-  /** Working directory path */
-  workingDir: string;
-  /** Branch name for the current work */
-  branchName?: string;
-  /** Phase index (for pre-phase/post-phase hooks) */
-  phaseIndex?: number;
-  /** Phase name (for pre-phase/post-phase hooks) */
-  phaseName?: string;
-  /** Environment variables to pass to the hook command */
-  env?: Record<string, string>;
-}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,49 @@
+/**
+ * Hook timing definitions for pipeline execution stages
+ */
+export type HookTiming =
+  | "pre-plan"
+  | "post-plan"
+  | "pre-phase"
+  | "post-phase"
+  | "pre-review"
+  | "post-review"
+  | "pre-pr"
+  | "post-pr";
+
+/**
+ * Hook definition with command and optional timeout
+ */
+export interface HookDefinition {
+  /** Command to execute */
+  command: string;
+  /** Timeout in milliseconds (optional) */
+  timeout?: number;
+}
+
+/**
+ * Configuration for hooks at different pipeline stages
+ */
+export type HooksConfig = Partial<Record<HookTiming, HookDefinition[]>>;
+
+/**
+ * Context information passed to hooks during execution
+ */
+export interface HookContext {
+  /** Current pipeline stage */
+  timing: HookTiming;
+  /** Issue number being processed */
+  issueNumber: number;
+  /** Repository name (owner/repo) */
+  repo: string;
+  /** Working directory path */
+  workingDir: string;
+  /** Branch name for the current work */
+  branchName?: string;
+  /** Phase index (for pre-phase/post-phase hooks) */
+  phaseIndex?: number;
+  /** Phase name (for pre-phase/post-phase hooks) */
+  phaseName?: string;
+  /** Environment variables to pass to the hook command */
+  env?: Record<string, string>;
+}


### PR DESCRIPTION
## Summary

Resolves #238 — feat: 파이프라인 훅 타입 정의 + config.yml 스키마 확장

파이프라인 실행 단계별(pre-plan, post-plan, pre-phase, post-phase 등) 사용자 정의 훅을 실행할 수 있는 기반이 없음. HookTiming, HookDefinition, HooksConfig, HookContext 타입을 정의하고, AQConfig에 hooks 필드를 추가하여 config.yml에서 훅을 설정할 수 있도록 스키마를 확장해야 함.

## Requirements

- src/types/hooks.ts 신규 생성 — HookTiming, HookDefinition, HooksConfig, HookContext 타입 정의
- src/types/config.ts에 AQConfig.hooks?: HooksConfig 필드 추가 (import 추가, 인터페이스 수정, 타입 내보내기)
- src/config/defaults.ts에 hooks: {} 기본값 추가
- src/config/validator.ts에 hooks Zod 스키마 추가 (optional, 빈 객체 기본값)
- npx tsc --noEmit 타입 체크 통과
- npx vitest run 테스트 통과

## Implementation Phases

- Phase 0: 훅 타입 정의 파일 생성 — SUCCESS (7e3c33e1)
- Phase 1: AQConfig에 hooks 필드 통합 — SUCCESS (e2a3a40a)
- Phase 2: 기본값 및 Zod 스키마 추가 — SUCCESS (e2a3a40a)

## Risks

- hooks.ts 타입과 validator.ts Zod 스키마 간 불일치 가능성
- AQConfig 변경 시 기존 config 로딩 로직에 영향
- HooksConfig 기본값이 빈 객체({})인데 Record 타입과의 호환성 확인 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/238-feat-config-yml` → `develop`
- **Tokens**: 307 input, 18777 output{{#stats.cacheCreationTokens}}, 156258 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1248005 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #238