### PR TITLE
[AQ-#240] feat: GitHub API memoize — 파이프라인 내 중복 조회 제거

### DIFF
--- a/src/github/github-cache.ts
+++ b/src/github/github-cache.ts
@@ -1,0 +1,59 @@
+/**
+ * GitHub API 결과를 메모이제이션하는 단순 캐시 모듈
+ * 파이프라인 실행 중 중복 API 호출을 방지하여 성능을 개선합니다.
+ */
+
+// 캐시 저장소 - 파이프라인 실행 동안 메모리에 유지됩니다
+const cache = new Map<string, unknown>();
+
+/**
+ * 캐시에서 값을 조회합니다
+ * @param key 캐시 키
+ * @returns 캐시된 값이 있으면 해당 값, 없으면 undefined
+ */
+export function getCached<T>(key: string): T | undefined {
+  return cache.get(key) as T | undefined;
+}
+
+/**
+ * 캐시에 값을 저장합니다
+ * @param key 캐시 키
+ * @param value 저장할 값
+ */
+export function setCached<T>(key: string, value: T): void {
+  cache.set(key, value);
+}
+
+/**
+ * 전체 캐시를 정리합니다
+ * 파이프라인 종료 시 메모리 누수를 방지하기 위해 호출해야 합니다
+ */
+export function clearCache(): void {
+  cache.clear();
+}
+
+/**
+ * 현재 캐시에 저장된 항목 수를 반환합니다
+ * @returns 캐시된 항목 수
+ */
+export function getCacheSize(): number {
+  return cache.size;
+}
+
+/**
+ * 특정 키가 캐시에 있는지 확인합니다
+ * @param key 확인할 캐시 키
+ * @returns 키가 존재하면 true, 없으면 false
+ */
+export function hasCached(key: string): boolean {
+  return cache.has(key);
+}
+
+/**
+ * 특정 키의 캐시 항목을 삭제합니다
+ * @param key 삭제할 캐시 키
+ * @returns 키가 존재했고 삭제되었으면 true, 없었으면 false
+ */
+export function deleteCached(key: string): boolean {
+  return cache.delete(key);
+}

--- a/src/github/issue-fetcher.ts
+++ b/src/github/issue-fetcher.ts
@@ -1,5 +1,6 @@
 import { runCli, CliRunOptions } from "../utils/cli-runner.js";
 import { sanitizeGhError, sanitizeErrorMessage } from "../utils/error-sanitizer.js";
+import { getCached, setCached } from "./github-cache.js";
 
 export interface GitHubIssue {
   number: number;
@@ -13,6 +14,15 @@ export async function fetchIssue(
   issueNumber: number,
   options?: { ghPath?: string; timeout?: number }
 ): Promise<GitHubIssue> {
+  // 캐시 키 생성: issue:{repo}:{issueNumber}
+  const cacheKey = `issue:${repo}:${issueNumber}`;
+
+  // 캐시에서 조회
+  const cached = getCached<GitHubIssue>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const ghPath = options?.ghPath ?? "gh";
   const cliOptions: CliRunOptions = {
     timeout: options?.timeout,
@@ -49,10 +59,15 @@ export async function fetchIssue(
     typeof l === "string" ? l : l.name
   );
 
-  return {
+  const issue: GitHubIssue = {
     number: parsed.number,
     title: parsed.title,
     body: parsed.body,
     labels,
   };
+
+  // 결과를 캐시에 저장
+  setCached(cacheKey, issue);
+
+  return issue;
 }

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -11,6 +11,7 @@ import type {
   OrchestratorInput,
   OrchestratorResult,
 } from "./pipeline-context.js";
+import { clearCache } from "../github/github-cache.js";
 
 
 export async function runPipeline(input: OrchestratorInput): Promise<OrchestratorResult> {
@@ -185,5 +186,8 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     const report = formatResult(issueNumber, repo, basicPlan, [], startTime);
 
     return { success: false, state: "FAILED", error: finalErrorMessage, report };
+  } finally {
+    // 파이프라인 종료 시 캐시 정리 - 성공/실패 모두 메모리 누수 방지
+    clearCache();
   }
 }

--- a/tests/github/github-cache.test.ts
+++ b/tests/github/github-cache.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getCached,
+  setCached,
+  clearCache,
+  getCacheSize,
+  hasCached,
+  deleteCached
+} from "../../src/github/github-cache.js";
+
+describe("github-cache", () => {
+  beforeEach(() => {
+    // 각 테스트 전에 캐시를 정리합니다
+    clearCache();
+  });
+
+  describe("setCached and getCached", () => {
+    it("should store and retrieve values with type safety", () => {
+      const testValue = { id: 1, name: "test" };
+      setCached<{ id: number; name: string }>("test-key", testValue);
+
+      const retrieved = getCached<{ id: number; name: string }>("test-key");
+      expect(retrieved).toEqual(testValue);
+    });
+
+    it("should return undefined for non-existent keys", () => {
+      const result = getCached<string>("non-existent");
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle different data types", () => {
+      // String
+      setCached("string-key", "hello world");
+      expect(getCached<string>("string-key")).toBe("hello world");
+
+      // Number
+      setCached("number-key", 42);
+      expect(getCached<number>("number-key")).toBe(42);
+
+      // Boolean
+      setCached("boolean-key", true);
+      expect(getCached<boolean>("boolean-key")).toBe(true);
+
+      // Array
+      setCached("array-key", [1, 2, 3]);
+      expect(getCached<number[]>("array-key")).toEqual([1, 2, 3]);
+
+      // Object
+      const obj = { foo: "bar", nested: { value: 123 } };
+      setCached("object-key", obj);
+      expect(getCached<typeof obj>("object-key")).toEqual(obj);
+    });
+
+    it("should overwrite existing values", () => {
+      setCached("key", "first value");
+      setCached("key", "second value");
+
+      expect(getCached<string>("key")).toBe("second value");
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should clear all cached items", () => {
+      setCached("key1", "value1");
+      setCached("key2", "value2");
+      setCached("key3", "value3");
+
+      expect(getCacheSize()).toBe(3);
+
+      clearCache();
+
+      expect(getCacheSize()).toBe(0);
+      expect(getCached<string>("key1")).toBeUndefined();
+      expect(getCached<string>("key2")).toBeUndefined();
+      expect(getCached<string>("key3")).toBeUndefined();
+    });
+
+    it("should work on empty cache", () => {
+      expect(getCacheSize()).toBe(0);
+      clearCache();
+      expect(getCacheSize()).toBe(0);
+    });
+  });
+
+  describe("getCacheSize", () => {
+    it("should return correct size", () => {
+      expect(getCacheSize()).toBe(0);
+
+      setCached("key1", "value1");
+      expect(getCacheSize()).toBe(1);
+
+      setCached("key2", "value2");
+      expect(getCacheSize()).toBe(2);
+
+      setCached("key1", "updated value"); // 덮어쓰기 - 크기는 그대로
+      expect(getCacheSize()).toBe(2);
+    });
+  });
+
+  describe("hasCached", () => {
+    it("should return true for existing keys", () => {
+      setCached("existing-key", "some value");
+      expect(hasCached("existing-key")).toBe(true);
+    });
+
+    it("should return false for non-existent keys", () => {
+      expect(hasCached("non-existent-key")).toBe(false);
+    });
+
+    it("should return true even for undefined values", () => {
+      setCached("undefined-key", undefined);
+      expect(hasCached("undefined-key")).toBe(true);
+      expect(getCached("undefined-key")).toBeUndefined();
+    });
+  });
+
+  describe("deleteCached", () => {
+    it("should delete existing keys and return true", () => {
+      setCached("to-delete", "value");
+      expect(hasCached("to-delete")).toBe(true);
+
+      const deleted = deleteCached("to-delete");
+
+      expect(deleted).toBe(true);
+      expect(hasCached("to-delete")).toBe(false);
+      expect(getCached<string>("to-delete")).toBeUndefined();
+    });
+
+    it("should return false for non-existent keys", () => {
+      const deleted = deleteCached("non-existent");
+      expect(deleted).toBe(false);
+    });
+
+    it("should not affect other cached items", () => {
+      setCached("keep1", "value1");
+      setCached("delete-me", "delete this");
+      setCached("keep2", "value2");
+
+      expect(getCacheSize()).toBe(3);
+
+      deleteCached("delete-me");
+
+      expect(getCacheSize()).toBe(2);
+      expect(getCached<string>("keep1")).toBe("value1");
+      expect(getCached<string>("keep2")).toBe("value2");
+      expect(getCached<string>("delete-me")).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty string as key", () => {
+      setCached("", "empty key value");
+      expect(getCached<string>("")).toBe("empty key value");
+      expect(hasCached("")).toBe(true);
+    });
+
+    it("should handle special characters in keys", () => {
+      const specialKey = "repo/owner#123:issue-data";
+      setCached(specialKey, { issue: "data" });
+      expect(getCached<{ issue: string }>(specialKey)).toEqual({ issue: "data" });
+    });
+
+    it("should handle null values", () => {
+      setCached("null-key", null);
+      expect(getCached("null-key")).toBe(null);
+      expect(hasCached("null-key")).toBe(true);
+    });
+
+    it("should maintain type safety across different types", () => {
+      interface User {
+        id: number;
+        name: string;
+        email?: string;
+      }
+
+      const user: User = { id: 1, name: "John" };
+      setCached<User>("user", user);
+
+      const retrievedUser = getCached<User>("user");
+      expect(retrievedUser).toEqual(user);
+      expect(retrievedUser?.id).toBe(1);
+      expect(retrievedUser?.name).toBe("John");
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should simulate GitHub issue caching scenario", () => {
+      // Simulate caching GitHub issue data
+      const issueData = {
+        number: 123,
+        title: "Fix login bug",
+        body: "The login form is broken",
+        labels: ["bug", "priority-high"]
+      };
+
+      const cacheKey = "github:issue:owner/repo:123";
+
+      // First call - cache miss
+      expect(getCached(cacheKey)).toBeUndefined();
+
+      // Cache the result
+      setCached(cacheKey, issueData);
+
+      // Second call - cache hit
+      const cached = getCached<typeof issueData>(cacheKey);
+      expect(cached).toEqual(issueData);
+      expect(cached?.number).toBe(123);
+    });
+
+    it("should handle multiple issue caching", () => {
+      const issues = [
+        { number: 1, title: "Issue 1" },
+        { number: 2, title: "Issue 2" },
+        { number: 3, title: "Issue 3" }
+      ];
+
+      // Cache multiple issues
+      issues.forEach(issue => {
+        setCached(`issue:${issue.number}`, issue);
+      });
+
+      expect(getCacheSize()).toBe(3);
+
+      // Verify all issues are cached correctly
+      issues.forEach(issue => {
+        const cached = getCached<typeof issue>(`issue:${issue.number}`);
+        expect(cached).toEqual(issue);
+      });
+    });
+  });
+});

--- a/tests/github/issue-fetcher.test.ts
+++ b/tests/github/issue-fetcher.test.ts
@@ -4,14 +4,24 @@ vi.mock("../../src/utils/cli-runner.js", () => ({
   runCli: vi.fn(),
 }));
 
+vi.mock("../../src/github/github-cache.js", () => ({
+  getCached: vi.fn(),
+  setCached: vi.fn(),
+}));
+
 import { fetchIssue } from "../../src/github/issue-fetcher.js";
 import { runCli } from "../../src/utils/cli-runner.js";
+import { getCached, setCached } from "../../src/github/github-cache.js";
 
 const mockRunCli = vi.mocked(runCli);
+const mockGetCached = vi.mocked(getCached);
+const mockSetCached = vi.mocked(setCached);
 
 describe("fetchIssue", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // 기본적으로 캐시 미스 상태로 설정
+    mockGetCached.mockReturnValue(undefined);
   });
 
   it("should fetch issue successfully with basic options", async () => {
@@ -318,5 +328,136 @@ describe("fetchIssue", () => {
       ["issue", "view", "999999", "--repo", "test/repo", "--json", "number,title,body,labels"],
       { timeout: undefined }
     );
+  });
+
+  describe("caching behavior", () => {
+    it("should return cached result without calling gh CLI on cache hit", async () => {
+      const cachedIssue = {
+        number: 123,
+        title: "Cached issue",
+        body: "This is from cache",
+        labels: ["cached", "test"]
+      };
+
+      // Mock cache hit
+      mockGetCached.mockReturnValue(cachedIssue);
+
+      const result = await fetchIssue("test/repo", 123);
+
+      expect(result).toEqual(cachedIssue);
+      expect(mockGetCached).toHaveBeenCalledWith("issue:test/repo:123");
+      expect(mockRunCli).not.toHaveBeenCalled();
+      expect(mockSetCached).not.toHaveBeenCalled();
+    });
+
+    it("should call gh CLI and cache result on cache miss", async () => {
+      const mockResponse = {
+        number: 456,
+        title: "Fresh issue",
+        body: "This is fresh from API",
+        labels: [
+          { name: "fresh" },
+          { name: "api" }
+        ]
+      };
+
+      const expectedIssue = {
+        number: 456,
+        title: "Fresh issue",
+        body: "This is fresh from API",
+        labels: ["fresh", "api"]
+      };
+
+      // Mock cache miss (already set in beforeEach)
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify(mockResponse),
+        stderr: "",
+        exitCode: 0
+      });
+
+      const result = await fetchIssue("test/repo", 456);
+
+      expect(result).toEqual(expectedIssue);
+      expect(mockGetCached).toHaveBeenCalledWith("issue:test/repo:456");
+      expect(mockRunCli).toHaveBeenCalledWith(
+        "gh",
+        ["issue", "view", "456", "--repo", "test/repo", "--json", "number,title,body,labels"],
+        { timeout: undefined }
+      );
+      expect(mockSetCached).toHaveBeenCalledWith("issue:test/repo:456", expectedIssue);
+    });
+
+    it("should generate correct cache key format", async () => {
+      const mockResponse = {
+        number: 789,
+        title: "Cache key test",
+        body: "Testing cache key format",
+        labels: []
+      };
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify(mockResponse),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await fetchIssue("owner/repository-name", 789);
+
+      expect(mockGetCached).toHaveBeenCalledWith("issue:owner/repository-name:789");
+      expect(mockSetCached).toHaveBeenCalledWith(
+        "issue:owner/repository-name:789",
+        expect.objectContaining({ number: 789 })
+      );
+    });
+
+    it("should cache different issues separately", async () => {
+      const mockResponse1 = {
+        number: 100,
+        title: "First issue",
+        body: "First issue body",
+        labels: ["first"]
+      };
+
+      const mockResponse2 = {
+        number: 200,
+        title: "Second issue",
+        body: "Second issue body",
+        labels: ["second"]
+      };
+
+      mockRunCli
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify(mockResponse1),
+          stderr: "",
+          exitCode: 0
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify(mockResponse2),
+          stderr: "",
+          exitCode: 0
+        });
+
+      await fetchIssue("test/repo", 100);
+      await fetchIssue("test/repo", 200);
+
+      expect(mockGetCached).toHaveBeenCalledWith("issue:test/repo:100");
+      expect(mockGetCached).toHaveBeenCalledWith("issue:test/repo:200");
+      expect(mockSetCached).toHaveBeenCalledWith("issue:test/repo:100", expect.objectContaining({ number: 100 }));
+      expect(mockSetCached).toHaveBeenCalledWith("issue:test/repo:200", expect.objectContaining({ number: 200 }));
+      expect(mockRunCli).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not cache when gh CLI fails", async () => {
+      mockRunCli.mockResolvedValue({
+        stdout: "",
+        stderr: "Issue not found",
+        exitCode: 1
+      });
+
+      await expect(fetchIssue("test/repo", 404)).rejects.toThrow();
+
+      expect(mockGetCached).toHaveBeenCalledWith("issue:test/repo:404");
+      expect(mockSetCached).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/pipeline/orchestrator.test.ts
+++ b/tests/pipeline/orchestrator.test.ts
@@ -64,6 +64,9 @@ vi.mock("../../src/pipeline/pipeline-setup.js", () => ({
   checkDuplicatePR: vi.fn(),
   fetchAndValidateIssue: vi.fn(),
 }));
+vi.mock("../../src/github/github-cache.js", () => ({
+  clearCache: vi.fn(),
+}));
 
 import { runPipeline } from "../../src/pipeline/orchestrator.js";
 import { fetchIssue } from "../../src/github/issue-fetcher.js";
@@ -80,6 +83,7 @@ import { runSimplify } from "../../src/review/simplify-runner.js";
 import { getDiffContent } from "../../src/git/diff-collector.js";
 import { validateIssue, validatePlan, validateBeforePush } from "../../src/safety/safety-checker.js";
 import { resolveResolvedProject, checkDuplicatePR, fetchAndValidateIssue } from "../../src/pipeline/pipeline-setup.js";
+import { clearCache } from "../../src/github/github-cache.js";
 
 const mockFetchIssue = vi.mocked(fetchIssue);
 const mockCreateDraftPR = vi.mocked(createDraftPR);
@@ -105,6 +109,7 @@ const mockValidateBeforePush = vi.mocked(validateBeforePush);
 const mockResolveResolvedProject = vi.mocked(resolveResolvedProject);
 const mockCheckDuplicatePR = vi.mocked(checkDuplicatePR);
 const mockFetchAndValidateIssue = vi.mocked(fetchAndValidateIssue);
+const mockClearCache = vi.mocked(clearCache);
 
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 
@@ -183,6 +188,8 @@ describe("runPipeline", () => {
     expect(result.success).toBe(true);
     expect(result.state).toBe("DONE");
     expect(result.prUrl).toBe("https://github.com/test/repo/pull/1");
+    // 파이프라인 종료 시 캐시가 정리되었는지 확인
+    expect(mockClearCache).toHaveBeenCalledTimes(1);
   });
 
   it("should fail if repo not in allowedRepos", async () => {
@@ -195,6 +202,8 @@ describe("runPipeline", () => {
     expect(result.success).toBe(false);
     expect(result.state).toBe("FAILED");
     expect(result.error).toContain("not configured");
+    // 실패 케이스에서도 캐시가 정리되었는지 확인
+    expect(mockClearCache).toHaveBeenCalledTimes(1);
   });
 
   it("should fail if core loop fails", async () => {


### PR DESCRIPTION
## Summary

Resolves #240 — feat: GitHub API memoize — 파이프라인 내 중복 조회 제거

파이프라인 실행 중 동일한 GitHub 이슈를 여러 번 조회하는 중복 API 호출이 발생하여 불필요한 네트워크 비용과 latency가 발생함. 모듈 레벨 Map 기반 단순 캐시를 도입하여 파이프라인 실행 동안 이슈 조회 결과를 메모이제이션하고, 파이프라인 종료 시 캐시를 정리하여 메모리 누수를 방지해야 함.

## Requirements

- src/github/github-cache.ts 신규 생성 - Map 기반 캐시로 getCached, setCached, clearCache 함수 구현
- src/github/issue-fetcher.ts의 fetchIssue에 캐시 조회→없으면 gh CLI 호출→캐시 저장 로직 추가
- src/pipeline/orchestrator.ts의 runPipeline finally 블록에서 clearCache 호출
- 기존 테스트 통과 및 새 캐시 기능에 대한 테스트 추가
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: 캐시 모듈 생성 — SUCCESS (7dedc00d)
- Phase 1: issue-fetcher 캐시 통합 — SUCCESS (4381af38)
- Phase 2: orchestrator finally 블록 추가 — SUCCESS (4381af38)

## Risks

- 캐시가 파이프라인 종료 시 정리되지 않으면 메모리 누수 발생 가능
- 테스트 간 캐시 상태 공유로 인한 테스트 격리 실패 가능성 - beforeEach에서 clearCache 필요
- 병렬 파이프라인 실행 시 캐시 충돌 가능성 (현재는 단일 파이프라인 가정)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/240-feat-github-api-memoize` → `develop`
- **Tokens**: 227 input, 13583 output{{#stats.cacheCreationTokens}}, 198030 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1021755 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #240