### PR TITLE
[AQ-#235] refactor: AQMTask 인터페이스 정의 + ClaudeTask 구현체

### DIFF
--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -1,0 +1,86 @@
+/**
+ * AQM Task 공통 인터페이스 정의
+ * Claude, Codex, Gemini 등 다양한 태스크 타입을 통합 관리하기 위한 추상화
+ */
+
+/**
+ * 태스크 실행 상태
+ */
+export enum TaskStatus {
+  /** 태스크가 생성되었으나 아직 실행되지 않은 상태 */
+  PENDING = "PENDING",
+  /** 태스크가 현재 실행 중인 상태 */
+  RUNNING = "RUNNING",
+  /** 태스크가 성공적으로 완료된 상태 */
+  SUCCESS = "SUCCESS",
+  /** 태스크 실행 중 오류가 발생한 상태 */
+  FAILED = "FAILED",
+  /** 태스크가 외부에서 강제 종료된 상태 */
+  KILLED = "KILLED"
+}
+
+/**
+ * 지원하는 태스크 타입
+ * 향후 CodexTask, GeminiTask 등 확장 가능
+ */
+export type AQMTaskType = "claude" | "codex" | "gemini";
+
+/**
+ * 태스크 JSON 직렬화를 위한 요약 정보
+ */
+export interface AQMTaskSummary {
+  /** 태스크 고유 식별자 */
+  id: string;
+  /** 태스크 타입 */
+  type: AQMTaskType;
+  /** 현재 실행 상태 */
+  status: TaskStatus;
+  /** 태스크 시작 시각 (ISO string) */
+  startedAt?: string;
+  /** 태스크 완료 시각 (ISO string) */
+  completedAt?: string;
+  /** 실행 소요 시간 (밀리초) */
+  durationMs?: number;
+  /** 실행 결과 메타데이터 */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * AQM 태스크 공통 인터페이스
+ * 모든 태스크 구현체가 따라야 하는 계약을 정의
+ */
+export interface AQMTask {
+  /** 태스크 고유 식별자 (읽기 전용) */
+  readonly id: string;
+
+  /** 태스크 타입 (읽기 전용) */
+  readonly type: AQMTaskType;
+
+  /** 현재 태스크 실행 상태 */
+  get status(): TaskStatus;
+
+  /**
+   * 실행 중인 태스크를 강제 종료
+   * @returns Promise that resolves when the task is killed
+   */
+  kill(): Promise<void>;
+
+  /**
+   * 태스크 정보를 JSON 직렬화 가능한 형태로 변환
+   * @returns 직렬화된 태스크 요약 정보
+   */
+  toJSON(): AQMTaskSummary;
+}
+
+/**
+ * 태스크 실행 옵션 (기본 인터페이스)
+ * 구체적인 태스크 타입별로 확장하여 사용
+ */
+export interface BaseTaskOptions {
+  /** 태스크 고유 식별자 (선택사항, 자동 생성됨) */
+  id?: string;
+  /** 작업 디렉토리 */
+  cwd?: string;
+  /** 태스크 메타데이터 */
+  metadata?: Record<string, unknown>;
+}

--- a/src/tasks/claude-task.ts
+++ b/src/tasks/claude-task.ts
@@ -44,29 +44,18 @@ export class ClaudeTask implements AQMTask {
     this._options = { ...options, id: this.id };
   }
 
-  /**
-   * 현재 태스크 실행 상태를 반환
-   * 프로세스 상태와 연동하여 동적으로 결정
-   */
   get status(): TaskStatus {
-    // RUNNING 상태인 경우 실제 프로세스 상태 확인
+    // Detect if process ended but status wasn't updated
     if (this._status === "RUNNING" && this._processId) {
       const activePids = getActiveProcessPids();
-      if (!activePids.includes(this._processId)) {
-        // 프로세스가 종료되었지만 상태가 업데이트되지 않은 경우
-        if (!this._completedAt) {
-          this._status = TaskStatus.FAILED;
-          this._completedAt = new Date();
-        }
+      if (!activePids.includes(this._processId) && !this._completedAt) {
+        this._status = TaskStatus.FAILED;
+        this._completedAt = new Date();
       }
     }
     return this._status;
   }
 
-  /**
-   * Claude 태스크 실행
-   * claude-runner.runClaude를 호출하고 상태 관리
-   */
   async run(): Promise<ClaudeRunResult> {
     if (this._status !== "PENDING") {
       throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
@@ -121,10 +110,6 @@ export class ClaudeTask implements AQMTask {
     }
   }
 
-  /**
-   * 실행 중인 태스크를 강제 종료
-   * 활성 프로세스를 찾아서 SIGTERM 시그널 전송
-   */
   async kill(): Promise<void> {
     if (this._status !== "RUNNING") {
       return;
@@ -152,13 +137,14 @@ export class ClaudeTask implements AQMTask {
     this._processId = undefined;
   }
 
-  /**
-   * 태스크 정보를 JSON 직렬화 가능한 형태로 변환
-   */
   toJSON(): AQMTaskSummary {
     const durationMs = this._completedAt && this._startedAt
       ? this._completedAt.getTime() - this._startedAt.getTime()
       : undefined;
+
+    const promptPreview = this._options.prompt.length > 100
+      ? this._options.prompt.slice(0, 100) + "..."
+      : this._options.prompt;
 
     return {
       id: this.id,
@@ -169,7 +155,7 @@ export class ClaudeTask implements AQMTask {
       durationMs,
       metadata: {
         ...this._options.metadata,
-        prompt: this._options.prompt.slice(0, 100) + (this._options.prompt.length > 100 ? "..." : ""),
+        prompt: promptPreview,
         systemPrompt: this._options.systemPrompt,
         maxTurns: this._options.maxTurns,
         enableAgents: this._options.enableAgents,
@@ -180,9 +166,6 @@ export class ClaudeTask implements AQMTask {
     };
   }
 
-  /**
-   * 태스크 실행 결과 반환 (실행 완료 후에만 사용 가능)
-   */
   getResult(): ClaudeRunResult | undefined {
     return this._result;
   }

--- a/src/tasks/claude-task.ts
+++ b/src/tasks/claude-task.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "crypto";
+import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
+import { runClaude, getActiveProcessPids, type ClaudeRunResult, type ClaudeRunOptions } from "../claude/claude-runner.js";
+import type { ClaudeCliConfig } from "../types/config.js";
+
+/**
+ * Claude 태스크 실행을 위한 옵션
+ * BaseTaskOptions를 확장하여 Claude 특화 옵션 추가
+ */
+export interface ClaudeTaskOptions extends BaseTaskOptions {
+  /** Claude 실행 프롬프트 */
+  prompt: string;
+  /** Claude CLI 설정 */
+  config: ClaudeCliConfig;
+  /** 시스템 프롬프트 (선택사항) */
+  systemPrompt?: string;
+  /** JSON 스키마 강제 구조화 출력 (선택사항) */
+  jsonSchema?: string;
+  /** 최대 대화 턴 수 (선택사항) */
+  maxTurns?: number;
+  /** 에이전트 도구 활성화 여부 (선택사항) */
+  enableAgents?: boolean;
+  /** stderr 라인별 콜백 (선택사항) */
+  onStderr?: (line: string) => void;
+}
+
+/**
+ * Claude CLI를 래핑하는 AQMTask 구현체
+ * claude-runner.ts의 기능을 태스크 추상화로 통합 관리
+ */
+export class ClaudeTask implements AQMTask {
+  public readonly id: string;
+  public readonly type = "claude" as const;
+
+  private _status: TaskStatus = TaskStatus.PENDING;
+  private _startedAt?: Date;
+  private _completedAt?: Date;
+  private _result?: ClaudeRunResult;
+  private _processId?: number;
+  private readonly _options: ClaudeTaskOptions;
+
+  constructor(options: ClaudeTaskOptions) {
+    this.id = options.id || randomUUID();
+    this._options = { ...options, id: this.id };
+  }
+
+  /**
+   * 현재 태스크 실행 상태를 반환
+   * 프로세스 상태와 연동하여 동적으로 결정
+   */
+  get status(): TaskStatus {
+    // RUNNING 상태인 경우 실제 프로세스 상태 확인
+    if (this._status === "RUNNING" && this._processId) {
+      const activePids = getActiveProcessPids();
+      if (!activePids.includes(this._processId)) {
+        // 프로세스가 종료되었지만 상태가 업데이트되지 않은 경우
+        if (!this._completedAt) {
+          this._status = TaskStatus.FAILED;
+          this._completedAt = new Date();
+        }
+      }
+    }
+    return this._status;
+  }
+
+  /**
+   * Claude 태스크 실행
+   * claude-runner.runClaude를 호출하고 상태 관리
+   */
+  async run(): Promise<ClaudeRunResult> {
+    if (this._status !== "PENDING") {
+      throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
+    }
+
+    this._status = TaskStatus.RUNNING;
+    this._startedAt = new Date();
+
+    try {
+      // Claude 실행 옵션 구성
+      const runOptions: ClaudeRunOptions = {
+        prompt: this._options.prompt,
+        cwd: this._options.cwd || process.cwd(),
+        config: this._options.config,
+        systemPrompt: this._options.systemPrompt,
+        jsonSchema: this._options.jsonSchema,
+        maxTurns: this._options.maxTurns,
+        enableAgents: this._options.enableAgents,
+        onStderr: this._options.onStderr,
+      };
+
+      // 프로세스 ID 추적을 위한 콜백 래핑
+      const originalOnStderr = runOptions.onStderr;
+      runOptions.onStderr = (line: string) => {
+        // 현재 실행 중인 프로세스 ID 추적
+        const activePids = getActiveProcessPids();
+        if (activePids.length > 0) {
+          this._processId = activePids[activePids.length - 1];
+        }
+        originalOnStderr?.(line);
+      };
+
+      this._result = await runClaude(runOptions);
+      this._completedAt = new Date();
+      this._status = this._result.success ? TaskStatus.SUCCESS : TaskStatus.FAILED;
+
+      return this._result;
+    } catch (error) {
+      this._completedAt = new Date();
+      this._status = TaskStatus.FAILED;
+
+      // 에러를 ClaudeRunResult 형태로 변환
+      this._result = {
+        success: false,
+        output: error instanceof Error ? error.message : String(error),
+        durationMs: this._completedAt.getTime() - (this._startedAt?.getTime() ?? 0),
+      };
+
+      throw error;
+    } finally {
+      this._processId = undefined;
+    }
+  }
+
+  /**
+   * 실행 중인 태스크를 강제 종료
+   * 활성 프로세스를 찾아서 SIGTERM 시그널 전송
+   */
+  async kill(): Promise<void> {
+    if (this._status !== "RUNNING") {
+      return;
+    }
+
+    if (this._processId) {
+      try {
+        process.kill(this._processId, "SIGTERM");
+
+        // 강제 종료 후 일정 시간 대기
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // 프로세스가 여전히 살아있으면 SIGKILL 사용
+        const activePids = getActiveProcessPids();
+        if (activePids.includes(this._processId)) {
+          process.kill(this._processId, "SIGKILL");
+        }
+      } catch (error) {
+        // 프로세스가 이미 종료되었거나 권한 없음 - 무시
+      }
+    }
+
+    this._status = TaskStatus.KILLED;
+    this._completedAt = new Date();
+    this._processId = undefined;
+  }
+
+  /**
+   * 태스크 정보를 JSON 직렬화 가능한 형태로 변환
+   */
+  toJSON(): AQMTaskSummary {
+    const durationMs = this._completedAt && this._startedAt
+      ? this._completedAt.getTime() - this._startedAt.getTime()
+      : undefined;
+
+    return {
+      id: this.id,
+      type: this.type,
+      status: this.status,
+      startedAt: this._startedAt?.toISOString(),
+      completedAt: this._completedAt?.toISOString(),
+      durationMs,
+      metadata: {
+        ...this._options.metadata,
+        prompt: this._options.prompt.slice(0, 100) + (this._options.prompt.length > 100 ? "..." : ""),
+        systemPrompt: this._options.systemPrompt,
+        maxTurns: this._options.maxTurns,
+        enableAgents: this._options.enableAgents,
+        success: this._result?.success,
+        costUsd: this._result?.costUsd,
+        usage: this._result?.usage,
+      },
+    };
+  }
+
+  /**
+   * 태스크 실행 결과 반환 (실행 완료 후에만 사용 가능)
+   */
+  getResult(): ClaudeRunResult | undefined {
+    return this._result;
+  }
+}

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,0 +1,18 @@
+/**
+ * AQM Tasks 모듈 - 태스크 인터페이스 및 구현체 export
+ */
+
+// 기본 인터페이스 및 타입 정의
+export {
+  AQMTask,
+  TaskStatus,
+  AQMTaskType,
+  AQMTaskSummary,
+  BaseTaskOptions
+} from "./aqm-task.js";
+
+// Claude 태스크 구현체
+export {
+  ClaudeTask,
+  ClaudeTaskOptions
+} from "./claude-task.js";

--- a/tests/tasks/aqm-task.test.ts
+++ b/tests/tasks/aqm-task.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  TaskStatus,
+  AQMTaskType,
+  AQMTaskSummary,
+  AQMTask,
+  BaseTaskOptions
+} from "../../src/tasks/aqm-task.js";
+
+describe("AQMTask 인터페이스 및 타입 정의", () => {
+  describe("TaskStatus enum", () => {
+    it("should define all required task states", () => {
+      expect(TaskStatus.PENDING).toBe("PENDING");
+      expect(TaskStatus.RUNNING).toBe("RUNNING");
+      expect(TaskStatus.SUCCESS).toBe("SUCCESS");
+      expect(TaskStatus.FAILED).toBe("FAILED");
+      expect(TaskStatus.KILLED).toBe("KILLED");
+    });
+
+    it("should have exactly 5 status values", () => {
+      const statusValues = Object.values(TaskStatus);
+      expect(statusValues).toHaveLength(5);
+      expect(statusValues).toEqual([
+        "PENDING",
+        "RUNNING",
+        "SUCCESS",
+        "FAILED",
+        "KILLED"
+      ]);
+    });
+  });
+
+  describe("AQMTaskType", () => {
+    it("should accept supported task types", () => {
+      // Type-only test: verify the type accepts expected values
+      const claudeType: AQMTaskType = "claude";
+      const codexType: AQMTaskType = "codex";
+      const geminiType: AQMTaskType = "gemini";
+
+      expect(claudeType).toBe("claude");
+      expect(codexType).toBe("codex");
+      expect(geminiType).toBe("gemini");
+    });
+  });
+
+  describe("AQMTaskSummary interface", () => {
+    it("should accept all required and optional fields", () => {
+      // Type-only test: verify interface structure
+      const summary: AQMTaskSummary = {
+        id: "test-id",
+        type: "claude",
+        status: TaskStatus.SUCCESS
+      };
+
+      expect(summary.id).toBe("test-id");
+      expect(summary.type).toBe("claude");
+      expect(summary.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should accept optional timestamp and metadata fields", () => {
+      const summary: AQMTaskSummary = {
+        id: "test-id",
+        type: "claude",
+        status: TaskStatus.SUCCESS,
+        startedAt: "2026-04-04T15:00:00.000Z",
+        completedAt: "2026-04-04T15:01:00.000Z",
+        durationMs: 60000,
+        metadata: {
+          prompt: "test prompt",
+          customField: "value"
+        }
+      };
+
+      expect(summary.startedAt).toBe("2026-04-04T15:00:00.000Z");
+      expect(summary.completedAt).toBe("2026-04-04T15:01:00.000Z");
+      expect(summary.durationMs).toBe(60000);
+      expect(summary.metadata).toEqual({
+        prompt: "test prompt",
+        customField: "value"
+      });
+    });
+  });
+
+  describe("BaseTaskOptions interface", () => {
+    it("should accept all optional fields", () => {
+      // Type-only test: verify all fields are optional
+      const options1: BaseTaskOptions = {};
+      const options2: BaseTaskOptions = {
+        id: "custom-id",
+        cwd: "/custom/path",
+        metadata: { key: "value" }
+      };
+
+      expect(options1).toEqual({});
+      expect(options2.id).toBe("custom-id");
+      expect(options2.cwd).toBe("/custom/path");
+      expect(options2.metadata).toEqual({ key: "value" });
+    });
+  });
+
+  describe("AQMTask interface", () => {
+    // Create a minimal implementation for testing
+    class TestTask implements AQMTask {
+      readonly id = "test-task";
+      readonly type: AQMTaskType = "claude";
+
+      get status() {
+        return TaskStatus.PENDING;
+      }
+
+      async kill() {
+        // Test implementation
+      }
+
+      toJSON(): AQMTaskSummary {
+        return {
+          id: this.id,
+          type: this.type,
+          status: this.status
+        };
+      }
+    }
+
+    it("should require id and type as readonly properties", () => {
+      const task = new TestTask();
+
+      expect(task.id).toBe("test-task");
+      expect(task.type).toBe("claude");
+
+      // These should be readonly - TypeScript compilation enforces this
+      // @ts-expect-error - readonly property
+      // task.id = "new-id";
+      // @ts-expect-error - readonly property
+      // task.type = "codex";
+    });
+
+    it("should require status getter", () => {
+      const task = new TestTask();
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should require kill method", async () => {
+      const task = new TestTask();
+
+      // Should not throw
+      await expect(task.kill()).resolves.toBeUndefined();
+    });
+
+    it("should require toJSON method", () => {
+      const task = new TestTask();
+      const json = task.toJSON();
+
+      expect(json).toEqual({
+        id: "test-task",
+        type: "claude",
+        status: TaskStatus.PENDING
+      });
+    });
+  });
+});

--- a/tests/tasks/claude-task.test.ts
+++ b/tests/tasks/claude-task.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ClaudeTask, ClaudeTaskOptions } from "../../src/tasks/claude-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+import { runClaude, getActiveProcessPids } from "../../src/claude/claude-runner.js";
+
+// Mock claude-runner 모듈
+vi.mock("../../src/claude/claude-runner.js");
+const mockRunClaude = vi.mocked(runClaude);
+const mockGetActiveProcessPids = vi.mocked(getActiveProcessPids);
+
+describe("ClaudeTask", () => {
+  let testOptions: ClaudeTaskOptions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    testOptions = {
+      prompt: "Test prompt",
+      config: {
+        path: "claude",
+        model: "sonnet",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: []
+      }
+    };
+
+    // Default mock setup
+    mockGetActiveProcessPids.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("생성 및 기본 속성", () => {
+    it("should create task with auto-generated ID", () => {
+      const task = new ClaudeTask(testOptions);
+
+      expect(task.id).toBeDefined();
+      expect(task.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i); // UUID format
+      expect(task.type).toBe("claude");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should create task with custom ID", () => {
+      const customOptions = { ...testOptions, id: "custom-task-id" };
+      const task = new ClaudeTask(customOptions);
+
+      expect(task.id).toBe("custom-task-id");
+      expect(task.type).toBe("claude");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should preserve all task options", () => {
+      const fullOptions: ClaudeTaskOptions = {
+        ...testOptions,
+        id: "test-id",
+        cwd: "/custom/path",
+        systemPrompt: "System prompt",
+        jsonSchema: "{}",
+        maxTurns: 5,
+        enableAgents: true,
+        metadata: { key: "value" }
+      };
+
+      const task = new ClaudeTask(fullOptions);
+      const json = task.toJSON();
+
+      expect(json.metadata).toMatchObject({
+        systemPrompt: "System prompt",
+        maxTurns: 5,
+        enableAgents: true,
+        key: "value"
+      });
+    });
+  });
+
+  describe("태스크 실행", () => {
+    it("should execute successfully", async () => {
+      const mockResult = {
+        success: true,
+        output: "Success output",
+        durationMs: 1500,
+        costUsd: 0.05,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 10,
+          cache_read_input_tokens: 20
+        }
+      };
+
+      mockRunClaude.mockResolvedValueOnce(mockResult);
+
+      const task = new ClaudeTask(testOptions);
+      const result = await task.run();
+
+      expect(result).toBe(mockResult);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+      expect(task.getResult()).toBe(mockResult);
+
+      // runClaude가 올바른 옵션으로 호출되었는지 확인
+      expect(mockRunClaude).toHaveBeenCalledWith({
+        prompt: testOptions.prompt,
+        cwd: process.cwd(),
+        config: testOptions.config,
+        systemPrompt: undefined,
+        jsonSchema: undefined,
+        maxTurns: undefined,
+        enableAgents: undefined,
+        onStderr: expect.any(Function),
+      });
+    });
+
+    it("should handle execution failure", async () => {
+      const mockResult = {
+        success: false,
+        output: "Error output",
+        durationMs: 800
+      };
+
+      mockRunClaude.mockResolvedValueOnce(mockResult);
+
+      const task = new ClaudeTask(testOptions);
+      const result = await task.run();
+
+      expect(result).toBe(mockResult);
+      expect(task.status).toBe(TaskStatus.FAILED);
+      expect(task.getResult()).toBe(mockResult);
+    });
+
+    it("should handle thrown error during execution", async () => {
+      const error = new Error("Claude execution failed");
+      mockRunClaude.mockRejectedValueOnce(error);
+
+      const task = new ClaudeTask(testOptions);
+
+      await expect(task.run()).rejects.toThrow("Claude execution failed");
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const result = task.getResult();
+      expect(result?.success).toBe(false);
+      expect(result?.output).toBe("Claude execution failed");
+    });
+
+    it("should prevent multiple runs on same task", async () => {
+      mockRunClaude.mockResolvedValue({ success: true, output: "test", durationMs: 1000 });
+
+      const task = new ClaudeTask(testOptions);
+
+      await task.run();
+
+      await expect(task.run()).rejects.toThrow(/already SUCCESS and cannot be run again/);
+    });
+
+    it("should track process ID during execution", async () => {
+      const mockPid = 12345;
+      mockGetActiveProcessPids.mockReturnValue([mockPid]);
+
+      mockRunClaude.mockImplementation(async (options) => {
+        // stderr 콜백 호출 시뮬레이션
+        options.onStderr?.("Test stderr output");
+        return { success: true, output: "test", durationMs: 1000 };
+      });
+
+      const task = new ClaudeTask(testOptions);
+      await task.run();
+
+      expect(mockGetActiveProcessPids).toHaveBeenCalled();
+    });
+  });
+
+  describe("태스크 종료", () => {
+    it("should kill running task", async () => {
+      const mockPid = 12345;
+
+      // process.kill을 모킹
+      const mockKill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const task = new ClaudeTask(testOptions);
+
+      // 실행 중인 상태로 설정
+      mockRunClaude.mockImplementation(async () => {
+        // 실행 중 상태를 시뮬레이션하기 위해 무한 대기
+        return new Promise(() => {});
+      });
+
+      // 별도 태스크로 실행 시작
+      const runPromise = task.run();
+
+      // 태스크를 실행 상태로 만들기 위해 잠깐 대기
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // 프로세스 ID 설정 (private이므로 reflection 사용)
+      (task as any)._processId = mockPid;
+      (task as any)._status = TaskStatus.RUNNING;
+
+      // 활성 프로세스 목록에 포함되도록 설정
+      mockGetActiveProcessPids.mockReturnValue([mockPid]);
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+      expect(mockKill).toHaveBeenCalledWith(mockPid, "SIGTERM");
+
+      mockKill.mockRestore();
+    });
+
+    it("should handle kill on non-running task", async () => {
+      const task = new ClaudeTask(testOptions);
+
+      // PENDING 상태에서 kill 호출
+      await task.kill();
+
+      // 상태 변경되지 않아야 함
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should handle process kill error gracefully", async () => {
+      const mockPid = 12345;
+      const mockKill = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw new Error("Process not found");
+      });
+
+      const task = new ClaudeTask(testOptions);
+
+      // 실행 중 상태로 설정
+      (task as any)._processId = mockPid;
+      (task as any)._status = TaskStatus.RUNNING;
+
+      // 에러가 발생해도 정상 종료되어야 함
+      await expect(task.kill()).resolves.toBeUndefined();
+      expect(task.status).toBe(TaskStatus.KILLED);
+
+      mockKill.mockRestore();
+    });
+  });
+
+  describe("상태 전이", () => {
+    it("should track status changes during execution lifecycle", async () => {
+      const task = new ClaudeTask(testOptions);
+
+      // 초기 상태
+      expect(task.status).toBe(TaskStatus.PENDING);
+
+      // 실행 중 상태 확인을 위한 모킹
+      mockRunClaude.mockImplementation(async () => {
+        // 실행 중임을 확인할 수 있도록 잠깐 대기
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return { success: true, output: "test", durationMs: 1000 };
+      });
+
+      const runPromise = task.run();
+
+      // 실행 시작 후 잠깐 대기하여 RUNNING 상태 확인
+      await new Promise(resolve => setTimeout(resolve, 5));
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should detect dead process and update status", () => {
+      const task = new ClaudeTask(testOptions);
+      const mockPid = 12345;
+
+      // 실행 중 상태로 설정
+      (task as any)._processId = mockPid;
+      (task as any)._status = TaskStatus.RUNNING;
+
+      // 프로세스가 죽었음을 시뮬레이션 (활성 목록에서 제외)
+      mockGetActiveProcessPids.mockReturnValue([]);
+
+      // status getter 호출 시 자동으로 FAILED로 전이되어야 함
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+  });
+
+  describe("직렬화", () => {
+    it("should serialize task to JSON summary", () => {
+      const task = new ClaudeTask({
+        ...testOptions,
+        id: "test-id",
+        metadata: { custom: "value" }
+      });
+
+      const json = task.toJSON();
+
+      expect(json).toEqual({
+        id: "test-id",
+        type: "claude",
+        status: TaskStatus.PENDING,
+        startedAt: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+        metadata: {
+          custom: "value",
+          prompt: testOptions.prompt,
+          systemPrompt: undefined,
+          maxTurns: undefined,
+          enableAgents: undefined,
+          success: undefined,
+          costUsd: undefined,
+          usage: undefined,
+        }
+      });
+    });
+
+    it("should truncate long prompt in metadata", () => {
+      const longPrompt = "a".repeat(150);
+      const task = new ClaudeTask({
+        ...testOptions,
+        prompt: longPrompt
+      });
+
+      const json = task.toJSON();
+
+      expect(json.metadata?.prompt).toBe("a".repeat(100) + "...");
+    });
+
+    it("should include execution result in metadata after run", async () => {
+      const mockResult = {
+        success: true,
+        output: "Success",
+        durationMs: 1500,
+        costUsd: 0.05,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 10,
+          cache_read_input_tokens: 20
+        }
+      };
+
+      mockRunClaude.mockResolvedValueOnce(mockResult);
+
+      const task = new ClaudeTask(testOptions);
+      await task.run();
+
+      const json = task.toJSON();
+
+      expect(json.metadata?.success).toBe(true);
+      expect(json.metadata?.costUsd).toBe(0.05);
+      expect(json.metadata?.usage).toEqual(mockResult.usage);
+      // durationMs는 실제 실행 시간을 계산하므로 정확한 값은 예측할 수 없음
+      // 대신 정의되어 있고 숫자인지만 확인
+      expect(json.durationMs).toBeDefined();
+      expect(typeof json.durationMs).toBe("number");
+      expect(json.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/tests/tasks/claude-task.test.ts
+++ b/tests/tasks/claude-task.test.ts
@@ -3,7 +3,6 @@ import { ClaudeTask, ClaudeTaskOptions } from "../../src/tasks/claude-task.js";
 import { TaskStatus } from "../../src/tasks/aqm-task.js";
 import { runClaude, getActiveProcessPids } from "../../src/claude/claude-runner.js";
 
-// Mock claude-runner 모듈
 vi.mock("../../src/claude/claude-runner.js");
 const mockRunClaude = vi.mocked(runClaude);
 const mockGetActiveProcessPids = vi.mocked(getActiveProcessPids);
@@ -25,7 +24,6 @@ describe("ClaudeTask", () => {
       }
     };
 
-    // Default mock setup
     mockGetActiveProcessPids.mockReturnValue([]);
   });
 


### PR DESCRIPTION
## Summary

Resolves #235 — refactor: AQMTask 인터페이스 정의 + ClaudeTask 구현체

현재 claude-runner.ts는 Claude CLI 실행을 위한 함수들(runClaude, isClaudeProcessAlive 등)을 제공하지만, 태스크 추상화 없이 직접 호출되고 있다. 이로 인해 다양한 태스크 타입(향후 Codex, Gemini 등)을 통합 관리하기 어렵고, 프로세스 상태 모니터링이 전역 함수에 분산되어 있다. AQMTask 공통 인터페이스를 정의하고 ClaudeTask 구현체로 기존 로직을 래핑하여 확장성과 일관성을 확보해야 한다.

## Requirements

- src/tasks/aqm-task.ts에 AQMTask 인터페이스 정의 (id, type, status, kill(), toJSON() 포함)
- src/tasks/claude-task.ts에 ClaudeTask 구현체 작성 (claude-runner.ts 래핑)
- ClaudeTask에서 isClaudeProcessAlive() 모니터링을 status 속성으로 통합
- 기존 claude-runner.ts는 수정하지 않고 유지
- npx tsc --noEmit 타입 체크 통과
- npx vitest run 테스트 통과

## Implementation Phases

- Phase 0: AQMTask 인터페이스 정의 — SUCCESS (75450bab)
- Phase 1: ClaudeTask 구현체 작성 — SUCCESS (f6b60352)
- Phase 2: 모듈 exports 및 테스트 작성 — SUCCESS (e303f199)

## Risks

- ClaudeTask가 claude-runner의 전역 activeProcesses Map과 상태 동기화 문제 가능성
- 기존 job-queue.ts에서 사용하는 isClaudeProcessAlive()와 ClaudeTask.status 간 불일치 가능성
- ChildProcess 모킹 테스트에서 타이밍 이슈 발생 가능

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/235-refactor-aqmtask-claudetask` → `develop`
- **Tokens**: 274 input, 18528 output{{#stats.cacheCreationTokens}}, 165030 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1104111 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #235