### PR TITLE
[AQ-#252] docs: API 문서 + 트러블슈팅 가이드 작성

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -318,6 +318,88 @@ const eventSource = new EventSource('/api/events?token=uuid-session-token');
 
 ---
 
+## Version API
+
+### GET /api/version
+시스템 버전 정보와 업데이트 상태를 조회합니다.
+
+**응답:**
+```json
+{
+  "currentVersion": "1.0.0",
+  "currentHash": "a1b2c3d4",
+  "remoteHash": "e5f6g7h8",
+  "hasUpdates": true,
+  "packageLockChanged": false
+}
+```
+
+**에러 응답:**
+```json
+{
+  "currentVersion": "1.0.0",
+  "currentHash": "unknown",
+  "remoteHash": "unknown", 
+  "hasUpdates": false,
+  "packageLockChanged": false,
+  "error": "업데이트 확인에 실패했습니다"
+}
+```
+
+**필드 설명:**
+- `currentVersion` - 현재 설치된 버전
+- `currentHash` - 현재 Git 커밋 해시 (처음 8자리)
+- `remoteHash` - 원격 저장소 최신 커밋 해시 (처음 8자리)
+- `hasUpdates` - 업데이트 가능 여부
+- `packageLockChanged` - 의존성 변경 여부
+- `error` - 업데이트 확인 실패 시 에러 메시지
+
+### POST /api/update
+시스템 자체 업데이트를 수행합니다.
+
+**응답 (성공):**
+```json
+{
+  "message": "업데이트가 완료되었습니다",
+  "updated": true,
+  "needsRestart": true
+}
+```
+
+**응답 (최신 버전):**
+```json
+{
+  "message": "이미 최신 버전입니다",
+  "updated": false,
+  "needsRestart": false
+}
+```
+
+**에러:**
+```json
+{
+  "error": "진행 중인 작업이 있어 업데이트를 수행할 수 없습니다",
+  "runningJobs": [
+    {
+      "id": "job-uuid",
+      "issueNumber": 123,
+      "repo": "owner/repo",
+      "status": "running"
+    }
+  ]
+}
+```
+
+- `409` - 진행 중인 작업이 있음 (업데이트 차단)
+- `500` - 업데이트 수행 중 오류
+
+**필드 설명:**
+- `updated` - 실제로 업데이트가 수행되었는지 여부
+- `needsRestart` - 시스템 재시작이 필요한지 여부
+- `runningJobs` - 진행 중인 작업 목록 (409 에러 시)
+
+---
+
 ## Server-Sent Events (SSE)
 
 ### GET /api/events

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -445,26 +445,19 @@ Phase execution failed: maxTurns limit reached
 
 ### 해결책
 
-#### 1. 전역 maxTurns 증가
+#### 1. maxTurns 설정 조정
 ```yaml
-# config.yml
+# config.yml - 전역 또는 모드별 설정
 commands:
   claudeCli:
-    maxTurns: 100  # 기본값 60에서 증가
-```
-
-#### 2. 실행 모드별 제한 설정
-```yaml
-# config.yml
-commands:
-  claudeCli:
-    maxTurnsPerMode:
+    maxTurns: 100  # 전역 제한 증가 (기본값 60)
+    maxTurnsPerMode:  # 또는 모드별 제한
       code: 80        # 코드 작업용
       content: 40     # 콘텐츠 작업용
-      debug: 120      # 디버깅용 (더 높게)
+      debug: 120      # 디버깅용
 ```
 
-#### 3. 작업 분할
+#### 2. 작업 분할
 큰 작업을 더 작은 Phase로 분할:
 ```markdown
 # 이슈에 Phase 분할 힌트 추가
@@ -476,13 +469,11 @@ phases_hint: |
   4. 리팩터링 및 최적화
 ```
 
-#### 4. 실행 모드 조정
+#### 3. 실행 모드 조정
 ```bash
-# 간단한 작업은 content 모드로
-aqm run --mode=content
-
-# 복잡한 디버깅은 debug 모드로  
-aqm run --mode=debug
+# 작업 복잡도에 맞게 모드 선택
+aqm run --mode=content  # 간단한 작업
+aqm run --mode=debug    # 복잡한 디버깅
 ```
 
 ---
@@ -505,9 +496,9 @@ Plan generation Claude call failed, collecting context for retry...
 
 ### 해결책
 
-#### 1. 이슈 명확화
+#### 1. 이슈 작성 개선
+이슈에 다음 정보를 추가하세요:
 ```markdown
-# 이슈 템플릿 개선
 ## 문제 정의
 - 현재 상태: (구체적으로 기술)
 - 목표 상태: (명확한 결과물)
@@ -528,30 +519,26 @@ pipeline:
     enableContextCollection: true  # 컨텍스트 수집 활성화
 ```
 
-#### 3. 프로젝트 컨텍스트 제공
-이슈에 프로젝트 정보 추가:
+#### 3. 프로젝트 정보 제공
+자동 계획이 실패할 경우 수동으로 아래 정보를 이슈에 추가:
 ```markdown
 ## 프로젝트 컨텍스트
 - 기술 스택: React, TypeScript, Vite
-- 주요 디렉토리: src/components, src/utils  
+- 주요 디렉토리: src/components, src/utils
 - 코딩 스타일: ESLint + Prettier
 - 테스트: Vitest
-```
 
-#### 4. 수동 계획 생성
-자동 계획 생성이 실패하면 수동으로 계획 제공:
-```markdown
-## 구현 계획
-### Phase 1: 컴포넌트 수정
+## 구현 계획 (선택사항)
+### Phase 1: 핵심 기능 수정
 - 파일: src/components/UserList.tsx
 - 작업: 검색 필터 기능 추가
 
-### Phase 2: 테스트 추가  
+### Phase 2: 테스트 추가
 - 파일: tests/components/UserList.test.tsx
 - 작업: 검색 필터 테스트 케이스
 ```
 
-#### 5. 로그 분석 및 디버깅
+#### 4. 로그 분석 및 디버깅
 ```bash
 # 계획 생성 실패 로그 확인
 aqm logs --phase=planning --verbose

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -429,6 +429,139 @@ safety:
 
 ---
 
+## ⚡ MaxTurns 초과 (Claude 대화 턴 제한)
+
+### 현상
+```
+Error: Claude max turns exceeded — increase commands.claudeCli.maxTurns in config
+Job failed: 최대 턴 수를 초과했습니다
+Phase execution failed: maxTurns limit reached
+```
+
+### 원인
+- Claude CLI 대화가 설정된 최대 턴 수를 초과함
+- 복잡한 작업이나 긴 디버깅 과정으로 인한 초과
+- 실행 모드별 maxTurns 제한에 걸림
+
+### 해결책
+
+#### 1. 전역 maxTurns 증가
+```yaml
+# config.yml
+commands:
+  claudeCli:
+    maxTurns: 100  # 기본값 60에서 증가
+```
+
+#### 2. 실행 모드별 제한 설정
+```yaml
+# config.yml
+commands:
+  claudeCli:
+    maxTurnsPerMode:
+      code: 80        # 코드 작업용
+      content: 40     # 콘텐츠 작업용
+      debug: 120      # 디버깅용 (더 높게)
+```
+
+#### 3. 작업 분할
+큰 작업을 더 작은 Phase로 분할:
+```markdown
+# 이슈에 Phase 분할 힌트 추가
+---
+phases_hint: |
+  1. 기본 구조 구현 (5개 파일)
+  2. 테스트 추가 (3개 파일)  
+  3. 문서 업데이트 (2개 파일)
+  4. 리팩터링 및 최적화
+```
+
+#### 4. 실행 모드 조정
+```bash
+# 간단한 작업은 content 모드로
+aqm run --mode=content
+
+# 복잡한 디버깅은 debug 모드로  
+aqm run --mode=debug
+```
+
+---
+
+## 📋 Plan 실패 (계획 생성 실패)
+
+### 현상
+```
+Error: Plan generation failed after 3 attempts: Claude response timeout
+Error: Plan generation failed: JSON 파싱 실패 (3회 시도)
+Error: Plan generation failed: unexpected exit
+Plan generation Claude call failed, collecting context for retry...
+```
+
+### 원인
+- 이슈 내용이 불명확하거나 너무 복잡함
+- Claude API 응답 지연 또는 타임아웃
+- 계획 JSON 형식 파싱 실패
+- 프로젝트 컨텍스트 부족
+
+### 해결책
+
+#### 1. 이슈 명확화
+```markdown
+# 이슈 템플릿 개선
+## 문제 정의
+- 현재 상태: (구체적으로 기술)
+- 목표 상태: (명확한 결과물)
+- 제약사항: (제한사항이 있다면)
+
+## 작업 범위  
+- 수정할 파일들: src/components/*.tsx
+- 제외할 영역: 외부 API 연동
+```
+
+#### 2. 계획 생성 재시도 설정
+```yaml
+# config.yml
+pipeline:
+  planning:
+    maxRetries: 5      # 재시도 횟수 증가
+    timeout: 300000    # 타임아웃 5분으로 증가
+    enableContextCollection: true  # 컨텍스트 수집 활성화
+```
+
+#### 3. 프로젝트 컨텍스트 제공
+이슈에 프로젝트 정보 추가:
+```markdown
+## 프로젝트 컨텍스트
+- 기술 스택: React, TypeScript, Vite
+- 주요 디렉토리: src/components, src/utils  
+- 코딩 스타일: ESLint + Prettier
+- 테스트: Vitest
+```
+
+#### 4. 수동 계획 생성
+자동 계획 생성이 실패하면 수동으로 계획 제공:
+```markdown
+## 구현 계획
+### Phase 1: 컴포넌트 수정
+- 파일: src/components/UserList.tsx
+- 작업: 검색 필터 기능 추가
+
+### Phase 2: 테스트 추가  
+- 파일: tests/components/UserList.test.tsx
+- 작업: 검색 필터 테스트 케이스
+```
+
+#### 5. 로그 분석 및 디버깅
+```bash
+# 계획 생성 실패 로그 확인
+aqm logs --phase=planning --verbose
+
+# Claude 응답 내용 확인
+aqm logs --job=job-id | grep -A 10 "Plan generation"
+```
+
+---
+
 ## 🔧 일반적인 진단 방법
 
 ### 1. 로그 분석


### PR DESCRIPTION
## Summary

Resolves #252 — docs: API 문서 + 트러블슈팅 가이드 작성

대시보드 API 문서와 트러블슈팅 가이드가 대부분 완성되어 있으나, 일부 엔드포인트(GET /api/version, POST /api/update)와 에러 케이스(maxTurns 초과, Plan 실패)가 누락되어 있어 문서 완성도가 부족합니다.

## Requirements

- docs/api.md에 누락된 엔드포인트(GET /api/version, POST /api/update) 추가
- docs/troubleshooting.md에 maxTurns 초과 에러 케이스 추가
- docs/troubleshooting.md에 Plan 실패 에러 케이스 추가
- 기존 동작을 깨뜨리지 않을 것
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase 0: 문서 보완 — SUCCESS (078adc77)

## Risks

- 문서 형식 일관성 유지 필요
- 기존 문서 스타일과 톤 맞춤 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/252-docs-api` → `develop`
- **Tokens**: 38 input, 3775 output{{#stats.cacheCreationTokens}}, 98438 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 107957 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #252