### PR TITLE
fix: Plan 생성 읽기 도구 허용 + 에러 로깅 강화

### DIFF
--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -266,7 +266,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       config: configForTask(ctx.claudeConfig, "plan"),
       jsonSchema: planSchema,
       enableAgents: false,
-      disallowedTools: ["Read", "Glob", "Grep", "Bash", "Write", "Edit"],
+      disallowedTools: ["Write", "Edit", "Bash"],
     });
 
     const duration = Date.now() - startTime;
@@ -275,7 +275,8 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
 
     if (!result.success) {
       errorCategory = "CLI_CRASH";
-      errorMessage = result.output.slice(0, 200);
+      errorMessage = result.output.slice(0, 500);
+      logger.error(`Plan generation failed (attempt ${attempt}): ${errorMessage}`);
 
       // 히스토리 기록
       retryContext.generationHistory.push({
@@ -318,6 +319,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
     } catch (parseError: unknown) {
       errorCategory = "UNKNOWN";
       errorMessage = getErrorMessage(parseError);
+      logger.error(`Plan JSON parsing failed (attempt ${attempt}): ${errorMessage}. Claude output: ${result.output.slice(0, 500)}`);
 
       // 히스토리 기록
       retryContext.generationHistory.push({


### PR DESCRIPTION
## Summary
- Plan 생성 시 disallowedTools에서 Read/Glob/Grep 제거 — 읽기는 허용, Write/Edit/Bash만 차단
- CLI_CRASH 및 JSON 파싱 실패 시 실제 에러 내용을 500자까지 logger.error로 기록

## 배경
- Plan 생성 attempt 1이 매번 CLI_CRASH로 실패 → retry로 이중 비용 발생
- 원인: 모든 도구를 차단하면서 Claude가 코드베이스 탐색 불가 → 턴 소모 후 에러
- 에러 로깅이 "CLI_CRASH"만 찍혀서 근본 원인 파악 불가

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run tests/pipeline/plan-generator.test.ts` 24개 전부 통과