### PR TITLE
[AQ-#243] feat: 대시보드 반응형 레이아웃 — 1080px 세로 모니터 대응

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -215,14 +215,11 @@ if (localStorage.getItem('aqm-theme') === 'light') {
         /* Center icons in rail mode */
         aside nav a {
             justify-content: center;
-            padding-left: 16px !important;
-            padding-right: 16px !important;
+            padding: 0 16px !important;
         }
 
         aside:hover nav a {
             justify-content: flex-start;
-            padding-left: 16px !important;
-            padding-right: 16px !important;
         }
 
         /* Stats grid responsive: 2 columns on 1080px and below */

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -224,6 +224,66 @@ if (localStorage.getItem('aqm-theme') === 'light') {
             padding-left: 16px !important;
             padding-right: 16px !important;
         }
+
+        /* Stats grid responsive: 2 columns on 1080px and below */
+        section.grid.grid-cols-1.md\\:grid-cols-4 {
+            grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+        }
+
+        /* Dashboard layout responsive: vertical stack on narrow screens */
+        .grid.grid-cols-12 {
+            grid-template-columns: 1fr !important;
+            gap: 1.5rem !important;
+        }
+
+        /* Job list and detail columns full width in vertical layout */
+        .col-span-4,
+        .col-span-8 {
+            grid-column: 1 / -1 !important;
+        }
+
+        /* Job list height adjustment for stacked layout */
+        #job-list {
+            max-height: 400px !important;
+        }
+
+        /* Job detail minimum height adjustment */
+        #job-detail {
+            min-height: 300px !important;
+        }
+
+        /* Job card responsive layout improvements */
+        #job-list .flex.justify-between.items-start {
+            flex-wrap: wrap !important;
+            gap: 0.5rem !important;
+        }
+
+        #job-list .flex.justify-between.items-center {
+            flex-direction: column !important;
+            align-items: flex-start !important;
+            gap: 0.25rem !important;
+        }
+
+        /* Job detail header responsive layout */
+        #job-detail .flex.justify-between.items-start {
+            flex-direction: column !important;
+            gap: 1rem !important;
+        }
+
+        #job-detail .flex.items-center.gap-6 {
+            flex-wrap: wrap !important;
+            gap: 1rem !important;
+        }
+
+        #job-detail .flex.gap-3 {
+            flex-wrap: wrap !important;
+        }
+
+        /* Responsive text sizing */
+        #job-detail h1 {
+            font-size: 1.25rem !important;
+            line-height: 1.75rem !important;
+        }
     }
 </style>
 </head>

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -473,6 +473,11 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     </div>
   </div>
 
+  <!-- ============ Mobile Activity Log ============ -->
+  <div id="mobile-activity-log" class="hidden xl:hidden bg-surface-container mx-6 mb-6 p-6 rounded-2xl ring-1 ring-outline-variant/20">
+    <!-- Content will be populated by JavaScript -->
+  </div>
+
   <!-- ============ Logs View ============ -->
   <div id="view-logs" class="view-panel">
     <h2 class="text-sm font-headline font-bold text-on-surface uppercase tracking-widest flex items-center gap-2 mb-6">

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -160,6 +160,71 @@ if (localStorage.getItem('aqm-theme') === 'light') {
         from { opacity: 0; transform: scale(0.95) translateY(10px); }
         to { opacity: 1; transform: scale(1) translateY(0); }
     }
+
+    /* Responsive Sidebar for 1080px and below */
+    @media (max-width: 1080px) {
+        /* Sidebar rail mode */
+        aside {
+            width: 56px !important;
+            transition: width 0.3s ease;
+            overflow: hidden;
+        }
+
+        /* Expand sidebar on hover */
+        aside:hover {
+            width: 280px !important;
+            overflow: visible;
+        }
+
+        /* Hide text in rail mode, show on hover */
+        aside nav a span:not(.material-symbols-outlined) {
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        aside:hover nav a span:not(.material-symbols-outlined) {
+            opacity: 1;
+        }
+
+        /* Hide header text in rail mode */
+        aside .mb-6 {
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        aside:hover .mb-6 {
+            opacity: 1;
+        }
+
+        /* Hide footer in rail mode */
+        aside .mt-auto {
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        aside:hover .mt-auto {
+            opacity: 1;
+        }
+
+        /* Adjust main content margin */
+        main {
+            margin-left: 56px !important;
+            transition: margin-left 0.3s ease;
+        }
+
+        /* Center icons in rail mode */
+        aside nav a {
+            justify-content: center;
+            padding-left: 16px !important;
+            padding-right: 16px !important;
+        }
+
+        aside:hover nav a {
+            justify-content: flex-start;
+            padding-left: 16px !important;
+            padding-right: 16px !important;
+        }
+    }
 </style>
 </head>
 <body class="bg-background text-on-surface font-body selection:bg-primary/30">

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -251,14 +251,10 @@ function renderMobileActivityLog(job) {
   var container = document.getElementById('mobile-activity-log');
   if (!container) return;
 
-  // Hide container if no job selected or on desktop
-  if (!job || window.innerWidth > 1080) {
-    container.style.display = 'none';
-    return;
-  }
-
-  // Show container for mobile layout
-  container.style.display = 'block';
+  // Show/hide based on job and viewport width
+  var shouldShow = job && window.innerWidth <= 1080;
+  container.style.display = shouldShow ? 'block' : 'none';
+  if (!shouldShow) return;
 
   if (!job.logs || job.logs.length === 0) {
     container.innerHTML = '<div class="text-outline text-center py-4">이 작업에 대한 활동 로그가 없습니다.</div>';

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -107,8 +107,10 @@ function renderJobDetail(job) {
     html += '<div class="flex items-center gap-2 mt-4 text-sm text-primary font-mono"><div class="w-2 h-2 bg-primary rounded-full animate-pulse"></div>' + esc(job.currentStep) + '</div>';
   }
 
-  // Log viewer
-  html += renderLogSection(job);
+  // Log viewer - only include in desktop layout
+  if (window.innerWidth > 1080) {
+    html += renderLogSection(job);
+  }
 
   return html;
 }
@@ -243,6 +245,48 @@ function renderLogSection(job) {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   Mobile Activity Log Renderer
+   ══════════════════════════════════════════════════════════════ */
+function renderMobileActivityLog(job) {
+  var container = document.getElementById('mobile-activity-log');
+  if (!container) return;
+
+  // Hide container if no job selected or on desktop
+  if (!job || window.innerWidth > 1080) {
+    container.style.display = 'none';
+    return;
+  }
+
+  // Show container for mobile layout
+  container.style.display = 'block';
+
+  if (!job.logs || job.logs.length === 0) {
+    container.innerHTML = '<div class="text-outline text-center py-4">이 작업에 대한 활동 로그가 없습니다.</div>';
+    return;
+  }
+
+  var maxLines = job.status === 'running' ? 10 : 20;
+  var lines = job.logs.slice(-maxLines);
+
+  var html = '<div class="space-y-3">';
+  html += '<div class="flex items-center justify-between">';
+  html += '<h3 class="text-xs font-headline font-bold text-outline uppercase tracking-widest">' + t('telemetry') + '</h3>';
+  html += '<button onclick="navigateTo(\'logs\')" class="text-[10px] text-primary hover:underline uppercase font-bold">' + t('expandLogs') + '</button>';
+  html += '</div>';
+
+  html += '<div class="relative">';
+  html += '<div class="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-surface-container to-transparent pointer-events-none z-10 rounded-t-xl"></div>';
+  html += '<div class="bg-surface-container-lowest p-4 rounded-xl font-mono text-xs leading-relaxed border border-outline-variant/10 max-h-64 overflow-y-auto custom-scrollbar">';
+
+  lines.forEach(function(line) {
+    html += colorizeLogLine(line);
+  });
+
+  html += '</div></div></div>';
+  container.innerHTML = html;
+}
+
+/* ══════════════════════════════════════════════════════════════
    Logs Full View
    ══════════════════════════════════════════════════════════════ */
 function renderLogsView(job) {
@@ -317,6 +361,7 @@ function renderFromState() {
     emptyEl.classList.remove('hidden');
     emptyEl.classList.add('flex');
     document.getElementById('job-detail').innerHTML = '<div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">' + t('noJobSelected') + '</div>';
+    renderMobileActivityLog(null);
     startLiveTickers();
     return;
   }
@@ -341,6 +386,9 @@ function renderFromState() {
   // Render detail
   var selectedJob = filtered.find(function(j) { return j.id === selectedJobId; }) || filtered[0];
   document.getElementById('job-detail').innerHTML = renderJobDetail(selectedJob);
+
+  // Render mobile activity log
+  renderMobileActivityLog(selectedJob);
 
   // Auto-scroll log
   var lb = document.getElementById('detail-log-box');
@@ -593,3 +641,16 @@ function renderObjectInput(fieldId, value, configPath, isReadonly) {
          '</textarea>' +
          '<div class="text-[10px] text-outline/50 mt-1">JSON</div>';
 }
+
+/* ══════════════════════════════════════════════════════════════
+   Responsive Activity Log Handler
+   ══════════════════════════════════════════════════════════════ */
+window.addEventListener('resize', function() {
+  // Re-render mobile activity log when window size changes
+  if (selectedJobId && currentJobs) {
+    var selectedJob = currentJobs.find(function(j) { return j.id === selectedJobId; });
+    if (selectedJob) {
+      renderMobileActivityLog(selectedJob);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Resolves #243 — feat: 대시보드 반응형 레이아웃 — 1080px 세로 모니터 대응

현재 대시보드는 넓은 화면에 최적화되어 있어 1080px 세로 모니터에서 사이드바가 과도한 공간을 차지하고, stats 그리드와 job 카드 레이아웃이 좁은 화면에서 가독성이 떨어진다. 또한 activity log가 오른쪽 패널에 고정되어 있어 좁은 화면에서 주요 콘텐츠 영역이 압박받는다.

## Requirements

- 1080px 이하 너비에서 사이드바를 56px 아이콘 전용 rail로 축소 (CSS media query)
- stats 그리드를 4열 → 2열로 변경 (1080px breakpoint)
- job 카드 레이아웃 reflow — 좁은 화면에서 세로 배치
- activity log 패널을 사이드 → 하단 배치로 전환
- 1280px 이상에서는 기존 레이아웃 유지
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase 0: 사이드바 반응형 CSS 구현 — SUCCESS (4498c031)
- Phase 1: Stats 그리드 및 Dashboard 레이아웃 반응형 — SUCCESS (5f9a7e55)
- Phase 2: Activity Log 하단 배치 전환 — SUCCESS (3fd6b53c)

## Risks

- CSS specificity 충돌으로 기존 레이아웃에 영향 줄 수 있음
- JavaScript 렌더링 함수 수정 시 기존 동작 깨질 수 있음
- breakpoint 경계에서 레이아웃 깜빡임(FOUC) 발생 가능
- hover 기반 사이드바 확장이 터치 디바이스에서 동작 안 할 수 있음

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/243-feat-1080px` → `develop`
- **Tokens**: 260 input, 16499 output{{#stats.cacheCreationTokens}}, 179068 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1050987 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #243