### PR TITLE
[AQ-#300] fix: Phase 커밋 메시지 index 0-based → 1-based

### DIFF
--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -171,7 +171,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
     return {
-      phaseIndex: ctx.phase.index,
+      phaseIndex: ctx.phase.index + 1,
       phaseName: ctx.phase.name,
       success: true,
       commitHash,
@@ -182,7 +182,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
     return {
-      phaseIndex: ctx.phase.index,
+      phaseIndex: ctx.phase.index + 1,
       phaseName: ctx.phase.name,
       success: false,
       error: errMsg,

--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -171,7 +171,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
     return {
-      phaseIndex: ctx.phase.index + 1,
+      phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: true,
       commitHash,
@@ -182,7 +182,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
     return {
-      phaseIndex: ctx.phase.index + 1,
+      phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: false,
       error: errMsg,

--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -152,7 +152,7 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
     jl?.log(`Claude 구현 완료: ${ctx.phase.name}`);
 
     // 3. Auto-commit if Claude didn't commit
-    const commitMsg = `[#${ctx.issue.number}] Phase ${ctx.phase.index}: ${ctx.phase.name}`;
+    const commitMsg = `[#${ctx.issue.number}] Phase ${ctx.phase.index + 1}: ${ctx.phase.name}`;
     const autoCommitted = await autoCommitIfDirty(ctx.gitPath, ctx.cwd, commitMsg);
     if (autoCommitted) {
       logger.info(`Auto-committing uncommitted changes for phase ${ctx.phase.index}`);


### PR DESCRIPTION
## Summary

Resolves #300

Phase 커밋 메시지에서 index가 0부터 시작하여 "Phase 0"이 생성됨. 사용자에게는 1-based가 자연스러우므로 "Phase 1"부터 시작하도록 수정 필요.

## Phases

- Phase index 수정: PASS

Closes #300