### PR TITLE
[AQ-#260] refactor: 프롬프트 레이어 분리 — 정적/동적 캐시 효율화

### DIFF
--- a/src/pipeline/core-loop.ts
+++ b/src/pipeline/core-loop.ts
@@ -14,6 +14,9 @@ import { PROGRESS_PLAN_GENERATED, phaseStart } from "./progress-tracker.js";
 import { createWorktree, removeWorktree } from "../git/worktree-manager.js";
 import { createCheckpoint } from "../safety/rollback-manager.js";
 import { createSlug } from "../utils/slug.js";
+import { buildBaseLayer, buildProjectLayer, loadTemplate } from "../prompt/template-renderer.js";
+import { createHash } from "crypto";
+import { resolve } from "path";
 
 const logger = getLogger();
 
@@ -69,6 +72,7 @@ export interface CoreLoopContext {
   checkpoint?: string;  // checkpoint hash for rollback
   worktreeInfo?: { path: string; branch: string };  // worktree information
   slug?: string;  // issue slug for worktree naming
+  cachedLayers?: import("../types/pipeline.js").CachedPromptLayer;  // 캐시된 Base+Project 레이어
 }
 
 export interface CoreLoopResult {
@@ -80,6 +84,82 @@ export interface CoreLoopResult {
 }
 
 export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult> {
+  // Step 0: Build and cache static prompt layers (Base + Project) if not already cached
+  if (!ctx.cachedLayers) {
+    logger.info("Building and caching static prompt layers (Base + Project)...");
+
+    const baseLayer = buildBaseLayer({
+      role: "시니어 개발자",
+      locale: ctx.config.general.locale,
+    });
+
+    const projectLayer = buildProjectLayer({
+      conventions: ctx.projectConventions || "",
+      structure: ctx.repoStructure,
+      skillsContext: ctx.skillsContext,
+      testCommand: ctx.config.commands.test,
+      lintCommand: ctx.config.commands.lint,
+    });
+
+    // Generate cache key based on project and conventions
+    const cacheKey = createHash("sha256")
+      .update(ctx.cwd + (ctx.projectConventions || "") + ctx.repoStructure)
+      .digest("hex")
+      .substring(0, 16);
+
+    // Load static template parts for caching
+    const planTemplatePath = resolve(ctx.promptsDir, "plan-generation.md");
+    const phaseTemplatePath = resolve(ctx.promptsDir, "phase-implementation.md");
+
+    try {
+      const planTemplate = loadTemplate(planTemplatePath);
+      const phaseTemplate = loadTemplate(phaseTemplatePath);
+
+      // Create static content by assembling base and project layers
+      const staticContent = `# ${baseLayer.role}
+
+${baseLayer.rules.map(rule => `- ${rule}`).join('\n')}
+
+${baseLayer.outputFormat}
+
+${baseLayer.progressReporting}
+
+${baseLayer.parallelWorkGuide}
+
+## 프로젝트 컨벤션
+
+${projectLayer.conventions}
+
+## 프로젝트 구조
+
+${projectLayer.structure}
+
+## 설정
+
+- 테스트 명령어: ${projectLayer.testCommand}
+- 린트 명령어: ${projectLayer.lintCommand}
+
+## 안전 규칙
+
+${projectLayer.safetyRules.map(rule => `- ${rule}`).join('\n')}
+
+${projectLayer.skillsContext ? `## 스킬 컨텍스트\n\n${projectLayer.skillsContext}` : ''}
+
+${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFailures}` : ''}`;
+
+      ctx.cachedLayers = {
+        staticContent,
+        cacheKey,
+        createdAt: new Date().toISOString(),
+        phaseTemplate: phaseTemplate,
+      };
+
+      logger.info(`Static layers cached with key: ${cacheKey}`);
+    } catch (error: unknown) {
+      logger.warn(`Failed to cache static layers: ${getErrorMessage(error)}, proceeding without cache`);
+    }
+  }
+
   // Step 1: Generate plan
   logger.info(`Generating plan for issue #${ctx.issue.number}...`);
 
@@ -99,6 +179,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
       maxPhases: ctx.config.safety.maxPhases,
       locale: ctx.config.general.locale,
       sensitivePaths: ctx.config.safety.sensitivePaths.join(", "),
+      cachedLayers: ctx.cachedLayers,
     });
     plan = planResult.plan;
     planCostUsd = planResult.costUsd;
@@ -220,6 +301,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         pastFailures: pastFailures || undefined,
         jobLogger: jl,
         locale: ctx.config.general.locale,
+        cachedLayers: ctx.cachedLayers,
       });
 
       // Retry on failure (skip for TIMEOUT and SAFETY_VIOLATION — not recoverable by retry)

--- a/src/pipeline/core-loop.ts
+++ b/src/pipeline/core-loop.ts
@@ -14,7 +14,7 @@ import { PROGRESS_PLAN_GENERATED, phaseStart } from "./progress-tracker.js";
 import { createWorktree, removeWorktree } from "../git/worktree-manager.js";
 import { createCheckpoint } from "../safety/rollback-manager.js";
 import { createSlug } from "../utils/slug.js";
-import { buildBaseLayer, buildProjectLayer, loadTemplate } from "../prompt/template-renderer.js";
+import { buildBaseLayer, buildProjectLayer, buildStaticContent, loadTemplate } from "../prompt/template-renderer.js";
 import { createHash } from "crypto";
 import { resolve } from "path";
 
@@ -112,46 +112,14 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     const phaseTemplatePath = resolve(ctx.promptsDir, "phase-implementation.md");
 
     try {
-      const planTemplate = loadTemplate(planTemplatePath);
       const phaseTemplate = loadTemplate(phaseTemplatePath);
-
-      // Create static content by assembling base and project layers
-      const staticContent = `# ${baseLayer.role}
-
-${baseLayer.rules.map(rule => `- ${rule}`).join('\n')}
-
-${baseLayer.outputFormat}
-
-${baseLayer.progressReporting}
-
-${baseLayer.parallelWorkGuide}
-
-## 프로젝트 컨벤션
-
-${projectLayer.conventions}
-
-## 프로젝트 구조
-
-${projectLayer.structure}
-
-## 설정
-
-- 테스트 명령어: ${projectLayer.testCommand}
-- 린트 명령어: ${projectLayer.lintCommand}
-
-## 안전 규칙
-
-${projectLayer.safetyRules.map(rule => `- ${rule}`).join('\n')}
-
-${projectLayer.skillsContext ? `## 스킬 컨텍스트\n\n${projectLayer.skillsContext}` : ''}
-
-${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFailures}` : ''}`;
+      const staticContent = buildStaticContent(baseLayer, projectLayer);
 
       ctx.cachedLayers = {
         staticContent,
         cacheKey,
         createdAt: new Date().toISOString(),
-        phaseTemplate: phaseTemplate,
+        phaseTemplate,
       };
 
       logger.info(`Static layers cached with key: ${cacheKey}`);

--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -32,6 +32,7 @@ export interface PhaseExecutorContext {
   pastFailures?: string;
   jobLogger?: JobLogger;
   locale?: string;
+  cachedLayers?: import("../types/pipeline.js").CachedPromptLayer;  // 캐시된 레이어
 }
 
 export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResult> {
@@ -40,9 +41,15 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
   let claudeResult: ClaudeRunResult | undefined;
 
   try {
-    // 1. Load and render phase implementation template
-    const templatePath = resolve(ctx.promptsDir, "phase-implementation.md");
-    const template = loadTemplate(templatePath);
+    // 1. Load and render phase implementation template using cached layers if available
+    let template: string;
+    if (ctx.cachedLayers) {
+      logger.info(`Using cached static layers for phase ${ctx.phase.index + 1} (cache key: ${ctx.cachedLayers.cacheKey})`);
+      template = ctx.cachedLayers.phaseTemplate;
+    } else {
+      const templatePath = resolve(ctx.promptsDir, "phase-implementation.md");
+      template = loadTemplate(templatePath);
+    }
 
     const previousSummary = ctx.previousResults
       .map(r => `Phase ${r.phaseIndex}: ${r.phaseName} - ${r.success ? "SUCCESS" : "FAILED"}`)

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -10,7 +10,7 @@ import type { Plan, ContextualizationInfo, PlanRetryContext, PlanGenerationResul
 
 export interface PlanTemplateBaseData {
   issue: {
-    number: string;
+    number: number;
     title: string;
     body: string;
     labels: string[];
@@ -25,7 +25,7 @@ export interface PlanTemplateBaseData {
     work: string;
   };
   config: {
-    maxPhases: string;
+    maxPhases: number;
     sensitivePaths: string;
   };
 }
@@ -109,7 +109,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     required: ["mode", "issueNumber", "title", "problemDefinition", "phases"],
   });
 
-  const maxPhases = String(ctx.maxPhases ?? 10);
+  const maxPhases = ctx.maxPhases ?? 10;
   const sensitivePaths = ctx.sensitivePaths ?? "";
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -119,7 +119,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     // 기본 데이터 구조
     const baseData = {
       issue: {
-        number: String(ctx.issue.number),
+        number: ctx.issue.number,
         title: ctx.issue.title,
         body: attempt === 1 ? `<USER_INPUT>\n${ctx.issue.body}\n</USER_INPUT>` : ctx.issue.body,
         labels: ctx.issue.labels,
@@ -142,7 +142,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       // 캐시된 정적 레이어 사용하여 동적 부분만 렌더링
       logger.info(`Using cached static layers (cache key: ${ctx.cachedLayers.cacheKey})`);
       const dynamicSection = buildDynamicSection({
-        issue: baseData.issue as { number: number; title: string; body: string; labels: string[] },
+        issue: baseData.issue,
         repo: baseData.repo,
         branch: baseData.branch,
         config: baseData.config,
@@ -201,7 +201,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       if (ctx.cachedLayers) {
         // 캐시된 레이어 사용 시 동적 섹션 재구성
         const dynamicSection = buildDynamicSection({
-          issue: templateData.issue as { number: number; title: string; body: string; labels: string[] },
+          issue: templateData.issue,
           repo: templateData.repo,
           branch: templateData.branch,
           config: templateData.config,

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -135,6 +135,9 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
 
     // 캐시된 레이어 활용 또는 원본 템플릿 로드
     let finalPrompt: string;
+    let templateData = baseData;
+    let template: string;
+
     if (ctx.cachedLayers) {
       // 캐시된 정적 레이어 사용하여 동적 부분만 렌더링
       logger.info(`Using cached static layers (cache key: ${ctx.cachedLayers.cacheKey})`);
@@ -165,11 +168,11 @@ ${baseData.repo.structure}
 `;
 
       finalPrompt = ctx.cachedLayers.staticContent + "\n\n" + dynamicSection;
+      template = ""; // 캐시된 레이어 사용 시에는 템플릿이 필요 없음
     } else {
       // 기존 방식: 원본 템플릿 로드
       const templatePath = resolve(ctx.promptsDir, "plan-generation.md");
-      let templateData = baseData;
-      const template = loadTemplate(templatePath);
+      template = loadTemplate(templatePath);
       finalPrompt = renderTemplate(template, templateData as unknown as TemplateVariables);
     }
 
@@ -214,7 +217,39 @@ ${baseData.repo.structure}
     // Helper to update and re-render
     const updateAndRerender = (updateFn: (data: PlanTemplateData) => PlanTemplateData, stage: string) => {
       templateData = updateFn(templateData);
-      finalPrompt = renderTemplate(template, templateData as unknown as TemplateVariables);
+
+      if (ctx.cachedLayers) {
+        // 캐시된 레이어 사용 시 동적 섹션 재구성
+        const dynamicSection = `
+# 이슈 정보
+
+**번호**: #${templateData.issue.number}
+**제목**: ${templateData.issue.title}
+**라벨**: ${templateData.issue.labels.join(", ")}
+
+**본문**:
+${templateData.issue.body}
+
+# 저장소 정보
+
+**소유자**: ${templateData.repo.owner}
+**이름**: ${templateData.repo.name}
+**구조**:
+${templateData.repo.structure}
+
+**브랜치**: ${templateData.branch.base} → ${templateData.branch.work}
+
+# 설정
+
+**최대 Phase 수**: ${templateData.config.maxPhases}
+**민감한 경로**: ${templateData.config.sensitivePaths}
+`;
+        finalPrompt = ctx.cachedLayers.staticContent + "\n\n" + dynamicSection;
+      } else {
+        // 기존 방식
+        finalPrompt = renderTemplate(template, templateData as unknown as TemplateVariables);
+      }
+
       if (ctx.modeHint) {
         finalPrompt += `\n\n## 추가 지시\n\n${ctx.modeHint}`;
       }

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -65,6 +65,7 @@ export interface PlanGeneratorContext {
   maxPhases?: number;
   sensitivePaths?: string;
   locale?: string;
+  cachedLayers?: import("../types/pipeline.js").CachedPromptLayer;  // 캐시된 레이어
 }
 
 export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithCost> {
@@ -132,12 +133,45 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       config: { maxPhases, sensitivePaths },
     };
 
-    // 항상 원본 템플릿을 기본으로 사용
-    const templatePath = resolve(ctx.promptsDir, "plan-generation.md");
-    let templateData = baseData;
+    // 캐시된 레이어 활용 또는 원본 템플릿 로드
+    let finalPrompt: string;
+    if (ctx.cachedLayers) {
+      // 캐시된 정적 레이어 사용하여 동적 부분만 렌더링
+      logger.info(`Using cached static layers (cache key: ${ctx.cachedLayers.cacheKey})`);
 
-    const template = loadTemplate(templatePath);
-    let finalPrompt = renderTemplate(template, templateData as unknown as TemplateVariables);
+      const dynamicSection = `
+# 이슈 정보
+
+**번호**: #${baseData.issue.number}
+**제목**: ${baseData.issue.title}
+**라벨**: ${baseData.issue.labels.join(", ")}
+
+**본문**:
+${baseData.issue.body}
+
+# 저장소 정보
+
+**소유자**: ${baseData.repo.owner}
+**이름**: ${baseData.repo.name}
+**구조**:
+${baseData.repo.structure}
+
+**브랜치**: ${baseData.branch.base} → ${baseData.branch.work}
+
+# 설정
+
+**최대 Phase 수**: ${baseData.config.maxPhases}
+**민감한 경로**: ${baseData.config.sensitivePaths}
+`;
+
+      finalPrompt = ctx.cachedLayers.staticContent + "\n\n" + dynamicSection;
+    } else {
+      // 기존 방식: 원본 템플릿 로드
+      const templatePath = resolve(ctx.promptsDir, "plan-generation.md");
+      let templateData = baseData;
+      const template = loadTemplate(templatePath);
+      finalPrompt = renderTemplate(template, templateData as unknown as TemplateVariables);
+    }
 
     // retry 시에는 retry 섹션을 append
     if (attempt > 1) {

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
 import { readFileSync, existsSync } from "fs";
 import * as ts from "typescript";
-import { renderTemplate, loadTemplate, TemplateVariables } from "../prompt/template-renderer.js";
+import { renderTemplate, loadTemplate, buildDynamicSection, TemplateVariables } from "../prompt/template-renderer.js";
 import { runClaude, extractJson } from "../claude/claude-runner.js";
 import { configForTask } from "../claude/model-router.js";
 import type { ClaudeCliConfig } from "../types/config.js";
@@ -141,34 +141,14 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     if (ctx.cachedLayers) {
       // 캐시된 정적 레이어 사용하여 동적 부분만 렌더링
       logger.info(`Using cached static layers (cache key: ${ctx.cachedLayers.cacheKey})`);
-
-      const dynamicSection = `
-# 이슈 정보
-
-**번호**: #${baseData.issue.number}
-**제목**: ${baseData.issue.title}
-**라벨**: ${baseData.issue.labels.join(", ")}
-
-**본문**:
-${baseData.issue.body}
-
-# 저장소 정보
-
-**소유자**: ${baseData.repo.owner}
-**이름**: ${baseData.repo.name}
-**구조**:
-${baseData.repo.structure}
-
-**브랜치**: ${baseData.branch.base} → ${baseData.branch.work}
-
-# 설정
-
-**최대 Phase 수**: ${baseData.config.maxPhases}
-**민감한 경로**: ${baseData.config.sensitivePaths}
-`;
-
+      const dynamicSection = buildDynamicSection({
+        issue: baseData.issue as { number: number; title: string; body: string; labels: string[] },
+        repo: baseData.repo,
+        branch: baseData.branch,
+        config: baseData.config,
+      });
       finalPrompt = ctx.cachedLayers.staticContent + "\n\n" + dynamicSection;
-      template = ""; // 캐시된 레이어 사용 시에는 템플릿이 필요 없음
+      template = "";
     } else {
       // 기존 방식: 원본 템플릿 로드
       const templatePath = resolve(ctx.promptsDir, "plan-generation.md");
@@ -220,30 +200,12 @@ ${baseData.repo.structure}
 
       if (ctx.cachedLayers) {
         // 캐시된 레이어 사용 시 동적 섹션 재구성
-        const dynamicSection = `
-# 이슈 정보
-
-**번호**: #${templateData.issue.number}
-**제목**: ${templateData.issue.title}
-**라벨**: ${templateData.issue.labels.join(", ")}
-
-**본문**:
-${templateData.issue.body}
-
-# 저장소 정보
-
-**소유자**: ${templateData.repo.owner}
-**이름**: ${templateData.repo.name}
-**구조**:
-${templateData.repo.structure}
-
-**브랜치**: ${templateData.branch.base} → ${templateData.branch.work}
-
-# 설정
-
-**최대 Phase 수**: ${templateData.config.maxPhases}
-**민감한 경로**: ${templateData.config.sensitivePaths}
-`;
+        const dynamicSection = buildDynamicSection({
+          issue: templateData.issue as { number: number; title: string; body: string; labels: string[] },
+          repo: templateData.repo,
+          branch: templateData.branch,
+          config: templateData.config,
+        });
         finalPrompt = ctx.cachedLayers.staticContent + "\n\n" + dynamicSection;
       } else {
         // 기존 방식

--- a/src/prompt/template-renderer.ts
+++ b/src/prompt/template-renderer.ts
@@ -1,4 +1,12 @@
 import { readFileSync } from "fs";
+import { createHash } from "crypto";
+import type {
+  BaseLayer,
+  ProjectLayer,
+  PhaseLayer,
+  PromptLayer,
+  AssembledPrompt
+} from "../types/pipeline.js";
 
 export interface TemplateVariables {
   [key: string]: string | number | boolean | string[] | TemplateVariables;
@@ -73,4 +81,205 @@ export function loadTemplate(templatePath: string): string {
       `Failed to read template file ${templatePath}: ${error.message}`
     );
   }
+}
+
+/**
+ * 기본 레이어를 구축합니다. 역할과 규칙 등 정적 내용을 포함합니다.
+ */
+export function buildBaseLayer(config: {
+  role: string;
+  locale?: string;
+}): BaseLayer {
+  const rules = [
+    "이 Phase의 대상 파일만 수정하세요. 범위를 벗어난 파일은 수정하지 마세요.",
+    "구현이 완료되면 반드시 git add + git commit을 수행하세요.",
+    "검증이 실패하면 수정 후 다시 검증하세요.",
+    "불필요한 파일, 주석, console.log를 추가하지 마세요.",
+    "기존 코드 스타일과 패턴을 따르세요.",
+    "any 금지: src/ 내 any 타입 사용 금지. unknown + 타입 가드로 좁힐 것.",
+    "에러 핸들링: catch (err: unknown) + getErrorMessage(err) 패턴.",
+    "ESM import: 반드시 .js 확장자 포함.",
+    "logger 사용: console.log 대신 getLogger() 사용.",
+    "safety guard: SafetyViolationError를 catch해서 삼키지 말 것."
+  ];
+
+  const outputFormat = `구현 완료 후 아래 JSON을 출력하세요:
+
+\`\`\`json
+{
+  "phaseIndex": <number>,
+  "phaseName": "<Phase 이름>",
+  "filesModified": ["<수정한 파일 경로>", ...],
+  "testsAdded": ["<추가한 테스트>", ...],
+  "commitMessage": "<커밋 메시지>",
+  "notes": "<특이사항>"
+}
+\`\`\``;
+
+  const progressReporting = `작업 중 2분마다 현재 진행 상황을 한 줄로 출력하세요. 형식:
+\`[HEARTBEAT] Phase <N>: <현재 하고 있는 작업> (<진행률>)\`
+
+예시:
+- \`[HEARTBEAT] Phase 1: src/components/Chat.tsx 수정 중 (30%)\`
+- \`[HEARTBEAT] Phase 2: 테스트 작성 중 (80%)\`
+
+**출력이 5분간 없으면 시스템이 작업을 중단합니다.** 반드시 주기적으로 진행 상황을 보고하세요.`;
+
+  const parallelWorkGuide = `**서브에이전트 활용이 활성화되어 있습니다.** 독립적인 파일들을 병렬로 처리하여 효율성을 높이세요.
+
+### 병렬 처리 권장 사항
+- **독립적인 파일 수정**: 서로 의존성이 없는 파일들은 동시에 작업하세요
+- **컴포넌트별 분리**: UI 컴포넌트, 유틸리티, 테스트 파일 등을 병렬로 처리하세요
+- **다중 도구 호출**: 여러 도구를 한 번에 호출하여 작업 속도를 높이세요
+
+### 예시
+\`\`\`
+여러 파일을 동시에 수정하는 경우:
+- src/utils/helper.ts (독립적 유틸리티)
+- src/components/Button.tsx (UI 컴포넌트)
+- tests/helper.test.ts (테스트 파일)
+\`\`\``;
+
+  return {
+    role: config.role,
+    rules,
+    outputFormat,
+    progressReporting,
+    parallelWorkGuide,
+  };
+}
+
+/**
+ * 프로젝트 레이어를 구축합니다. 프로젝트별 설정과 컨벤션을 포함합니다.
+ */
+export function buildProjectLayer(config: {
+  conventions: string;
+  structure?: string;
+  skillsContext?: string;
+  pastFailures?: string;
+  testCommand: string;
+  lintCommand: string;
+  safetyRules?: string[];
+}): ProjectLayer {
+  const defaultSafetyRules = [
+    "config 필드 추가 시: types/config.ts + config/defaults.ts + config/validator.ts 3곳 동시 수정 필수",
+    "안전장치 우회 금지. safety guard를 비활성화하는 코드 작성하지 않는다",
+    "git add -f 절대 금지",
+  ];
+
+  return {
+    conventions: config.conventions,
+    structure: config.structure || "",
+    skillsContext: config.skillsContext,
+    pastFailures: config.pastFailures,
+    testCommand: config.testCommand,
+    lintCommand: config.lintCommand,
+    safetyRules: config.safetyRules || defaultSafetyRules,
+  };
+}
+
+/**
+ * Phase 레이어를 구축합니다. 현재 실행 컨텍스트와 동적 정보를 포함합니다.
+ */
+export function buildPhaseLayer(config: {
+  issue: {
+    number: number;
+    title: string;
+    body: string;
+    labels: string[];
+  };
+  planSummary: string;
+  currentPhase: {
+    index: number;
+    totalCount: number;
+    name: string;
+    description: string;
+    targetFiles: string[];
+  };
+  previousResults: string;
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  locale?: string;
+}): PhaseLayer {
+  return {
+    issue: config.issue,
+    planSummary: config.planSummary,
+    currentPhase: config.currentPhase,
+    previousResults: config.previousResults,
+    repository: config.repository,
+    locale: config.locale,
+  };
+}
+
+/**
+ * 전체 프롬프트 레이어를 조립합니다.
+ */
+export function assemblePrompt(
+  layers: PromptLayer,
+  templateContent: string
+): AssembledPrompt {
+  const startTime = Date.now();
+
+  // 정적 레이어 캐시 키 생성
+  const cacheKey = createHash("sha256")
+    .update(layers.base.role + JSON.stringify(layers.base.rules) + layers.project.conventions)
+    .digest("hex")
+    .substring(0, 16);
+
+  // 템플릿 변수 준비
+  const variables: TemplateVariables = {
+    // Base Layer
+    role: layers.base.role,
+    rules: layers.base.rules,
+    outputFormat: layers.base.outputFormat,
+    progressReporting: layers.base.progressReporting,
+    parallelWorkGuide: layers.base.parallelWorkGuide,
+
+    // Project Layer
+    projectConventions: layers.project.conventions,
+    projectStructure: layers.project.structure,
+    skillsContext: layers.project.skillsContext || "",
+    pastFailures: layers.project.pastFailures || "",
+    config: {
+      testCommand: layers.project.testCommand,
+      lintCommand: layers.project.lintCommand,
+    },
+    safetyRules: layers.project.safetyRules,
+
+    // Phase Layer
+    issue: {
+      number: String(layers.phase.issue.number),
+      title: layers.phase.issue.title,
+      body: layers.phase.issue.body,
+      labels: layers.phase.issue.labels,
+    },
+    plan: {
+      summary: layers.phase.planSummary,
+    },
+    phase: {
+      index: String(layers.phase.currentPhase.index),
+      totalCount: String(layers.phase.currentPhase.totalCount),
+      name: layers.phase.currentPhase.name,
+      description: layers.phase.currentPhase.description,
+      files: layers.phase.currentPhase.targetFiles,
+    },
+    previousPhases: {
+      summary: layers.phase.previousResults,
+    },
+    repository: layers.phase.repository,
+  };
+
+  const assembledContent = renderTemplate(templateContent, variables);
+  const assemblyTime = Date.now() - startTime;
+
+  return {
+    content: assembledContent,
+    cacheKey,
+    cacheHit: false, // 실제 캐시 구현에서는 이 값을 적절히 설정
+    assemblyTimeMs: assemblyTime,
+  };
 }

--- a/src/prompt/template-renderer.ts
+++ b/src/prompt/template-renderer.ts
@@ -216,6 +216,77 @@ export function buildPhaseLayer(config: {
 }
 
 /**
+ * 동적 섹션(이슈, 저장소, 설정)을 구성합니다.
+ */
+export function buildDynamicSection(data: {
+  issue: { number: number; title: string; body: string; labels: string[] };
+  repo: { owner: string; name: string; structure: string };
+  branch: { base: string; work: string };
+  config: { maxPhases: number; sensitivePaths: string };
+}): string {
+  return `
+# 이슈 정보
+
+**번호**: #${data.issue.number}
+**제목**: ${data.issue.title}
+**라벨**: ${data.issue.labels.join(", ")}
+
+**본문**:
+${data.issue.body}
+
+# 저장소 정보
+
+**소유자**: ${data.repo.owner}
+**이름**: ${data.repo.name}
+**구조**:
+${data.repo.structure}
+
+**브랜치**: ${data.branch.base} → ${data.branch.work}
+
+# 설정
+
+**최대 Phase 수**: ${data.config.maxPhases}
+**민감한 경로**: ${data.config.sensitivePaths}
+`;
+}
+
+/**
+ * 정적 레이어(Base + Project)를 조립한 콘텐츠를 생성합니다.
+ */
+export function buildStaticContent(baseLayer: BaseLayer, projectLayer: ProjectLayer): string {
+  return `# ${baseLayer.role}
+
+${baseLayer.rules.map(rule => `- ${rule}`).join('\n')}
+
+${baseLayer.outputFormat}
+
+${baseLayer.progressReporting}
+
+${baseLayer.parallelWorkGuide}
+
+## 프로젝트 컨벤션
+
+${projectLayer.conventions}
+
+## 프로젝트 구조
+
+${projectLayer.structure}
+
+## 설정
+
+- 테스트 명령어: ${projectLayer.testCommand}
+- 린트 명령어: ${projectLayer.lintCommand}
+
+## 안전 규칙
+
+${projectLayer.safetyRules.map(rule => `- ${rule}`).join('\n')}
+
+${projectLayer.skillsContext ? `## 스킬 컨텍스트\n\n${projectLayer.skillsContext}` : ''}
+
+${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFailures}` : ''}`;
+}
+
+/**
  * 전체 프롬프트 레이어를 조립합니다.
  */
 export function assemblePrompt(
@@ -279,7 +350,7 @@ export function assemblePrompt(
   return {
     content: assembledContent,
     cacheKey,
-    cacheHit: false, // 실제 캐시 구현에서는 이 값을 적절히 설정
+    cacheHit: false,
     assemblyTimeMs: assemblyTime,
   };
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -248,3 +248,115 @@ export interface PlanRetryContext {
   /** 재시도 가능 여부 */
   canRetry: boolean;
 }
+
+// 프롬프트 레이어 분리를 위한 타입 정의
+
+/**
+ * 기본 레이어 - 역할과 규칙 등 정적 내용
+ */
+export interface BaseLayer {
+  /** AI 역할 정의 (예: "시니어 개발자", "소프트웨어 아키텍트") */
+  role: string;
+  /** 기본 규칙과 지침 */
+  rules: string[];
+  /** 출력 포맷 지침 */
+  outputFormat: string;
+  /** 진행 보고 규칙 */
+  progressReporting: string;
+  /** 병렬 작업 가이드 */
+  parallelWorkGuide: string;
+}
+
+/**
+ * 프로젝트 레이어 - 프로젝트 수준 설정 (정적)
+ */
+export interface ProjectLayer {
+  /** 프로젝트 컨벤션 (CLAUDE.md 내용) */
+  conventions: string;
+  /** 프로젝트 구조 정보 */
+  structure: string;
+  /** 스킬 컨텍스트 */
+  skillsContext?: string;
+  /** 과거 실패 사례 */
+  pastFailures?: string;
+  /** 테스트 명령어 */
+  testCommand: string;
+  /** 린트 명령어 */
+  lintCommand: string;
+  /** 프로젝트 특정 안전 규칙 */
+  safetyRules: string[];
+}
+
+/**
+ * Phase 레이어 - 현재 실행 컨텍스트 (동적)
+ */
+export interface PhaseLayer {
+  /** 이슈 정보 */
+  issue: {
+    number: number;
+    title: string;
+    body: string;
+    labels: string[];
+  };
+  /** 전체 계획 요약 */
+  planSummary: string;
+  /** 현재 Phase 정보 */
+  currentPhase: {
+    index: number;
+    totalCount: number;
+    name: string;
+    description: string;
+    targetFiles: string[];
+  };
+  /** 이전 Phase 결과 요약 */
+  previousResults: string;
+  /** 저장소 정보 */
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  /** 로케일 설정 */
+  locale?: string;
+}
+
+/**
+ * 조합된 프롬프트 레이어
+ */
+export interface PromptLayer {
+  /** 기본 레이어 (정적) */
+  base: BaseLayer;
+  /** 프로젝트 레이어 (정적) */
+  project: ProjectLayer;
+  /** Phase 레이어 (동적) */
+  phase: PhaseLayer;
+}
+
+/**
+ * 캐시된 프롬프트 레이어 (Base + Project는 1회만 조립)
+ */
+export interface CachedPromptLayer {
+  /** 정적 레이어 조합 결과 (Base + Project) */
+  staticContent: string;
+  /** 정적 레이어 캐시 키 (프로젝트 루트 + 컨벤션 해시) */
+  cacheKey: string;
+  /** 캐시 생성 시각 */
+  createdAt: string;
+  /** Phase 레이어 템플릿 (동적 부분만) */
+  phaseTemplate: string;
+}
+
+/**
+ * 프롬프트 조립 결과
+ */
+export interface AssembledPrompt {
+  /** 최종 조립된 프롬프트 */
+  content: string;
+  /** 사용된 캐시 키 */
+  cacheKey?: string;
+  /** 캐시 히트 여부 */
+  cacheHit: boolean;
+  /** 조립에 소요된 시간 (ms) */
+  assemblyTimeMs: number;
+}

--- a/tests/prompt/template-renderer.test.ts
+++ b/tests/prompt/template-renderer.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { renderTemplate } from "../../src/prompt/template-renderer.js";
+import {
+  renderTemplate,
+  buildBaseLayer,
+  buildProjectLayer,
+  buildPhaseLayer,
+  assemblePrompt
+} from "../../src/prompt/template-renderer.js";
+import type { PromptLayer } from "../../src/types/pipeline.js";
 
 describe("renderTemplate", () => {
   it("should replace simple variables", () => {
@@ -44,5 +51,269 @@ describe("renderTemplate", () => {
       a: { b: { c: "deep" } },
     });
     expect(result).toBe("deep");
+  });
+});
+
+describe("buildBaseLayer", () => {
+  it("should create base layer with required fields", () => {
+    const result = buildBaseLayer({
+      role: "시니어 개발자",
+    });
+
+    expect(result.role).toBe("시니어 개발자");
+    expect(result.rules).toBeInstanceOf(Array);
+    expect(result.rules.length).toBeGreaterThan(0);
+    expect(result.outputFormat).toContain("JSON");
+    expect(result.progressReporting).toContain("HEARTBEAT");
+    expect(result.parallelWorkGuide).toContain("서브에이전트");
+  });
+
+  it("should handle optional locale field", () => {
+    const result = buildBaseLayer({
+      role: "Software Engineer",
+      locale: "en",
+    });
+
+    expect(result.role).toBe("Software Engineer");
+    expect(result.rules).toBeInstanceOf(Array);
+  });
+
+  it("should include all required rule categories", () => {
+    const result = buildBaseLayer({ role: "Developer" });
+
+    const rulesText = result.rules.join(" ");
+    expect(rulesText).toContain("Phase의 대상 파일만");
+    expect(rulesText).toContain("git add + git commit");
+    expect(rulesText).toContain("any 금지");
+    expect(rulesText).toContain("ESM import");
+    expect(rulesText).toContain("logger 사용");
+  });
+});
+
+describe("buildProjectLayer", () => {
+  it("should create project layer with required fields", () => {
+    const result = buildProjectLayer({
+      conventions: "TypeScript + ESM + Vitest",
+      testCommand: "npx vitest run",
+      lintCommand: "npx eslint src/ tests/",
+    });
+
+    expect(result.conventions).toBe("TypeScript + ESM + Vitest");
+    expect(result.testCommand).toBe("npx vitest run");
+    expect(result.lintCommand).toBe("npx eslint src/ tests/");
+    expect(result.structure).toBe("");
+    expect(result.skillsContext).toBeUndefined();
+    expect(result.pastFailures).toBeUndefined();
+    expect(result.safetyRules).toBeInstanceOf(Array);
+  });
+
+  it("should handle optional fields", () => {
+    const result = buildProjectLayer({
+      conventions: "Test conventions",
+      structure: "src/ tests/ docs/",
+      skillsContext: "Skills context",
+      pastFailures: "Past failures",
+      testCommand: "npm test",
+      lintCommand: "npm run lint",
+      safetyRules: ["custom rule 1", "custom rule 2"],
+    });
+
+    expect(result.structure).toBe("src/ tests/ docs/");
+    expect(result.skillsContext).toBe("Skills context");
+    expect(result.pastFailures).toBe("Past failures");
+    expect(result.safetyRules).toEqual(["custom rule 1", "custom rule 2"]);
+  });
+
+  it("should use default safety rules when not provided", () => {
+    const result = buildProjectLayer({
+      conventions: "Test",
+      testCommand: "test",
+      lintCommand: "lint",
+    });
+
+    expect(result.safetyRules).toHaveLength(3);
+    expect(result.safetyRules[0]).toContain("config 필드 추가 시");
+    expect(result.safetyRules[1]).toContain("안전장치 우회 금지");
+    expect(result.safetyRules[2]).toBe("git add -f 절대 금지");
+  });
+});
+
+describe("buildPhaseLayer", () => {
+  it("should create phase layer with complete structure", () => {
+    const result = buildPhaseLayer({
+      issue: {
+        number: 123,
+        title: "Fix critical bug",
+        body: "This bug needs to be fixed urgently",
+        labels: ["bug", "critical"],
+      },
+      planSummary: "Fix the bug by updating config",
+      currentPhase: {
+        index: 2,
+        totalCount: 4,
+        name: "Implementation",
+        description: "Implement the fix",
+        targetFiles: ["src/config.ts", "tests/config.test.ts"],
+      },
+      previousResults: "Phase 1: SUCCESS - Analysis complete",
+      repository: {
+        owner: "test-org",
+        name: "test-repo",
+        baseBranch: "main",
+        workBranch: "fix/123-bug",
+      },
+    });
+
+    expect(result.issue.number).toBe(123);
+    expect(result.issue.title).toBe("Fix critical bug");
+    expect(result.issue.labels).toEqual(["bug", "critical"]);
+    expect(result.planSummary).toBe("Fix the bug by updating config");
+    expect(result.currentPhase.index).toBe(2);
+    expect(result.currentPhase.totalCount).toBe(4);
+    expect(result.currentPhase.targetFiles).toEqual(["src/config.ts", "tests/config.test.ts"]);
+    expect(result.previousResults).toBe("Phase 1: SUCCESS - Analysis complete");
+    expect(result.repository.owner).toBe("test-org");
+    expect(result.repository.name).toBe("test-repo");
+    expect(result.locale).toBeUndefined();
+  });
+
+  it("should handle optional locale field", () => {
+    const result = buildPhaseLayer({
+      issue: {
+        number: 1,
+        title: "Test",
+        body: "Body",
+        labels: [],
+      },
+      planSummary: "Plan",
+      currentPhase: {
+        index: 1,
+        totalCount: 1,
+        name: "Test Phase",
+        description: "Description",
+        targetFiles: [],
+      },
+      previousResults: "",
+      repository: {
+        owner: "owner",
+        name: "repo",
+        baseBranch: "main",
+        workBranch: "feature",
+      },
+      locale: "en",
+    });
+
+    expect(result.locale).toBe("en");
+  });
+});
+
+describe("assemblePrompt", () => {
+  function createTestLayers(): PromptLayer {
+    return {
+      base: buildBaseLayer({
+        role: "Test Developer",
+      }),
+      project: buildProjectLayer({
+        conventions: "Test conventions",
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+      }),
+      phase: buildPhaseLayer({
+        issue: {
+          number: 42,
+          title: "Test Issue",
+          body: "Test body",
+          labels: ["test"],
+        },
+        planSummary: "Test plan",
+        currentPhase: {
+          index: 1,
+          totalCount: 2,
+          name: "Test Phase",
+          description: "Test description",
+          targetFiles: ["src/test.ts"],
+        },
+        previousResults: "Previous success",
+        repository: {
+          owner: "test",
+          name: "repo",
+          baseBranch: "main",
+          workBranch: "test",
+        },
+      }),
+    };
+  }
+
+  it("should assemble prompt with variable replacement", () => {
+    const layers = createTestLayers();
+    const template = "Role: {{role}}\nIssue #{{issue.number}}: {{issue.title}}\nPhase {{phase.index}}/{{phase.totalCount}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Role: Test Developer");
+    expect(result.content).toContain("Issue #42: Test Issue");
+    expect(result.content).toContain("Phase 1/2");
+    expect(result.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+    expect(result.cacheHit).toBe(false);
+    expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should generate consistent cache keys for same static content", () => {
+    const layers1 = createTestLayers();
+    const layers2 = createTestLayers();
+    const template = "{{role}}";
+
+    const result1 = assemblePrompt(layers1, template);
+    const result2 = assemblePrompt(layers2, template);
+
+    expect(result1.cacheKey).toBe(result2.cacheKey);
+  });
+
+  it("should handle complex nested variables", () => {
+    const layers = createTestLayers();
+    const template = `
+Repository: {{repository.owner}}/{{repository.name}}
+Test Command: {{config.testCommand}}
+Labels: {{issue.labels}}
+Target Files: {{phase.files}}
+`;
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Repository: test/repo");
+    expect(result.content).toContain("Test Command: npm test");
+    expect(result.content).toContain("Labels: test");
+    expect(result.content).toContain("Target Files: src/test.ts");
+  });
+
+  it("should preserve unresolved variables", () => {
+    const layers = createTestLayers();
+    const template = "Known: {{role}}, Unknown: {{unknown.variable}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Known: Test Developer");
+    expect(result.content).toContain("Unknown: {{unknown.variable}}");
+  });
+
+  it("should handle arrays in phase files", () => {
+    const layers = createTestLayers();
+    layers.phase.currentPhase.targetFiles = ["file1.ts", "file2.ts", "file3.ts"];
+    const template = "Files: {{phase.files}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Files: file1.ts, file2.ts, file3.ts");
+  });
+
+  it("should measure assembly time", () => {
+    const layers = createTestLayers();
+    const template = "Simple template {{role}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(typeof result.assemblyTimeMs).toBe("number");
+    expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
+    expect(result.assemblyTimeMs).toBeLessThan(1000); // Should be fast
   });
 });


### PR DESCRIPTION
## Summary

Resolves #260 — refactor: 프롬프트 레이어 분리 — 정적/동적 캐시 효율화

현재 프롬프트 조립이 plan-generator.ts와 phase-executor.ts에서 매번 전체 템플릿을 로드하고 렌더링하여 비효율적입니다. Base(역할/규칙)와 Project(CLAUDE.md) 레이어는 파이프라인 실행 중 변하지 않으므로 1회만 조립하고, Phase 레이어(현재 Phase/결과)만 매번 갱신하면 캐시 효율성이 향상됩니다.

## Requirements

- 프롬프트를 Base(역할/규칙) + Project(CLAUDE.md) + Phase(현재 Phase/결과) 레이어로 분리
- Base/Project 레이어는 파이프라인 시작 시 1회 조립, Phase 레이어만 매번 갱신
- src/prompt/template-renderer.ts에 레이어 조립 함수 추가
- src/pipeline/core-loop.ts에서 프롬프트 조립 리팩터
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase 0: PromptLayer 타입 정의 — SUCCESS (366b9743)
- Phase 1: 레이어 조립 함수 구현 — SUCCESS (14ae994e)
- Phase 2: core-loop 프롬프트 조립 리팩터 — SUCCESS (5cb746a4)
- Phase 3: 테스트 추가 및 검증 — SUCCESS (53db04fa)

## Risks

- 기존 plan-generator, phase-executor의 프롬프트 조립 로직 변경 시 기능 회귀
- 레이어 분리 후 템플릿 변수 바인딩 누락 가능성
- 캐시된 레이어와 동적 레이어 간 조합 오류

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/260-refactor` → `develop`
- **Tokens**: 571 input, 37132 output{{#stats.cacheCreationTokens}}, 301028 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3350302 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #260