### PR TITLE
[AQ-#234] fix: SSE 메모리 누수 방지 + job-store 캐시 크기 제한

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -124,7 +124,7 @@ function startPeriodicCleanup(): void {
   }, HEARTBEAT_INTERVAL_MS);
 }
 
-function stopPeriodicCleanup(): void {
+export function stopPeriodicCleanup(): void {
   if (tokenCleanupInterval) {
     clearInterval(tokenCleanupInterval);
     tokenCleanupInterval = undefined;
@@ -133,6 +133,30 @@ function stopPeriodicCleanup(): void {
     clearInterval(heartbeatInterval);
     heartbeatInterval = undefined;
   }
+}
+
+/**
+ * Clean up all active SSE clients by closing their connections.
+ */
+export function cleanupAllSSEClients(): void {
+  for (const [clientId, client] of sseClients) {
+    try {
+      client.controller.close();
+    } catch {
+      // Ignore errors when closing already closed streams
+    }
+  }
+  sseClients.clear();
+}
+
+/**
+ * Comprehensive cleanup function for dashboard resources.
+ * Should be called when the server is shutting down.
+ */
+export function cleanupDashboardResources(): void {
+  stopPeriodicCleanup();
+  cleanupAllSSEClients();
+  sessionTokens.clear();
 }
 
 function isValidSessionToken(token: string): boolean {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -139,7 +139,7 @@ export function stopPeriodicCleanup(): void {
  * Clean up all active SSE clients by closing their connections.
  */
 export function cleanupAllSSEClients(): void {
-  for (const [clientId, client] of sseClients) {
+  for (const [, client] of sseClients) {
     try {
       client.controller.close();
     } catch {

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 import { EventEmitter } from "events";
-import { createDashboardRoutes } from "../../src/server/dashboard-api.js";
+import { createDashboardRoutes, stopPeriodicCleanup, cleanupAllSSEClients, cleanupDashboardResources } from "../../src/server/dashboard-api.js";
 import type { JobStore } from "../../src/queue/job-store.js";
 import type { JobQueue } from "../../src/queue/job-queue.js";
 
@@ -1544,6 +1544,57 @@ describe("Dashboard API - Version Management", () => {
     it("should handle SSE client connections properly", async () => {
       const response = await app.request("/api/events?token=test-token");
       expect(response.status).toBe(401);
+    });
+
+    describe("cleanup functions", () => {
+      it("should export stopPeriodicCleanup function", () => {
+        expect(typeof stopPeriodicCleanup).toBe("function");
+      });
+
+      it("should export cleanupAllSSEClients function", () => {
+        expect(typeof cleanupAllSSEClients).toBe("function");
+      });
+
+      it("should export cleanupDashboardResources function", () => {
+        expect(typeof cleanupDashboardResources).toBe("function");
+      });
+
+      it("should call cleanup functions without errors", () => {
+        // These functions should be callable and not throw errors
+        expect(() => stopPeriodicCleanup()).not.toThrow();
+        expect(() => cleanupAllSSEClients()).not.toThrow();
+        expect(() => cleanupDashboardResources()).not.toThrow();
+      });
+
+      it("cleanupDashboardResources should call all cleanup functions", () => {
+        // Mock console to avoid potential logging during cleanup
+        const originalConsole = console;
+        const mockConsole = {
+          ...console,
+          log: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        };
+        global.console = mockConsole as any;
+
+        // Should not throw and should clean up resources
+        expect(() => cleanupDashboardResources()).not.toThrow();
+
+        // Restore console
+        global.console = originalConsole;
+      });
+
+      it("cleanup functions should handle repeated calls gracefully", () => {
+        // Multiple calls should not cause issues
+        expect(() => {
+          stopPeriodicCleanup();
+          stopPeriodicCleanup();
+          cleanupAllSSEClients();
+          cleanupAllSSEClients();
+          cleanupDashboardResources();
+          cleanupDashboardResources();
+        }).not.toThrow();
+      });
     });
   });
 });

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -1547,50 +1547,14 @@ describe("Dashboard API - Version Management", () => {
     });
 
     describe("cleanup functions", () => {
-      it("should export stopPeriodicCleanup function", () => {
-        expect(typeof stopPeriodicCleanup).toBe("function");
-      });
-
-      it("should export cleanupAllSSEClients function", () => {
-        expect(typeof cleanupAllSSEClients).toBe("function");
-      });
-
-      it("should export cleanupDashboardResources function", () => {
-        expect(typeof cleanupDashboardResources).toBe("function");
-      });
-
       it("should call cleanup functions without errors", () => {
-        // These functions should be callable and not throw errors
         expect(() => stopPeriodicCleanup()).not.toThrow();
         expect(() => cleanupAllSSEClients()).not.toThrow();
         expect(() => cleanupDashboardResources()).not.toThrow();
       });
 
-      it("cleanupDashboardResources should call all cleanup functions", () => {
-        // Mock console to avoid potential logging during cleanup
-        const originalConsole = console;
-        const mockConsole = {
-          ...console,
-          log: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        };
-        global.console = mockConsole as any;
-
-        // Should not throw and should clean up resources
-        expect(() => cleanupDashboardResources()).not.toThrow();
-
-        // Restore console
-        global.console = originalConsole;
-      });
-
       it("cleanup functions should handle repeated calls gracefully", () => {
-        // Multiple calls should not cause issues
         expect(() => {
-          stopPeriodicCleanup();
-          stopPeriodicCleanup();
-          cleanupAllSSEClients();
-          cleanupAllSSEClients();
           cleanupDashboardResources();
           cleanupDashboardResources();
         }).not.toThrow();


### PR DESCRIPTION
## Summary

Resolves #234 — fix: SSE 메모리 누수 방지 + job-store 캐시 크기 제한

SSE 클라이언트 연결 해제 시 리소스가 완전히 정리되지 않아 메모리 누수가 발생할 수 있음. job-store의 캐시 크기 제한 로직과 config-watcher의 fs.watch 핸들러 정리는 이미 구현되어 있으나, dashboard-api의 SSE cleanup 함수가 외부에서 호출 불가능하여 서버 종료 시 interval/클라이언트 정리가 누락될 수 있음.

## Requirements

- SSE 클라이언트 연결 해제 시 리소스 정리 확인 + cleanup 함수 export
- 서버 종료 시 모든 SSE 클라이언트 및 interval 정리 가능하도록 API 제공
- job-store의 maxJobs 초과 시 오래된 완료 job 자동 삭제 로직 검증 (이미 구현됨)
- config-watcher의 fs.watch 핸들러 정리 검증 (이미 구현됨)
- 기존 동작 유지 + npx tsc --noEmit 및 npx vitest run 통과

## Implementation Phases

- Phase 0: SSE cleanup 함수 export 및 테스트 추가 — SUCCESS (f928ff23)

## Risks

- SSE cleanup 함수 export 시 기존 API 호환성 유지 필요
- interval 정리 순서가 잘못되면 메모리 누수 발생 가능

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/234-fix-sse-job-store` → `develop`
- **Tokens**: 48 input, 4704 output{{#stats.cacheCreationTokens}}, 105125 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 156001 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #234