### PR TITLE
[AQ-#280] fix: review-orchestrator configForTask → configForTaskWithMode 전환

### DIFF
--- a/src/pipeline/pipeline-review.ts
+++ b/src/pipeline/pipeline-review.ts
@@ -17,7 +17,8 @@ import type { TemplateVariables } from "../prompt/template-renderer.js";
 import type {
   GitConfig,
   ProjectConfig,
-  ExecutionModePreset
+  ExecutionModePreset,
+  ExecutionMode
 } from "../types/config.js";
 import type { PipelineState, Plan, PhaseResult } from "../types/pipeline.js";
 import type { PipelineCheckpoint } from "./checkpoint.js";
@@ -26,6 +27,16 @@ import type { PipelineTimer } from "../safety/timeout-manager.js";
 import type { GitHubIssue } from "../github/issue-fetcher.js";
 
 const logger = getLogger();
+
+/**
+ * ExecutionModePreset에서 ExecutionMode를 역추적합니다.
+ * reviewRounds 값을 기반으로 모드를 결정합니다.
+ */
+function getExecutionModeFromPreset(preset: ExecutionModePreset): ExecutionMode {
+  if (preset.reviewRounds === 0) return "economy";
+  if (preset.reviewRounds === 3) return "thorough";
+  return "standard"; // reviewRounds === 1 or other values
+}
 
 function hasCriticalAnalystIssues(result: AnalystResult | undefined): boolean {
   return result?.findings.some(f =>
@@ -152,6 +163,7 @@ export async function runReviewPhase(
         cwd: ctx.worktreePath,
         variables: reviewVariables as unknown as TemplateVariables,
         maxRounds: executionModePreset.reviewRounds,
+        executionMode: getExecutionModeFromPreset(executionModePreset),
       });
 
       if (analystResult) {
@@ -235,6 +247,7 @@ export async function runReviewPhase(
               cwd: ctx.worktreePath,
               variables: reviewVariables as unknown as TemplateVariables,
               maxRounds: executionModePreset.reviewRounds,
+              executionMode: getExecutionModeFromPreset(executionModePreset),
             });
 
             let retryAnalystResult: AnalystResult | undefined;

--- a/src/review/review-orchestrator.ts
+++ b/src/review/review-orchestrator.ts
@@ -1,5 +1,5 @@
 import { runReviewRound } from "./review-runner.js";
-import { configForTask } from "../claude/model-router.js";
+import { configForTaskWithMode } from "../claude/model-router.js";
 import { runClaude, extractJson } from "../claude/claude-runner.js";
 import { loadTemplate, renderTemplate, type TemplateVariables } from "../prompt/template-renderer.js";
 import { exceedsTokenLimit, getEffectiveTokenLimit } from "./token-estimator.js";
@@ -7,7 +7,7 @@ import { splitDiffByFiles, groupFilesByTokenBudget, combineBatchDiffs } from "./
 import { mergeReviewResults } from "./result-merger.js";
 import { getLogger } from "../utils/logger.js";
 import { resolve } from "path";
-import type { ReviewConfig, ReviewRound, ClaudeCliConfig } from "../types/config.js";
+import type { ReviewConfig, ReviewRound, ClaudeCliConfig, ExecutionMode } from "../types/config.js";
 import type { ReviewResult, ReviewPipelineResult, SplitReviewResult, UnifiedReviewResult, UnifiedReviewPerspective, ReviewFinding } from "../types/review.js";
 
 // 통합 리뷰 API 응답 타입
@@ -27,6 +27,7 @@ export interface ReviewOrchestratorContext {
   cwd: string;
   variables: TemplateVariables;
   maxRounds?: number; // Limit number of rounds based on ExecutionModePreset
+  executionMode: ExecutionMode;
 }
 
 function applyRoundModes(variables: TemplateVariables, round: ReviewRound): TemplateVariables {
@@ -177,7 +178,7 @@ async function runUnifiedReview(ctx: ReviewOrchestratorContext): Promise<Unified
   logger.info("Starting unified review (3 perspectives in 1 call)");
 
   // unified review용 Claude 설정
-  const claudeConfig = configForTask(ctx.claudeConfig, "review");
+  const claudeConfig = configForTaskWithMode(ctx.claudeConfig, "review", ctx.executionMode);
 
   // 통합 리뷰 프롬프트 템플릿 로드
   const templatePath = resolve(ctx.promptsDir, "review-unified.md");
@@ -296,7 +297,7 @@ export async function runReviews(ctx: ReviewOrchestratorContext): Promise<Review
 
       const claudeConfig = round.model
         ? { ...ctx.claudeConfig, model: round.model }
-        : configForTask(ctx.claudeConfig, "review");
+        : configForTaskWithMode(ctx.claudeConfig, "review", ctx.executionMode);
 
       const roundVariables = applyRoundModes(ctx.variables, round);
 

--- a/tests/pipeline/pipeline-review.test.ts
+++ b/tests/pipeline/pipeline-review.test.ts
@@ -270,6 +270,7 @@ describe("pipeline-review", () => {
         cwd: "/tmp/worktree",
         variables: expect.objectContaining({ issue: expect.objectContaining({ number: "42" }) }),
         maxRounds: 1,
+        executionMode: "standard",
       });
       expect(mockRunAnalyst).not.toHaveBeenCalled();
       expect(ctx.checkpoint).toHaveBeenCalledWith({
@@ -321,6 +322,7 @@ describe("pipeline-review", () => {
         cwd: "/tmp/worktree",
         variables: expect.objectContaining({ issue: expect.objectContaining({ number: "42" }) }),
         maxRounds: 1,
+        executionMode: "standard",
       });
     });
 

--- a/tests/pipeline/pipeline-review.test.ts
+++ b/tests/pipeline/pipeline-review.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../src/claude/claude-runner.js", () => ({
 }));
 vi.mock("../../src/claude/model-router.js", () => ({
   configForTask: vi.fn(),
+  configForTaskWithMode: vi.fn(),
 }));
 vi.mock("../../src/git/commit-helper.js", () => ({
   autoCommitIfDirty: vi.fn(),
@@ -38,7 +39,7 @@ import {
 } from "../../src/pipeline/pipeline-review.js";
 import type { ExecutionModePreset } from "../../src/types/config.js";
 import { runClaude } from "../../src/claude/claude-runner.js";
-import { configForTask } from "../../src/claude/model-router.js";
+import { configForTask, configForTaskWithMode } from "../../src/claude/model-router.js";
 import { autoCommitIfDirty } from "../../src/git/commit-helper.js";
 import { getDiffContent } from "../../src/git/diff-collector.js";
 import { runReviews } from "../../src/review/review-orchestrator.js";
@@ -49,6 +50,7 @@ import type { ReviewPipelineResult, AnalystResult } from "../../src/types/review
 
 const mockRunClaude = vi.mocked(runClaude);
 const mockConfigForTask = vi.mocked(configForTask);
+const mockConfigForTaskWithMode = vi.mocked(configForTaskWithMode);
 const mockAutoCommitIfDirty = vi.mocked(autoCommitIfDirty);
 const mockGetDiffContent = vi.mocked(getDiffContent);
 const mockRunReviews = vi.mocked(runReviews);
@@ -145,6 +147,7 @@ describe("pipeline-review", () => {
     mockGetDiffContent.mockResolvedValue("test diff content");
     mockExistsSync.mockReturnValue(true);
     mockConfigForTask.mockReturnValue({ path: "claude", model: "sonnet" });
+    mockConfigForTaskWithMode.mockReturnValue({ path: "claude", model: "sonnet" });
     mockIsPastState.mockReturnValue(false);
   });
 

--- a/tests/review/review-orchestrator.test.ts
+++ b/tests/review/review-orchestrator.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../src/prompt/template-renderer.js", () => ({
 
 vi.mock("../../src/claude/model-router.js", () => ({
   configForTask: vi.fn(),
+  configForTaskWithMode: vi.fn(),
 }));
 
 vi.mock("../../src/claude/claude-runner.js", () => ({
@@ -39,7 +40,7 @@ import { exceedsTokenLimit, getEffectiveTokenLimit } from "../../src/review/toke
 import { splitDiffByFiles, groupFilesByTokenBudget, combineBatchDiffs } from "../../src/review/diff-splitter.js";
 import { mergeReviewResults } from "../../src/review/result-merger.js";
 import { loadTemplate, renderTemplate } from "../../src/prompt/template-renderer.js";
-import { configForTask } from "../../src/claude/model-router.js";
+import { configForTask, configForTaskWithMode } from "../../src/claude/model-router.js";
 import { runClaude, extractJson } from "../../src/claude/claude-runner.js";
 import type { ReviewResult } from "../../src/types/review.js";
 
@@ -53,6 +54,7 @@ const mockMergeReviewResults = vi.mocked(mergeReviewResults);
 const mockLoadTemplate = vi.mocked(loadTemplate);
 const mockRenderTemplate = vi.mocked(renderTemplate);
 const mockConfigForTask = vi.mocked(configForTask);
+const mockConfigForTaskWithMode = vi.mocked(configForTaskWithMode);
 const mockRunClaude = vi.mocked(runClaude);
 const mockExtractJson = vi.mocked(extractJson);
 
@@ -91,6 +93,7 @@ function unifiedReviewContext(overrides = {}) {
       diff: { full: "test diff" },
       ...overrides.variables,
     },
+    executionMode: overrides.executionMode || "standard",
   };
 }
 
@@ -110,6 +113,7 @@ describe("runReviews", () => {
 
     // Default mock setup for unified review functionality
     mockConfigForTask.mockReturnValue(claudeConfig);
+    mockConfigForTaskWithMode.mockReturnValue(claudeConfig);
     mockRunClaude.mockResolvedValue({
       success: true,
       output: JSON.stringify(defaultUnifiedReviewResponse)
@@ -486,7 +490,7 @@ describe("runReviews", () => {
       expect(result.rounds[2].roundName).toBe("Unified Review - simplification");
 
       // Verify unified review was called
-      expect(mockConfigForTask).toHaveBeenCalledWith(claudeConfig, "review");
+      expect(mockConfigForTaskWithMode).toHaveBeenCalledWith(claudeConfig, "review", "standard");
       expect(mockLoadTemplate).toHaveBeenCalledWith("/prompts/review-unified.md");
       expect(mockRunClaude).toHaveBeenCalledTimes(1);
       expect(mockExtractJson).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Resolves #280 — fix: review-orchestrator configForTask → configForTaskWithMode 전환

review-orchestrator.ts에서 configForTask를 configForTaskWithMode로 전환하여 executionMode 기반 모델 라우팅을 지원해야 합니다. ReviewOrchestratorContext에 executionMode 필드를 추가하고, 관련 테스트를 업데이트해야 합니다.

## Requirements

- ReviewOrchestratorContext에 executionMode 필드 추가
- review-orchestrator.ts에서 configForTask → configForTaskWithMode 전환
- configForTaskWithMode import 경로 업데이트
- tests/review/review-orchestrator.test.ts에서 mock 업데이트
- tests/pipeline/pipeline-review.test.ts에서 mock 업데이트
- 테스트에서 executionMode를 'standard'로 설정하여 기존 동작 유지

## Implementation Phases

- Phase 0: Context 인터페이스 업데이트 — SUCCESS (9e6def11)
- Phase 1: configForTask → configForTaskWithMode 전환 — SUCCESS (41e6a49e)
- Phase 2: 테스트 파일 업데이트 — SUCCESS (fb47a081)

## Risks

- model-router.ts의 configForTaskWithMode 함수가 변경될 경우 호환성 문제
- ExecutionMode 타입이 변경될 경우 타입 에러 발생 가능성

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/280-fix-review-orchestrator-configfortask-configfortas` → `develop`
- **Tokens**: 142 input, 10900 output{{#stats.cacheCreationTokens}}, 121674 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 680639 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #280