### PR TITLE
[AQ-#250] fix: 한국어 토큰 추정 보정 — locale:ko 시 chars/token 비율 조정

### DIFF
--- a/src/pipeline/core-loop.ts
+++ b/src/pipeline/core-loop.ts
@@ -97,6 +97,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
       cwd: ctx.cwd,
       modeHint: ctx.modeHint,
       maxPhases: ctx.config.safety.maxPhases,
+      locale: ctx.config.general.locale,
       sensitivePaths: ctx.config.safety.sensitivePaths.join(", "),
     });
     plan = planResult.plan;
@@ -218,6 +219,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         skillsContext: ctx.skillsContext,
         pastFailures: pastFailures || undefined,
         jobLogger: jl,
+        locale: ctx.config.general.locale,
       });
 
       // Retry on failure (skip for TIMEOUT and SAFETY_VIOLATION — not recoverable by retry)

--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -31,6 +31,7 @@ export interface PhaseExecutorContext {
   skillsContext?: string;
   pastFailures?: string;
   jobLogger?: JobLogger;
+  locale?: string;
 }
 
 export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResult> {
@@ -87,7 +88,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
     let rendered = renderTemplate(template, createTemplateData(optimizedPreviousSummary));
 
     // Check token usage and optimize if budget exceeded
-    const tokenUsage = analyzeTokenUsage(rendered, modelName);
+    const tokenUsage = analyzeTokenUsage(rendered, modelName, ctx.locale || 'en');
     if (tokenUsage.exceedsLimit) {
       logger.warn(
         `Phase ${ctx.phase.index} prompt exceeds token budget: ${tokenUsage.estimatedTokens.toLocaleString()} tokens ` +
@@ -99,10 +100,10 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       if (previousSummary.length > 1000 && ctx.previousResults.length > 0) {
         logger.warn(`Attempting to reduce previousResults context to fit budget...`);
         const targetTokens = Math.floor(tokenUsage.effectiveLimit * 0.1);
-        optimizedPreviousSummary = summarizeForBudget(previousSummary, targetTokens);
+        optimizedPreviousSummary = summarizeForBudget(previousSummary, targetTokens, ctx.locale || 'en');
         rendered = renderTemplate(template, createTemplateData(optimizedPreviousSummary));
 
-        const optimizedUsage = analyzeTokenUsage(rendered, modelName);
+        const optimizedUsage = analyzeTokenUsage(rendered, modelName, ctx.locale || 'en');
         if (!optimizedUsage.exceedsLimit) {
           logger.warn(
             `Successfully reduced prompt to ${optimizedUsage.estimatedTokens.toLocaleString()} tokens ` +

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -64,6 +64,7 @@ export interface PlanGeneratorContext {
   modeHint?: string;
   maxPhases?: number;
   sensitivePaths?: string;
+  locale?: string;
 }
 
 export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithCost> {
@@ -172,7 +173,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     // Token budget cap: 프롬프트 크기 체크 및 축소
     const claudeConfig = configForTask(ctx.claudeConfig, "plan");
     const modelName = claudeConfig.model;
-    let tokenAnalysis = analyzeTokenUsage(finalPrompt, modelName);
+    let tokenAnalysis = analyzeTokenUsage(finalPrompt, modelName, ctx.locale || 'en');
 
     logger.info(`Initial prompt token analysis: ${tokenAnalysis.estimatedTokens}/${tokenAnalysis.effectiveLimit} tokens (${tokenAnalysis.usagePercentage.toFixed(1)}%)`);
 
@@ -183,7 +184,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       if (ctx.modeHint) {
         finalPrompt += `\n\n## 추가 지시\n\n${ctx.modeHint}`;
       }
-      tokenAnalysis = analyzeTokenUsage(finalPrompt, modelName);
+      tokenAnalysis = analyzeTokenUsage(finalPrompt, modelName, ctx.locale || 'en');
       logger.info(`After ${stage}: ${tokenAnalysis.estimatedTokens}/${tokenAnalysis.effectiveLimit} tokens (${tokenAnalysis.usagePercentage.toFixed(1)}%)`);
     };
 
@@ -191,7 +192,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     if (tokenAnalysis.exceedsLimit && ctx.repoStructure) {
       logger.warn(`Prompt exceeds token limit (${tokenAnalysis.estimatedTokens} > ${tokenAnalysis.effectiveLimit}), truncating repository structure`);
       const repoTokenBudget = Math.floor(tokenAnalysis.effectiveLimit * 0.3);
-      const truncatedRepoStructure = truncateRepoStructure(ctx.repoStructure, repoTokenBudget);
+      const truncatedRepoStructure = truncateRepoStructure(ctx.repoStructure, repoTokenBudget, ctx.locale || 'en');
 
       updateAndRerender(
         (data) => {
@@ -209,7 +210,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     if (tokenAnalysis.exceedsLimit && ctx.issue.body) {
       logger.warn(`Prompt still exceeds token limit after repo truncation, truncating issue body`);
       const issueBodyTokenBudget = Math.floor(tokenAnalysis.effectiveLimit * 0.2);
-      const truncatedIssueBody = truncateToTokenBudget(ctx.issue.body, issueBodyTokenBudget);
+      const truncatedIssueBody = truncateToTokenBudget(ctx.issue.body, issueBodyTokenBudget, ctx.locale || 'en');
 
       updateAndRerender(
         (data) => ({

--- a/src/review/token-estimator.ts
+++ b/src/review/token-estimator.ts
@@ -51,7 +51,7 @@ export const CHARS_PER_TOKEN = CHARS_PER_TOKEN_BY_TYPE.natural;
  * Gets locale-specific character-to-token ratios
  * Defaults to English if locale not found
  */
-function getLocaleRatios(locale: string): typeof CHARS_PER_TOKEN_BY_LOCALE.en {
+function getLocaleRatios(locale: string): { readonly code: number; readonly natural: number } {
   return CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
     || CHARS_PER_TOKEN_BY_LOCALE.en;
 }

--- a/src/review/token-estimator.ts
+++ b/src/review/token-estimator.ts
@@ -48,6 +48,24 @@ export const CHARS_PER_TOKEN_BY_LOCALE = {
 export const CHARS_PER_TOKEN = CHARS_PER_TOKEN_BY_TYPE.natural;
 
 /**
+ * Gets locale-specific character-to-token ratios
+ * Defaults to English if locale not found
+ */
+function getLocaleRatios(locale: string): typeof CHARS_PER_TOKEN_BY_LOCALE.en {
+  return CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
+    || CHARS_PER_TOKEN_BY_LOCALE.en;
+}
+
+/**
+ * Gets the appropriate chars-per-token ratio for text in a given locale
+ * Detects code vs natural language and returns the corresponding ratio
+ */
+function getCharsPerToken(text: string, locale: string): number {
+  const localeRatios = getLocaleRatios(locale);
+  return isCodeContent(text) ? localeRatios.code : localeRatios.natural;
+}
+
+/**
  * Detects if the content is primarily code based on various patterns
  */
 export function isCodeContent(text: string): boolean {
@@ -138,18 +156,13 @@ export function estimateTokenCount(text: string, contentType: ContentType = 'aut
     return 0;
   }
 
-  // Get locale-specific ratios, fallback to 'en' if locale not found
-  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
-    || CHARS_PER_TOKEN_BY_LOCALE.en;
-
   let charsPerToken: number;
 
   if (contentType === 'auto') {
     // Auto-detect content type
-    charsPerToken = isCodeContent(text)
-      ? localeRatios.code
-      : localeRatios.natural;
+    charsPerToken = getCharsPerToken(text, locale);
   } else {
+    const localeRatios = getLocaleRatios(locale);
     charsPerToken = localeRatios[contentType];
   }
 
@@ -257,12 +270,8 @@ export function truncateToTokenBudget(text: string, maxTokens: number, locale: s
   const ellipsisTokens = estimateTokenCount('...', 'auto', locale);
   const availableTokens = Math.max(1, maxTokens - ellipsisTokens);
 
-  // Get locale-specific ratios for character estimation
-  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
-    || CHARS_PER_TOKEN_BY_LOCALE.en;
-  const charsPerToken = isCodeContent(text) ? localeRatios.code : localeRatios.natural;
-
   // Calculate approximate character limit
+  const charsPerToken = getCharsPerToken(text, locale);
   const targetChars = Math.floor(availableTokens * charsPerToken);
   if (targetChars <= 0) return '';
 
@@ -320,11 +329,7 @@ export function summarizeForBudget(text: string, targetTokens: number, locale: s
   const beginTokens = Math.floor(availableTokens * 0.6);
   const endTokens = availableTokens - beginTokens;
 
-  // Get locale-specific ratios for character estimation
-  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
-    || CHARS_PER_TOKEN_BY_LOCALE.en;
-  const charsPerToken = isCodeContent(text) ? localeRatios.code : localeRatios.natural;
-
+  const charsPerToken = getCharsPerToken(text, locale);
   const beginChars = Math.floor(beginTokens * charsPerToken);
   const endChars = Math.floor(endTokens * charsPerToken);
 

--- a/src/review/token-estimator.ts
+++ b/src/review/token-estimator.ts
@@ -30,6 +30,20 @@ export const CHARS_PER_TOKEN_BY_TYPE = {
   natural: 4,
 } as const;
 
+/** Characters per token by locale */
+export const CHARS_PER_TOKEN_BY_LOCALE = {
+  /** English - standard ratio */
+  en: {
+    code: 3.2,
+    natural: 4.0,
+  },
+  /** Korean - denser token usage due to more information per character */
+  ko: {
+    code: 2.0,
+    natural: 2.4,
+  },
+} as const;
+
 /** Default characters per token (backwards compatibility) */
 export const CHARS_PER_TOKEN = CHARS_PER_TOKEN_BY_TYPE.natural;
 
@@ -117,21 +131,26 @@ export function isCodeContent(text: string): boolean {
  * Estimates the token count for a given text
  * @param text The text to analyze
  * @param contentType Content type hint ('code', 'natural', or 'auto' for detection)
+ * @param locale Language locale for token estimation (defaults to 'en')
  */
-export function estimateTokenCount(text: string, contentType: ContentType = 'auto'): number {
+export function estimateTokenCount(text: string, contentType: ContentType = 'auto', locale: string = 'en'): number {
   if (!text || text.length === 0) {
     return 0;
   }
+
+  // Get locale-specific ratios, fallback to 'en' if locale not found
+  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
+    || CHARS_PER_TOKEN_BY_LOCALE.en;
 
   let charsPerToken: number;
 
   if (contentType === 'auto') {
     // Auto-detect content type
     charsPerToken = isCodeContent(text)
-      ? CHARS_PER_TOKEN_BY_TYPE.code
-      : CHARS_PER_TOKEN_BY_TYPE.natural;
+      ? localeRatios.code
+      : localeRatios.natural;
   } else {
-    charsPerToken = CHARS_PER_TOKEN_BY_TYPE[contentType];
+    charsPerToken = localeRatios[contentType];
   }
 
   return Math.ceil(text.length / charsPerToken);
@@ -201,9 +220,12 @@ export interface TokenUsageInfo {
 
 /**
  * Analyzes token usage for a text and model
+ * @param text The text to analyze
+ * @param modelName The Claude model name
+ * @param locale Language locale for token estimation (defaults to 'en')
  */
-export function analyzeTokenUsage(text: string, modelName: string): TokenUsageInfo {
-  const estimatedTokens = estimateTokenCount(text);
+export function analyzeTokenUsage(text: string, modelName: string, locale: string = 'en'): TokenUsageInfo {
+  const estimatedTokens = estimateTokenCount(text, 'auto', locale);
   const modelLimit = getTokenLimit(modelName);
   const effectiveLimit = getEffectiveTokenLimit(modelName);
   const exceedsLimit = estimatedTokens > effectiveLimit;
@@ -221,19 +243,27 @@ export function analyzeTokenUsage(text: string, modelName: string): TokenUsageIn
 /**
  * Truncates text to fit within a token budget
  * Attempts to preserve sentence boundaries when possible
+ * @param text The text to truncate
+ * @param maxTokens Maximum token budget
+ * @param locale Language locale for token estimation (defaults to 'en')
  */
-export function truncateToTokenBudget(text: string, maxTokens: number): string {
+export function truncateToTokenBudget(text: string, maxTokens: number, locale: string = 'en'): string {
   if (!text || maxTokens <= 0) return '';
 
-  const estimatedTokens = estimateTokenCount(text);
+  const estimatedTokens = estimateTokenCount(text, 'auto', locale);
   if (estimatedTokens <= maxTokens) return text;
 
   // Reserve tokens for ellipsis
-  const ellipsisTokens = estimateTokenCount('...');
+  const ellipsisTokens = estimateTokenCount('...', 'auto', locale);
   const availableTokens = Math.max(1, maxTokens - ellipsisTokens);
 
+  // Get locale-specific ratios for character estimation
+  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
+    || CHARS_PER_TOKEN_BY_LOCALE.en;
+  const charsPerToken = isCodeContent(text) ? localeRatios.code : localeRatios.natural;
+
   // Calculate approximate character limit
-  const targetChars = Math.floor(availableTokens * CHARS_PER_TOKEN);
+  const targetChars = Math.floor(availableTokens * charsPerToken);
   if (targetChars <= 0) return '';
 
   // Try to truncate at sentence boundaries first
@@ -242,7 +272,7 @@ export function truncateToTokenBudget(text: string, maxTokens: number): string {
 
   for (const sentence of sentences) {
     const testResult = result + (result ? ' ' : '') + sentence;
-    if (estimateTokenCount(testResult) > availableTokens) {
+    if (estimateTokenCount(testResult, 'auto', locale) > availableTokens) {
       break;
     }
     result = testResult;
@@ -266,32 +296,40 @@ export function truncateToTokenBudget(text: string, maxTokens: number): string {
 /**
  * Summarizes text to fit within a target token budget
  * Keeps beginning and end, with summary indicator in the middle
+ * @param text The text to summarize
+ * @param targetTokens Target token budget
+ * @param locale Language locale for token estimation (defaults to 'en')
  */
-export function summarizeForBudget(text: string, targetTokens: number): string {
+export function summarizeForBudget(text: string, targetTokens: number, locale: string = 'en'): string {
   if (!text || targetTokens <= 0) return '';
 
-  const estimatedTokens = estimateTokenCount(text);
+  const estimatedTokens = estimateTokenCount(text, 'auto', locale);
   if (estimatedTokens <= targetTokens) return text;
 
   // Reserve tokens for summary indicator
   const summaryIndicator = '\n\n[... content truncated ...]\n\n';
-  const reservedTokens = estimateTokenCount(summaryIndicator);
+  const reservedTokens = estimateTokenCount(summaryIndicator, 'auto', locale);
   const availableTokens = Math.max(0, targetTokens - reservedTokens);
 
   if (availableTokens < 10) {
     // If too little space, just truncate
-    return truncateToTokenBudget(text, targetTokens);
+    return truncateToTokenBudget(text, targetTokens, locale);
   }
 
   // Split available tokens between beginning and end
   const beginTokens = Math.floor(availableTokens * 0.6);
   const endTokens = availableTokens - beginTokens;
 
-  const beginChars = Math.floor(beginTokens * CHARS_PER_TOKEN);
-  const endChars = Math.floor(endTokens * CHARS_PER_TOKEN);
+  // Get locale-specific ratios for character estimation
+  const localeRatios = CHARS_PER_TOKEN_BY_LOCALE[locale as keyof typeof CHARS_PER_TOKEN_BY_LOCALE]
+    || CHARS_PER_TOKEN_BY_LOCALE.en;
+  const charsPerToken = isCodeContent(text) ? localeRatios.code : localeRatios.natural;
+
+  const beginChars = Math.floor(beginTokens * charsPerToken);
+  const endChars = Math.floor(endTokens * charsPerToken);
 
   if (beginChars <= 0 || endChars <= 0) {
-    return truncateToTokenBudget(text, targetTokens);
+    return truncateToTokenBudget(text, targetTokens, locale);
   }
 
   // Get beginning part
@@ -311,7 +349,7 @@ export function summarizeForBudget(text: string, targetTokens: number): string {
 
   // Make sure we don't have overlapping or adjacent parts
   if (beginning.length + ending.length >= text.length - 10) {
-    return truncateToTokenBudget(text, targetTokens);
+    return truncateToTokenBudget(text, targetTokens, locale);
   }
 
   return beginning + summaryIndicator + ending;
@@ -320,11 +358,14 @@ export function summarizeForBudget(text: string, targetTokens: number): string {
 /**
  * Truncates repository structure to fit within token budget
  * Prioritizes important files and directories
+ * @param structure The repository structure string
+ * @param maxTokens Maximum token budget
+ * @param locale Language locale for token estimation (defaults to 'en')
  */
-export function truncateRepoStructure(structure: string, maxTokens: number): string {
+export function truncateRepoStructure(structure: string, maxTokens: number, locale: string = 'en'): string {
   if (!structure || maxTokens <= 0) return '';
 
-  const estimatedTokens = estimateTokenCount(structure);
+  const estimatedTokens = estimateTokenCount(structure, 'auto', locale);
   if (estimatedTokens <= maxTokens) return structure;
 
   const lines = structure.split('\n').filter(line => line.trim());
@@ -368,7 +409,7 @@ export function truncateRepoStructure(structure: string, maxTokens: number): str
 
   // First, try to include the highest priority items
   for (const item of scoredLines) {
-    const lineTokens = estimateTokenCount(item.line + '\n');
+    const lineTokens = estimateTokenCount(item.line + '\n', 'auto', locale);
     if (currentTokens + lineTokens <= maxTokens) {
       result.push(item);
       currentTokens += lineTokens;
@@ -384,7 +425,7 @@ export function truncateRepoStructure(structure: string, maxTokens: number): str
   if (result.length < lines.length) {
     const truncatedCount = lines.length - result.length;
     const indicator = `... (${truncatedCount} more files/directories truncated)`;
-    const indicatorTokens = estimateTokenCount(indicator + '\n');
+    const indicatorTokens = estimateTokenCount(indicator + '\n', 'auto', locale);
 
     // Only add indicator if we have room and it's useful
     if (currentTokens + indicatorTokens <= maxTokens && result.length > 0) {

--- a/tests/pipeline/phase-executor.test.ts
+++ b/tests/pipeline/phase-executor.test.ts
@@ -366,7 +366,7 @@ describe("executePhase", () => {
     const result = await executePhase(ctx);
 
     expect(result.success).toBe(true);
-    expect(mockAnalyzeTokenUsage).toHaveBeenCalledWith("rendered prompt", "claude-sonnet-4-6");
+    expect(mockAnalyzeTokenUsage).toHaveBeenCalledWith("rendered prompt", "claude-sonnet-4-6", "en");
   });
 
   it("includes usage when Claude returns usage information", async () => {

--- a/tests/review/token-estimator.test.ts
+++ b/tests/review/token-estimator.test.ts
@@ -13,6 +13,7 @@ import {
   SAFETY_MARGIN,
   CHARS_PER_TOKEN,
   CHARS_PER_TOKEN_BY_TYPE,
+  CHARS_PER_TOKEN_BY_LOCALE,
 } from "../../src/review/token-estimator.js";
 
 describe("token-estimator", () => {
@@ -69,6 +70,56 @@ describe("token-estimator", () => {
       expect(autoTokens).toBe(codeTokens);
       // Code should have more tokens than natural
       expect(codeTokens).toBeGreaterThan(naturalTokens);
+    });
+
+    it("should support locale parameter for Korean text", () => {
+      const koreanText = "안녕하세요 반갑습니다"; // 10 characters
+
+      const englishTokens = estimateTokenCount(koreanText, 'natural', 'en');
+      const koreanTokens = estimateTokenCount(koreanText, 'natural', 'ko');
+
+      // Korean should have more tokens due to denser ratio (2.4 vs 4.0 chars/token)
+      expect(koreanTokens).toBeGreaterThan(englishTokens);
+
+      // Verify specific calculations
+      expect(englishTokens).toBe(Math.ceil(10 / 4.0)); // 3 tokens
+      expect(koreanTokens).toBe(Math.ceil(10 / 2.4)); // 5 tokens
+    });
+
+    it("should support locale parameter for Korean code", () => {
+      const koreanCode = "함수이름() { return 값; }"; // 20 characters
+
+      const englishTokens = estimateTokenCount(koreanCode, 'code', 'en');
+      const koreanTokens = estimateTokenCount(koreanCode, 'code', 'ko');
+
+      // Korean should have more tokens due to denser ratio (2.0 vs 3.2 chars/token)
+      expect(koreanTokens).toBeGreaterThan(englishTokens);
+
+      // Verify specific calculations
+      expect(englishTokens).toBe(Math.ceil(20 / 3.2)); // 7 tokens
+      expect(koreanTokens).toBe(Math.ceil(20 / 2.0)); // 10 tokens
+    });
+
+    it("should default to English locale when not specified", () => {
+      const text = "Hello world"; // 11 characters
+
+      const defaultTokens = estimateTokenCount(text, 'natural');
+      const explicitEnglishTokens = estimateTokenCount(text, 'natural', 'en');
+
+      // Should be identical
+      expect(defaultTokens).toBe(explicitEnglishTokens);
+      expect(defaultTokens).toBe(Math.ceil(11 / 4.0)); // 3 tokens
+    });
+
+    it("should fallback to English for unsupported locales", () => {
+      const text = "Test text"; // 9 characters
+
+      const unknownLocaleTokens = estimateTokenCount(text, 'natural', 'fr');
+      const englishTokens = estimateTokenCount(text, 'natural', 'en');
+
+      // Should fallback to English ratios
+      expect(unknownLocaleTokens).toBe(englishTokens);
+      expect(unknownLocaleTokens).toBe(Math.ceil(9 / 4.0)); // 3 tokens
     });
   });
 
@@ -175,6 +226,24 @@ describe("token-estimator", () => {
       expect(analysis.exceedsLimit).toBe(false);
       expect(analysis.usagePercentage).toBeCloseTo(15.625); // 25K / 160K
     });
+
+    it("should support locale parameter for token analysis", () => {
+      const koreanText = "안녕하세요 반갑습니다"; // 10 characters
+
+      const englishAnalysis = analyzeTokenUsage(koreanText, "claude-opus-4-5", "en");
+      const koreanAnalysis = analyzeTokenUsage(koreanText, "claude-opus-4-5", "ko");
+
+      // Korean should estimate more tokens
+      expect(koreanAnalysis.estimatedTokens).toBeGreaterThan(englishAnalysis.estimatedTokens);
+
+      // Verify specific calculations
+      expect(englishAnalysis.estimatedTokens).toBe(3); // Math.ceil(10 / 4.0)
+      expect(koreanAnalysis.estimatedTokens).toBe(5); // Math.ceil(10 / 2.4)
+
+      // Both should have same model limits
+      expect(englishAnalysis.modelLimit).toBe(koreanAnalysis.modelLimit);
+      expect(englishAnalysis.effectiveLimit).toBe(koreanAnalysis.effectiveLimit);
+    });
   });
 
   describe("constants", () => {
@@ -255,6 +324,20 @@ describe("token-estimator", () => {
       const result = truncateToTokenBudget(text, 5);
       expect(result).toContain("...");
       expect(estimateTokenCount(result)).toBeLessThanOrEqual(5);
+    });
+
+    it("should support locale parameter for truncation", () => {
+      const koreanText = "첫 번째 문장입니다. 두 번째 문장입니다. 세 번째 문장입니다."; // ~35 characters
+
+      const englishTruncated = truncateToTokenBudget(koreanText, 5, "en");
+      const koreanTruncated = truncateToTokenBudget(koreanText, 5, "ko");
+
+      // With Korean locale (denser tokens), we should truncate more aggressively
+      expect(koreanTruncated.length).toBeLessThanOrEqual(englishTruncated.length);
+
+      // Both should be shorter than original
+      expect(englishTruncated.length).toBeLessThan(koreanText.length);
+      expect(koreanTruncated.length).toBeLessThan(koreanText.length);
     });
   });
 
@@ -901,6 +984,50 @@ export class APIClient {
       // Should detect as code and use code ratio
       expect(autoTokens).toBe(codeTokens);
       expect(codeTokens).toBe(Math.ceil(largeCode.length / CHARS_PER_TOKEN_BY_TYPE.code));
+    });
+  });
+
+  describe("locale support", () => {
+    it("should have locale-specific character ratios defined", () => {
+      expect(CHARS_PER_TOKEN_BY_LOCALE.en.natural).toBe(4.0);
+      expect(CHARS_PER_TOKEN_BY_LOCALE.en.code).toBe(3.2);
+      expect(CHARS_PER_TOKEN_BY_LOCALE.ko.natural).toBe(2.4);
+      expect(CHARS_PER_TOKEN_BY_LOCALE.ko.code).toBe(2.0);
+    });
+
+    it("should demonstrate significant difference between English and Korean token estimation", () => {
+      const mixedText = "Hello 안녕하세요 World 세계"; // 20 characters total
+
+      const englishEstimate = estimateTokenCount(mixedText, 'natural', 'en');
+      const koreanEstimate = estimateTokenCount(mixedText, 'natural', 'ko');
+
+      // Korean should estimate significantly more tokens
+      expect(koreanEstimate).toBeGreaterThan(englishEstimate);
+
+      // Verify math: 20 chars
+      expect(englishEstimate).toBe(Math.ceil(20 / 4.0)); // 5 tokens
+      expect(koreanEstimate).toBe(Math.ceil(20 / 2.4)); // 9 tokens
+    });
+
+    it("should handle locale consistently across all functions", () => {
+      const koreanText = "한국어 텍스트 예제입니다"; // 13 characters
+
+      // All functions should use same base estimation
+      const baseTokens = estimateTokenCount(koreanText, 'natural', 'ko');
+      const analysisTokens = analyzeTokenUsage(koreanText, 'claude-opus-4-5', 'ko').estimatedTokens;
+
+      expect(baseTokens).toBe(analysisTokens);
+      expect(baseTokens).toBe(Math.ceil(13 / 2.4)); // 6 tokens
+    });
+
+    it("should preserve backwards compatibility when locale not specified", () => {
+      const text = "Sample text for testing"; // 23 characters
+
+      const oldWay = estimateTokenCount(text);
+      const newWayDefault = estimateTokenCount(text, 'auto', 'en');
+
+      // Should produce identical results
+      expect(oldWay).toBe(newWayDefault);
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves #250 — fix: 한국어 토큰 추정 보정 — locale:ko 시 chars/token 비율 조정

현재 token-estimator는 영어 기준 chars/token 비율(natural: 4.0, code: 3.2)만 사용하여 한국어 텍스트의 토큰 수를 과소추정합니다. 한국어는 1~2 char당 1 token으로 더 밀집되어 있어, 이슈 본문이나 프롬프트의 실제 토큰 수가 추정치의 2배에 달할 수 있습니다. 이로 인해 context overflow 위험이 있으며, 토큰 예산 기반 truncation이 부정확해집니다.

## Requirements

- token-estimator.ts에 locale별 CHARS_PER_TOKEN 비율 상수 추가 (ko: 2.0~2.5)
- estimateTokenCount, analyzeTokenUsage, truncateToTokenBudget 등 주요 함수에 optional locale 파라미터 추가
- phase-executor.ts에서 ctx.claudeConfig.general.locale을 token-estimator 함수에 전달
- plan-generator.ts에서 ctx.claudeConfig.general.locale을 token-estimator 함수에 전달
- 기존 호출자(diff-splitter 등)는 영어 기본값으로 동작하여 하위 호환성 유지
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: token-estimator locale 지원 추가 — SUCCESS (b748da1d)
- Phase 1: phase-executor, plan-generator locale 전달 — SUCCESS (306dd8b5)
- Phase 2: 테스트 추가 및 업데이트 — SUCCESS (8b32a2aa)

## Risks

- locale 파라미터 추가 시 기존 호출자에서 타입 에러 발생 가능 — optional 파라미터로 해결
- 한국어 chars/token 비율 선택이 실제 토크나이저와 다를 수 있음 — 2.0~2.5 범위 내에서 보수적 선택(2.5) 권장
- diff-splitter.ts는 이슈 범위 밖이지만 token-estimator 사용 — optional 파라미터로 하위 호환성 보장

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/250-fix-locale-ko-chars-token` → `develop`
- **Tokens**: 465 input, 30761 output{{#stats.cacheCreationTokens}}, 206268 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2678910 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #250