### PR TITLE
[AQ-#246] feat: 토큰 기반 비용 추정 — usage 토큰으로 costUsd 계산

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcess } from "child_process";
 import type { ClaudeCliConfig } from "../types/config.js";
 import { withRetry } from "../utils/rate-limiter.js";
 import { classifyError } from "../pipeline/error-classifier.js";
+import { calculateCostFromUsage } from "./token-pricing.js";
 
 const activeProcesses: Map<number, { process: ChildProcess; lastActivity: number }> = new Map();
 
@@ -245,11 +246,26 @@ async function _runClaudeInternal(options: ClaudeRunOptions): Promise<ClaudeRunR
 
   const durationMs = Date.now() - startTime;
 
+  // Calculate fallback cost if needed
+  const getFallbackCost = (costUsd?: number, usage?: UsageInfo): number | undefined => {
+    // Use existing cost if valid
+    if (costUsd && costUsd > 0) {
+      return costUsd;
+    }
+
+    // Calculate fallback cost from usage if available
+    if (usage && (usage.input_tokens > 0 || usage.output_tokens > 0)) {
+      return calculateCostFromUsage(usage, config.model);
+    }
+
+    return costUsd; // Return original value (0 or undefined)
+  };
+
   if (result.exitCode !== 0) {
     return {
       success: false,
       output: result.stderr || result.stdout,
-      costUsd: result.costUsd,
+      costUsd: getFallbackCost(result.costUsd, result.usage),
       usage: result.usage,
       durationMs,
     };
@@ -258,7 +274,7 @@ async function _runClaudeInternal(options: ClaudeRunOptions): Promise<ClaudeRunR
   return {
     success: true,
     output: result.stdout,
-    costUsd: result.costUsd,
+    costUsd: getFallbackCost(result.costUsd, result.usage),
     usage: result.usage,
     durationMs,
   };

--- a/src/claude/token-pricing.ts
+++ b/src/claude/token-pricing.ts
@@ -1,0 +1,107 @@
+import type { UsageInfo } from "../types/pipeline.js";
+
+/**
+ * 모델별 토큰 단가 (1M 토큰 기준, USD)
+ */
+interface ModelPricing {
+  input: number;
+  output: number;
+}
+
+/**
+ * Claude 모델별 토큰 단가 테이블
+ * 캐시: cache_read는 input의 10%, cache_creation은 input의 125%
+ */
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  sonnet: {
+    input: 3.0,
+    output: 15.0,
+  },
+  haiku: {
+    input: 0.25,
+    output: 1.25,
+  },
+  opus: {
+    input: 15.0,
+    output: 75.0,
+  },
+} as const;
+
+/**
+ * 기본 fallback 단가 (unknown 모델용)
+ */
+export const DEFAULT_PRICING: ModelPricing = {
+  input: 3.0, // sonnet과 동일
+  output: 15.0,
+};
+
+/**
+ * 캐시 토큰 요율
+ */
+export const CACHE_PRICING = {
+  READ_MULTIPLIER: 0.1, // input의 10%
+  CREATION_MULTIPLIER: 1.25, // input의 125%
+} as const;
+
+/**
+ * 모델 이름 정규화 (claude-3-sonnet -> sonnet)
+ */
+function normalizeModelName(model: string): string {
+  const lowerModel = model.toLowerCase();
+
+  if (lowerModel.includes("sonnet")) return "sonnet";
+  if (lowerModel.includes("haiku")) return "haiku";
+  if (lowerModel.includes("opus")) return "opus";
+
+  return "unknown";
+}
+
+/**
+ * 모델별 단가 조회
+ */
+function getModelPricing(model: string): ModelPricing {
+  const normalizedModel = normalizeModelName(model);
+  return MODEL_PRICING[normalizedModel] ?? DEFAULT_PRICING;
+}
+
+/**
+ * usage 토큰 정보를 기반으로 비용을 계산합니다.
+ *
+ * @param usage - Claude CLI가 반환한 토큰 사용량 정보
+ * @param model - Claude 모델명 (예: "claude-3-sonnet-20240229")
+ * @returns USD 단위의 비용
+ */
+export function calculateCostFromUsage(usage: UsageInfo, model: string): number {
+  const pricing = getModelPricing(model);
+
+  // 기본 토큰 비용 계산 (1M 토큰 기준이므로 1,000,000으로 나눔)
+  const inputCost = (usage.input_tokens * pricing.input) / 1_000_000;
+  const outputCost = (usage.output_tokens * pricing.output) / 1_000_000;
+
+  // 캐시 토큰 비용 계산
+  const cacheReadCost = usage.cache_read_input_tokens
+    ? (usage.cache_read_input_tokens * pricing.input * CACHE_PRICING.READ_MULTIPLIER) / 1_000_000
+    : 0;
+
+  const cacheCreationCost = usage.cache_creation_input_tokens
+    ? (usage.cache_creation_input_tokens * pricing.input * CACHE_PRICING.CREATION_MULTIPLIER) / 1_000_000
+    : 0;
+
+  return inputCost + outputCost + cacheReadCost + cacheCreationCost;
+}
+
+/**
+ * 모델별 단가 정보를 반환합니다.
+ *
+ * @param model - Claude 모델명
+ * @returns 모델의 단가 정보
+ */
+export function getModelPricingInfo(model: string): ModelPricing & { normalizedName: string } {
+  const normalizedName = normalizeModelName(model);
+  const pricing = getModelPricing(model);
+
+  return {
+    normalizedName,
+    ...pricing,
+  };
+}

--- a/tests/claude/claude-runner.test.ts
+++ b/tests/claude/claude-runner.test.ts
@@ -295,3 +295,213 @@ describe("ClaudeRunResult", () => {
     expect(result.costUsd).toBeUndefined();
   });
 });
+
+describe("cost fallback behavior", () => {
+  let mockChild: EventEmitter & {
+    pid: number;
+    stdin: { write: () => void; end: () => void };
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+    killed: boolean;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChild = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      stdin: { write: vi.fn(), end: vi.fn() },
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: vi.fn(),
+      killed: false,
+    });
+
+    mockSpawn.mockReturnValue(mockChild as any);
+  });
+
+  it("should calculate fallback cost when total_cost_usd is 0", async () => {
+    const options: ClaudeRunOptions = {
+      prompt: "test prompt",
+      config: {
+        path: "claude",
+        model: "sonnet",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: [],
+      },
+    };
+
+    const runPromise = runClaude(options);
+
+    setTimeout(() => {
+      // Simulate Claude CLI response with cost 0 but usage info
+      const response = JSON.stringify({
+        type: "result",
+        result: "success",
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200
+        }
+      });
+      mockChild.stdout.emit("data", Buffer.from(response + "\n"));
+      mockChild.emit("close", 0);
+    }, 10);
+
+    const result = await runPromise;
+    expect(result.success).toBe(true);
+    expect(result.costUsd).toBeGreaterThan(0);
+    // Expected cost calculation:
+    // input: (1000 * 3.0) / 1000000 = 0.003
+    // output: (500 * 15.0) / 1000000 = 0.0075
+    // cache_creation: (100 * 3.0 * 1.25) / 1000000 = 0.000375
+    // cache_read: (200 * 3.0 * 0.1) / 1000000 = 0.00006
+    // total: 0.010935
+    expect(result.costUsd).toBeCloseTo(0.010935, 6);
+  });
+
+  it("should calculate fallback cost when total_cost_usd is undefined", async () => {
+    const options: ClaudeRunOptions = {
+      prompt: "test prompt",
+      config: {
+        path: "claude",
+        model: "haiku",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: [],
+      },
+    };
+
+    const runPromise = runClaude(options);
+
+    setTimeout(() => {
+      // Simulate Claude CLI response without total_cost_usd but with usage
+      const response = JSON.stringify({
+        type: "result",
+        result: "success",
+        usage: {
+          input_tokens: 2000,
+          output_tokens: 1000
+        }
+      });
+      mockChild.stdout.emit("data", Buffer.from(response + "\n"));
+      mockChild.emit("close", 0);
+    }, 10);
+
+    const result = await runPromise;
+    expect(result.success).toBe(true);
+    expect(result.costUsd).toBeGreaterThan(0);
+    // Expected cost for haiku:
+    // input: (2000 * 0.25) / 1000000 = 0.0005
+    // output: (1000 * 1.25) / 1000000 = 0.00125
+    // total: 0.00175
+    expect(result.costUsd).toBeCloseTo(0.00175, 6);
+  });
+
+  it("should use original cost when total_cost_usd is valid", async () => {
+    const options: ClaudeRunOptions = {
+      prompt: "test prompt",
+      config: {
+        path: "claude",
+        model: "opus",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: [],
+      },
+    };
+
+    const runPromise = runClaude(options);
+
+    setTimeout(() => {
+      // Simulate Claude CLI response with valid cost
+      const response = JSON.stringify({
+        type: "result",
+        result: "success",
+        total_cost_usd: 0.05,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 500
+        }
+      });
+      mockChild.stdout.emit("data", Buffer.from(response + "\n"));
+      mockChild.emit("close", 0);
+    }, 10);
+
+    const result = await runPromise;
+    expect(result.success).toBe(true);
+    expect(result.costUsd).toBe(0.05); // Should use original value
+  });
+
+  it("should return 0 cost when no usage and total_cost_usd is 0", async () => {
+    const options: ClaudeRunOptions = {
+      prompt: "test prompt",
+      config: {
+        path: "claude",
+        model: "sonnet",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: [],
+      },
+    };
+
+    const runPromise = runClaude(options);
+
+    setTimeout(() => {
+      // Simulate Claude CLI response with no cost and no usage
+      const response = JSON.stringify({
+        type: "result",
+        result: "success",
+        total_cost_usd: 0
+      });
+      mockChild.stdout.emit("data", Buffer.from(response + "\n"));
+      mockChild.emit("close", 0);
+    }, 10);
+
+    const result = await runPromise;
+    expect(result.success).toBe(true);
+    expect(result.costUsd).toBe(0); // Should remain 0
+  });
+
+  it("should apply fallback for error results too", async () => {
+    const options: ClaudeRunOptions = {
+      prompt: "test prompt",
+      config: {
+        path: "claude",
+        model: "sonnet",
+        maxTurns: 10,
+        timeout: 30000,
+        additionalArgs: [],
+      },
+    };
+
+    const runPromise = runClaude(options);
+
+    setTimeout(() => {
+      // Simulate error response with usage but no cost
+      const response = JSON.stringify({
+        type: "result",
+        result: "Error occurred",
+        is_error: true,
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 500,
+          output_tokens: 100
+        }
+      });
+      mockChild.stdout.emit("data", Buffer.from(response + "\n"));
+      mockChild.emit("close", 0);
+    }, 10);
+
+    const result = await runPromise;
+    expect(result.success).toBe(false);
+    expect(result.costUsd).toBeGreaterThan(0);
+    // Expected cost calculation for sonnet:
+    // input: (500 * 3.0) / 1000000 = 0.0015
+    // output: (100 * 15.0) / 1000000 = 0.0015
+    // total: 0.003
+    expect(result.costUsd).toBeCloseTo(0.003, 6);
+  });
+});

--- a/tests/claude/token-pricing.test.ts
+++ b/tests/claude/token-pricing.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateCostFromUsage,
+  getModelPricingInfo,
+  MODEL_PRICING,
+  DEFAULT_PRICING,
+  CACHE_PRICING
+} from "../../src/claude/token-pricing.js";
+import type { UsageInfo } from "../../src/types/pipeline.js";
+
+describe("token-pricing", () => {
+  describe("calculateCostFromUsage", () => {
+    it("should calculate cost for basic input/output tokens (sonnet)", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000, // 1M tokens
+        output_tokens: 500_000,  // 0.5M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "claude-3-sonnet-20240229");
+
+      // Expected: 1M * $3 + 0.5M * $15 = $3 + $7.5 = $10.5
+      expect(cost).toBeCloseTo(10.5, 6);
+    });
+
+    it("should calculate cost for haiku model", () => {
+      const usage: UsageInfo = {
+        input_tokens: 2_000_000, // 2M tokens
+        output_tokens: 1_000_000, // 1M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "claude-3-haiku-20240307");
+
+      // Expected: 2M * $0.25 + 1M * $1.25 = $0.5 + $1.25 = $1.75
+      expect(cost).toBeCloseTo(1.75, 6);
+    });
+
+    it("should calculate cost for opus model", () => {
+      const usage: UsageInfo = {
+        input_tokens: 100_000, // 0.1M tokens
+        output_tokens: 50_000,  // 0.05M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "claude-3-opus-20240229");
+
+      // Expected: 0.1M * $15 + 0.05M * $75 = $1.5 + $3.75 = $5.25
+      expect(cost).toBeCloseTo(5.25, 6);
+    });
+
+    it("should handle cache read tokens", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+        cache_read_input_tokens: 200_000, // 0.2M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+
+      // Expected:
+      // Base: 1M * $3 + 0.5M * $15 = $10.5
+      // Cache read: 0.2M * $3 * 0.1 = $0.06
+      // Total: $10.5 + $0.06 = $10.56
+      expect(cost).toBeCloseTo(10.56, 6);
+    });
+
+    it("should handle cache creation tokens", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+        cache_creation_input_tokens: 100_000, // 0.1M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+
+      // Expected:
+      // Base: 1M * $3 + 0.5M * $15 = $10.5
+      // Cache creation: 0.1M * $3 * 1.25 = $0.375
+      // Total: $10.5 + $0.375 = $10.875
+      expect(cost).toBeCloseTo(10.875, 6);
+    });
+
+    it("should handle all token types together", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+        cache_read_input_tokens: 200_000,
+        cache_creation_input_tokens: 100_000,
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+
+      // Expected:
+      // Base: 1M * $3 + 0.5M * $15 = $10.5
+      // Cache read: 0.2M * $3 * 0.1 = $0.06
+      // Cache creation: 0.1M * $3 * 1.25 = $0.375
+      // Total: $10.5 + $0.06 + $0.375 = $10.935
+      expect(cost).toBeCloseTo(10.935, 6);
+    });
+
+    it("should use default pricing for unknown models", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+      };
+
+      const cost = calculateCostFromUsage(usage, "unknown-model");
+
+      // Should use default pricing (same as sonnet)
+      // Expected: 1M * $3 + 0.5M * $15 = $10.5
+      expect(cost).toBeCloseTo(10.5, 6);
+    });
+
+    it("should handle zero tokens", () => {
+      const usage: UsageInfo = {
+        input_tokens: 0,
+        output_tokens: 0,
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+      expect(cost).toBe(0);
+    });
+
+    it("should normalize model names correctly", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+      };
+
+      // Test various model name formats
+      const sonnetCost1 = calculateCostFromUsage(usage, "claude-3-sonnet-20240229");
+      const sonnetCost2 = calculateCostFromUsage(usage, "SONNET");
+      const sonnetCost3 = calculateCostFromUsage(usage, "sonnet");
+
+      expect(sonnetCost1).toBeCloseTo(sonnetCost2, 6);
+      expect(sonnetCost2).toBeCloseTo(sonnetCost3, 6);
+
+      const haikuCost1 = calculateCostFromUsage(usage, "claude-3-haiku-20240307");
+      const haikuCost2 = calculateCostFromUsage(usage, "HAIKU");
+
+      // Haiku should be different from sonnet
+      expect(haikuCost1).not.toBeCloseTo(sonnetCost1, 6);
+      expect(haikuCost1).toBeCloseTo(haikuCost2, 6);
+    });
+  });
+
+  describe("getModelPricingInfo", () => {
+    it("should return pricing info for known models", () => {
+      const info = getModelPricingInfo("claude-3-sonnet-20240229");
+
+      expect(info.normalizedName).toBe("sonnet");
+      expect(info.input).toBe(MODEL_PRICING.sonnet.input);
+      expect(info.output).toBe(MODEL_PRICING.sonnet.output);
+    });
+
+    it("should return pricing info for haiku", () => {
+      const info = getModelPricingInfo("haiku");
+
+      expect(info.normalizedName).toBe("haiku");
+      expect(info.input).toBe(MODEL_PRICING.haiku.input);
+      expect(info.output).toBe(MODEL_PRICING.haiku.output);
+    });
+
+    it("should return pricing info for opus", () => {
+      const info = getModelPricingInfo("claude-3-opus-20240229");
+
+      expect(info.normalizedName).toBe("opus");
+      expect(info.input).toBe(MODEL_PRICING.opus.input);
+      expect(info.output).toBe(MODEL_PRICING.opus.output);
+    });
+
+    it("should return default pricing for unknown models", () => {
+      const info = getModelPricingInfo("unknown-model");
+
+      expect(info.normalizedName).toBe("unknown");
+      expect(info.input).toBe(DEFAULT_PRICING.input);
+      expect(info.output).toBe(DEFAULT_PRICING.output);
+    });
+
+    it("should handle case insensitive model names", () => {
+      const info1 = getModelPricingInfo("SONNET");
+      const info2 = getModelPricingInfo("sonnet");
+      const info3 = getModelPricingInfo("Sonnet");
+
+      expect(info1).toEqual(info2);
+      expect(info2).toEqual(info3);
+    });
+  });
+
+  describe("constants", () => {
+    it("should have correct model pricing values", () => {
+      expect(MODEL_PRICING.sonnet.input).toBe(3.0);
+      expect(MODEL_PRICING.sonnet.output).toBe(15.0);
+
+      expect(MODEL_PRICING.haiku.input).toBe(0.25);
+      expect(MODEL_PRICING.haiku.output).toBe(1.25);
+
+      expect(MODEL_PRICING.opus.input).toBe(15.0);
+      expect(MODEL_PRICING.opus.output).toBe(75.0);
+    });
+
+    it("should have correct cache pricing multipliers", () => {
+      expect(CACHE_PRICING.READ_MULTIPLIER).toBe(0.1);
+      expect(CACHE_PRICING.CREATION_MULTIPLIER).toBe(1.25);
+    });
+
+    it("should have default pricing that matches sonnet", () => {
+      expect(DEFAULT_PRICING.input).toBe(MODEL_PRICING.sonnet.input);
+      expect(DEFAULT_PRICING.output).toBe(MODEL_PRICING.sonnet.output);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle very small token amounts", () => {
+      const usage: UsageInfo = {
+        input_tokens: 1, // 1 token
+        output_tokens: 1, // 1 token
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+
+      // Expected: 1 * $3 / 1M + 1 * $15 / 1M = $0.000003 + $0.000015 = $0.000018
+      expect(cost).toBeCloseTo(0.000018, 9);
+    });
+
+    it("should handle very large token amounts", () => {
+      const usage: UsageInfo = {
+        input_tokens: 100_000_000, // 100M tokens
+        output_tokens: 50_000_000,  // 50M tokens
+      };
+
+      const cost = calculateCostFromUsage(usage, "sonnet");
+
+      // Expected: 100M * $3 / 1M + 50M * $15 / 1M = $300 + $750 = $1050
+      expect(cost).toBeCloseTo(1050, 6);
+    });
+
+    it("should handle missing optional cache tokens", () => {
+      const usageWithoutCache: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+        // No cache tokens
+      };
+
+      const usageWithUndefinedCache: UsageInfo = {
+        input_tokens: 1_000_000,
+        output_tokens: 500_000,
+        cache_read_input_tokens: undefined,
+        cache_creation_input_tokens: undefined,
+      };
+
+      const cost1 = calculateCostFromUsage(usageWithoutCache, "sonnet");
+      const cost2 = calculateCostFromUsage(usageWithUndefinedCache, "sonnet");
+
+      expect(cost1).toBeCloseTo(cost2, 6);
+      expect(cost1).toBeCloseTo(10.5, 6); // Base cost only
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #246 — feat: 토큰 기반 비용 추정 — usage 토큰으로 costUsd 계산

현재 비용 추정은 Claude CLI가 반환하는 total_cost_usd에만 의존하는데, 이 값이 0이거나 undefined인 경우 비용 추적이 불가능합니다. usage 토큰 정보(input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens)를 활용하여 모델별 단가 기반 fallback 비용 계산 기능을 추가해야 합니다.

## Requirements

- src/claude/token-pricing.ts 신규 모듈 생성 — 모델별 토큰 단가 테이블 + calculateCostFromUsage(usage, model) 함수
- claude-runner.ts에서 costUsd가 0 또는 undefined일 때 usage 토큰으로 비용 추정 (fallback)
- 모델별 단가 적용: input/output/cache_read/cache_creation 토큰 각각 다른 단가
- cache_read는 input의 10%, cache_creation은 input의 125% 단가 적용
- total_cost_usd가 정상 값이면 우선 사용, 0일 때만 fallback
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: token-pricing 모듈 생성 — SUCCESS (7a8608c1)
- Phase 1: claude-runner costUsd fallback 적용 — SUCCESS (9960a47f)

## Risks

- 모델 이름 매칭 실패 시 단가 적용 불가 — unknown 모델 대비 기본값 필요
- 단가 정보 하드코딩으로 API 가격 변경 시 수동 업데이트 필요
- cache 토큰이 없는 응답에서 undefined 처리 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/246-feat-usage-costusd` → `develop`
- **Tokens**: 177 input, 12881 output{{#stats.cacheCreationTokens}}, 118937 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 753301 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #246