### PR TITLE
[AQ-#275] fix: job-store에 Phase별 costUsd/usage + 전체 비용 집계 저장

### DIFF
--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -85,7 +85,8 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       skillsContext: envResult.skillsContext,
       preset: coreResult.preset,
       timer: setupResult.timer,
-      checkpoint: checkpointFn
+      checkpoint: checkpointFn,
+      jobLogger: input.jobLogger
     };
 
     const finalResult = await executePostProcessingPhases(

--- a/src/pipeline/pipeline-phases.ts
+++ b/src/pipeline/pipeline-phases.ts
@@ -27,6 +27,7 @@ import type { ModePreset } from "../config/mode-presets.js";
 import type { EnvironmentPrepResult } from "./pipeline-git-setup.js";
 import type { PipelineCheckpoint } from "./checkpoint.js";
 import type { PipelineReport } from "./result-reporter.js";
+import type { JobLogger } from "../queue/job-logger.js";
 
 const logger = getLogger();
 
@@ -68,6 +69,7 @@ export interface PostProcessingContext {
   preset: ModePreset;
   timer: PipelineTimer;
   checkpoint: (overrides?: Partial<PipelineCheckpoint>) => void;
+  jobLogger?: JobLogger;
 }
 
 /**
@@ -489,6 +491,11 @@ export async function executePostProcessingPhases(
 
   transitionState(runtime, "DONE");
   jl?.setProgress(PROGRESS_DONE);
+
+  // Update job with total cost and usage from core-loop results
+  if (context.jobLogger && coreResult.totalCostUsd !== undefined) {
+    context.jobLogger.setCosts(coreResult.totalCostUsd, coreResult.totalUsage);
+  }
 
   return {
     prUrl,

--- a/src/queue/job-logger.ts
+++ b/src/queue/job-logger.ts
@@ -1,5 +1,6 @@
 import type { Job } from "./job-store.js";
 import { JobStore } from "./job-store.js";
+import type { UsageInfo } from "../types/pipeline.js";
 
 /**
  * Appends log messages to a job and updates its current step.
@@ -30,5 +31,10 @@ export class JobLogger {
 
   setProgress(progress: number): void {
     this.store.update(this.jobId, { progress: Math.round(progress) });
+  }
+
+  setCosts(totalCostUsd: number, totalUsage?: UsageInfo): void {
+    const updates: Partial<Job> = { totalCostUsd, totalUsage };
+    this.store.update(this.jobId, updates);
   }
 }

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -184,7 +184,8 @@ export class JobStore extends EventEmitter {
       progress: dbJob.progress,
       isRetry: dbJob.isRetry,
       costUsd: dbJob.costUsd,
-      totalCostUsd: dbJob.totalCostUsd
+      totalCostUsd: dbJob.totalCostUsd,
+      totalUsage: dbJob.totalUsage
     };
 
     // Phase 결과를 phaseResults 배열로 변환
@@ -235,7 +236,8 @@ export class JobStore extends EventEmitter {
       progress: job.progress,
       isRetry: job.isRetry,
       costUsd: job.costUsd,
-      totalCostUsd: job.totalCostUsd
+      totalCostUsd: job.totalCostUsd,
+      totalUsage: job.totalUsage
     };
   }
 

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -41,6 +41,12 @@ export interface Job {
   isRetry?: boolean;  // Indicates if this job is a retry of a previously failed job
   costUsd?: number;
   totalCostUsd?: number;
+  totalUsage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
 }
 
 export class JobStore extends EventEmitter {

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -233,7 +233,7 @@ export class JobStore extends EventEmitter {
     };
   }
 
-  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean): Job {
+  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, initialPhaseResults?: Job['phaseResults']): Job {
     const id = `aq-${issueNumber}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const job: Job = {
       id,
@@ -243,11 +243,34 @@ export class JobStore extends EventEmitter {
       createdAt: new Date().toISOString(),
       ...(dependencies && dependencies.length > 0 ? { dependencies } : {}),
       ...(isRetry ? { isRetry } : {}),
+      ...(initialPhaseResults && initialPhaseResults.length > 0 ? { phaseResults: initialPhaseResults } : {}),
     };
 
     // SQLite에 저장
     const dbJob = this.jobToDbJob(job);
     this.db.createJob(dbJob);
+
+    // 초기 Phase results가 있다면 별도로 저장
+    if (initialPhaseResults && initialPhaseResults.length > 0) {
+      for (let index = 0; index < initialPhaseResults.length; index++) {
+        const phaseResult = initialPhaseResults[index];
+        const dbPhase: DatabasePhase = {
+          jobId: id,
+          phaseIndex: index,
+          phaseName: phaseResult.name,
+          success: phaseResult.success,
+          commitHash: phaseResult.commit,
+          durationMs: phaseResult.durationMs,
+          error: phaseResult.error,
+          costUsd: phaseResult.costUsd,
+          inputTokens: phaseResult.usage?.input_tokens,
+          outputTokens: phaseResult.usage?.output_tokens,
+          cacheCreationInputTokens: phaseResult.usage?.cache_creation_input_tokens,
+          cacheReadInputTokens: phaseResult.usage?.cache_read_input_tokens
+        };
+        this.db.createPhase(dbPhase);
+      }
+    }
 
     // 캐시에 추가 (queued 상태이므로)
     this.addToCache(job);

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -29,6 +29,13 @@ export interface Job {
     commit?: string;
     durationMs: number;
     error?: string;
+    costUsd?: number;
+    usage?: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
   }>;
   progress?: number;  // 0-100 overall pipeline progress
   isRetry?: boolean;  // Indicates if this job is a retry of a previously failed job
@@ -182,7 +189,14 @@ export class JobStore extends EventEmitter {
         success: phase.success,
         commit: phase.commitHash,
         durationMs: phase.durationMs,
-        error: phase.error
+        error: phase.error,
+        costUsd: phase.costUsd,
+        usage: phase.inputTokens !== undefined ? {
+          input_tokens: phase.inputTokens,
+          output_tokens: phase.outputTokens || 0,
+          cache_creation_input_tokens: phase.cacheCreationInputTokens,
+          cache_read_input_tokens: phase.cacheReadInputTokens
+        } : undefined
       }));
     }
 
@@ -285,7 +299,12 @@ export class JobStore extends EventEmitter {
           success: phaseResult.success,
           commitHash: phaseResult.commit,
           durationMs: phaseResult.durationMs,
-          error: phaseResult.error
+          error: phaseResult.error,
+          costUsd: phaseResult.costUsd,
+          inputTokens: phaseResult.usage?.input_tokens,
+          outputTokens: phaseResult.usage?.output_tokens,
+          cacheCreationInputTokens: phaseResult.usage?.cache_creation_input_tokens,
+          cacheReadInputTokens: phaseResult.usage?.cache_read_input_tokens
         };
         this.db.createPhase(dbPhase);
       }

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -24,6 +24,10 @@ interface JobRow {
   is_retry: number;
   cost_usd: number | null;
   total_cost_usd: number | null;
+  total_input_tokens: number | null;
+  total_output_tokens: number | null;
+  total_cache_creation_input_tokens: number | null;
+  total_cache_read_input_tokens: number | null;
 }
 
 interface PhaseRow {
@@ -66,6 +70,12 @@ export interface DatabaseJob {
   isRetry?: boolean;
   costUsd?: number;
   totalCostUsd?: number;
+  totalUsage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
 }
 
 export interface DatabasePhase {
@@ -127,7 +137,11 @@ export class AQDatabase {
         progress INTEGER CHECK (progress >= 0 AND progress <= 100),
         is_retry INTEGER CHECK (is_retry IN (0, 1)),
         cost_usd REAL CHECK (cost_usd >= 0),
-        total_cost_usd REAL CHECK (total_cost_usd >= 0)
+        total_cost_usd REAL CHECK (total_cost_usd >= 0),
+        total_input_tokens INTEGER CHECK (total_input_tokens >= 0),
+        total_output_tokens INTEGER CHECK (total_output_tokens >= 0),
+        total_cache_creation_input_tokens INTEGER CHECK (total_cache_creation_input_tokens >= 0),
+        total_cache_read_input_tokens INTEGER CHECK (total_cache_read_input_tokens >= 0)
       )
     `);
 
@@ -187,15 +201,16 @@ export class AQDatabase {
       INSERT INTO jobs (
         id, issue_number, repo, status, created_at, started_at, completed_at,
         pr_url, error, last_updated_at, current_step, dependencies, progress,
-        is_retry, cost_usd, total_cost_usd
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        is_retry, cost_usd, total_cost_usd, total_input_tokens, total_output_tokens,
+        total_cache_creation_input_tokens, total_cache_read_input_tokens
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const params = this.jobToParams(job);
     stmt.run(
       params[0], params[1], params[2], params[3], params[4], params[5], params[6],
       params[7], params[8], params[9], params[10], params[11], params[12], params[13],
-      params[14], params[15]
+      params[14], params[15], params[16], params[17], params[18], params[19]
     );
 
     logger.debug(`Job created: ${job.id}`);
@@ -218,7 +233,9 @@ export class AQDatabase {
         issue_number = ?, repo = ?, status = ?, created_at = ?,
         started_at = ?, completed_at = ?, pr_url = ?, error = ?,
         last_updated_at = ?, current_step = ?, dependencies = ?,
-        progress = ?, is_retry = ?, cost_usd = ?, total_cost_usd = ?
+        progress = ?, is_retry = ?, cost_usd = ?, total_cost_usd = ?,
+        total_input_tokens = ?, total_output_tokens = ?, total_cache_creation_input_tokens = ?,
+        total_cache_read_input_tokens = ?
       WHERE id = ?
     `);
 
@@ -226,7 +243,7 @@ export class AQDatabase {
     const changes = stmt.run(
       params[1], params[2], params[3], params[4], params[5], params[6], params[7],
       params[8], params[9], params[10], params[11], params[12], params[13], params[14],
-      params[15], id
+      params[15], params[16], params[17], params[18], params[19], id
     ).changes;
 
     if (changes > 0) {
@@ -379,7 +396,11 @@ export class AQDatabase {
       job.progress || null,
       job.isRetry ? 1 : 0,
       job.costUsd || null,
-      job.totalCostUsd || null
+      job.totalCostUsd || null,
+      job.totalUsage?.input_tokens || null,
+      job.totalUsage?.output_tokens || null,
+      job.totalUsage?.cache_creation_input_tokens || null,
+      job.totalUsage?.cache_read_input_tokens || null
     ];
   }
 
@@ -400,7 +421,13 @@ export class AQDatabase {
       progress: row.progress ?? undefined,
       isRetry: row.is_retry === 1,
       costUsd: row.cost_usd ?? undefined,
-      totalCostUsd: row.total_cost_usd ?? undefined
+      totalCostUsd: row.total_cost_usd ?? undefined,
+      totalUsage: (row.total_input_tokens !== null && row.total_output_tokens !== null) ? {
+        input_tokens: row.total_input_tokens,
+        output_tokens: row.total_output_tokens,
+        cache_creation_input_tokens: row.total_cache_creation_input_tokens ?? undefined,
+        cache_read_input_tokens: row.total_cache_read_input_tokens ?? undefined
+      } : undefined
     };
   }
 

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -36,6 +36,10 @@ interface PhaseRow {
   duration_ms: number | null;
   error: string | null;
   cost_usd: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  cache_read_input_tokens: number | null;
 }
 
 interface LogRow {
@@ -74,6 +78,10 @@ export interface DatabasePhase {
   durationMs: number;
   error?: string;
   costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
 }
 
 export interface DatabaseLog {
@@ -135,6 +143,10 @@ export class AQDatabase {
         duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
         error TEXT,
         cost_usd REAL CHECK (cost_usd >= 0),
+        input_tokens INTEGER CHECK (input_tokens >= 0),
+        output_tokens INTEGER CHECK (output_tokens >= 0),
+        cache_creation_input_tokens INTEGER CHECK (cache_creation_input_tokens >= 0),
+        cache_read_input_tokens INTEGER CHECK (cache_read_input_tokens >= 0),
         FOREIGN KEY (job_id) REFERENCES jobs (id) ON DELETE CASCADE
       )
     `);
@@ -266,8 +278,8 @@ export class AQDatabase {
 
   createPhase(phase: DatabasePhase): number {
     const stmt = this.db.prepare(`
-      INSERT INTO phases (job_id, phase_index, phase_name, success, commit_hash, duration_ms, error, cost_usd)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO phases (job_id, phase_index, phase_name, success, commit_hash, duration_ms, error, cost_usd, input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const result = stmt.run(
@@ -278,7 +290,11 @@ export class AQDatabase {
       phase.commitHash || null,
       phase.durationMs,
       phase.error || null,
-      phase.costUsd || null
+      phase.costUsd || null,
+      phase.inputTokens || null,
+      phase.outputTokens || null,
+      phase.cacheCreationInputTokens || null,
+      phase.cacheReadInputTokens || null
     );
 
     logger.debug(`Phase created for job ${phase.jobId}: ${phase.phaseName}`);
@@ -298,7 +314,11 @@ export class AQDatabase {
       commitHash: row.commit_hash ?? undefined,
       durationMs: row.duration_ms ?? 0,
       error: row.error ?? undefined,
-      costUsd: row.cost_usd ?? undefined
+      costUsd: row.cost_usd ?? undefined,
+      inputTokens: row.input_tokens ?? undefined,
+      outputTokens: row.output_tokens ?? undefined,
+      cacheCreationInputTokens: row.cache_creation_input_tokens ?? undefined,
+      cacheReadInputTokens: row.cache_read_input_tokens ?? undefined
     }));
   }
 

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -529,6 +529,350 @@ describe("JobStore", () => {
     });
   });
 
+  describe("Phase Results and Cost Tracking", () => {
+    it("should store and retrieve phase results with cost and usage data", () => {
+      const job = store.create(42, "test/repo");
+
+      const phaseResults = [{
+        name: "phase-1",
+        success: true,
+        commit: "abc123",
+        durationMs: 5000,
+        costUsd: 0.25,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200
+        }
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob).toBeTruthy();
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.25);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(1000);
+      expect(retrievedJob?.phaseResults?.[0].usage?.output_tokens).toBe(500);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_creation_input_tokens).toBe(100);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_read_input_tokens).toBe(200);
+    });
+
+    it("should create job with initial phase results", () => {
+      const initialPhaseResults = [{
+        name: "setup",
+        success: true,
+        durationMs: 1500,
+        costUsd: 0.15,
+        usage: {
+          input_tokens: 800,
+          output_tokens: 400
+        }
+      }];
+
+      const job = store.create(43, "test/repo", undefined, false, initialPhaseResults);
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob).toBeTruthy();
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].name).toBe("setup");
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.15);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(800);
+      expect(retrievedJob?.phaseResults?.[0].usage?.output_tokens).toBe(400);
+    });
+
+    it("should handle multiple phase results with different cost data", () => {
+      const job = store.create(44, "test/repo");
+
+      const phaseResults = [
+        {
+          name: "phase-1",
+          success: true,
+          durationMs: 3000,
+          costUsd: 0.20,
+          usage: {
+            input_tokens: 500,
+            output_tokens: 250
+          }
+        },
+        {
+          name: "phase-2",
+          success: false,
+          durationMs: 2000,
+          error: "Test error",
+          costUsd: 0.10,
+          usage: {
+            input_tokens: 300,
+            output_tokens: 150,
+            cache_read_input_tokens: 100
+          }
+        }
+      ];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(2);
+
+      const phase1 = retrievedJob?.phaseResults?.[0];
+      expect(phase1?.name).toBe("phase-1");
+      expect(phase1?.success).toBe(true);
+      expect(phase1?.costUsd).toBe(0.20);
+      expect(phase1?.usage?.input_tokens).toBe(500);
+
+      const phase2 = retrievedJob?.phaseResults?.[1];
+      expect(phase2?.name).toBe("phase-2");
+      expect(phase2?.success).toBe(false);
+      expect(phase2?.error).toBe("Test error");
+      expect(phase2?.costUsd).toBe(0.10);
+      expect(phase2?.usage?.cache_read_input_tokens).toBe(100);
+    });
+
+    it("should handle phase results without usage data", () => {
+      const job = store.create(45, "test/repo");
+
+      const phaseResults = [{
+        name: "simple-phase",
+        success: true,
+        durationMs: 1000,
+        costUsd: 0.05
+        // No usage data
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.05);
+      expect(retrievedJob?.phaseResults?.[0].usage).toBeUndefined();
+    });
+
+    it("should handle phase results without cost data", () => {
+      const job = store.create(46, "test/repo");
+
+      const phaseResults = [{
+        name: "no-cost-phase",
+        success: true,
+        durationMs: 2500,
+        usage: {
+          input_tokens: 600,
+          output_tokens: 300
+        }
+        // No costUsd
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBeUndefined();
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(600);
+    });
+
+    it("should persist phase results across store restart", () => {
+      const job = store.create(47, "test/repo");
+
+      const phaseResults = [{
+        name: "persistent-phase",
+        success: true,
+        durationMs: 4000,
+        costUsd: 0.30,
+        usage: {
+          input_tokens: 1200,
+          output_tokens: 600,
+          cache_creation_input_tokens: 50
+        }
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      // Create new store instance (simulating restart)
+      const newStore = new JobStore(dataDir);
+
+      const retrievedJob = newStore.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].name).toBe("persistent-phase");
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.30);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(1200);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_creation_input_tokens).toBe(50);
+
+      newStore.close();
+    });
+  });
+
+  describe("Phase Results and Cost Tracking", () => {
+    it("should store and retrieve phase results with cost and usage data", () => {
+      const job = store.create(42, "test/repo");
+
+      const phaseResults = [{
+        name: "phase-1",
+        success: true,
+        commit: "abc123",
+        durationMs: 5000,
+        costUsd: 0.25,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200
+        }
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob).toBeTruthy();
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.25);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(1000);
+      expect(retrievedJob?.phaseResults?.[0].usage?.output_tokens).toBe(500);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_creation_input_tokens).toBe(100);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_read_input_tokens).toBe(200);
+    });
+
+    it("should create job with initial phase results", () => {
+      const initialPhaseResults = [{
+        name: "setup",
+        success: true,
+        durationMs: 1500,
+        costUsd: 0.15,
+        usage: {
+          input_tokens: 800,
+          output_tokens: 400
+        }
+      }];
+
+      const job = store.create(43, "test/repo", undefined, false, initialPhaseResults);
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob).toBeTruthy();
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].name).toBe("setup");
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.15);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(800);
+      expect(retrievedJob?.phaseResults?.[0].usage?.output_tokens).toBe(400);
+    });
+
+    it("should handle multiple phase results with different cost data", () => {
+      const job = store.create(44, "test/repo");
+
+      const phaseResults = [
+        {
+          name: "phase-1",
+          success: true,
+          durationMs: 3000,
+          costUsd: 0.20,
+          usage: {
+            input_tokens: 500,
+            output_tokens: 250
+          }
+        },
+        {
+          name: "phase-2",
+          success: false,
+          durationMs: 2000,
+          error: "Test error",
+          costUsd: 0.10,
+          usage: {
+            input_tokens: 300,
+            output_tokens: 150,
+            cache_read_input_tokens: 100
+          }
+        }
+      ];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(2);
+
+      const phase1 = retrievedJob?.phaseResults?.[0];
+      expect(phase1?.name).toBe("phase-1");
+      expect(phase1?.success).toBe(true);
+      expect(phase1?.costUsd).toBe(0.20);
+      expect(phase1?.usage?.input_tokens).toBe(500);
+
+      const phase2 = retrievedJob?.phaseResults?.[1];
+      expect(phase2?.name).toBe("phase-2");
+      expect(phase2?.success).toBe(false);
+      expect(phase2?.error).toBe("Test error");
+      expect(phase2?.costUsd).toBe(0.10);
+      expect(phase2?.usage?.cache_read_input_tokens).toBe(100);
+    });
+
+    it("should handle phase results without usage data", () => {
+      const job = store.create(45, "test/repo");
+
+      const phaseResults = [{
+        name: "simple-phase",
+        success: true,
+        durationMs: 1000,
+        costUsd: 0.05
+        // No usage data
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.05);
+      expect(retrievedJob?.phaseResults?.[0].usage).toBeUndefined();
+    });
+
+    it("should handle phase results without cost data", () => {
+      const job = store.create(46, "test/repo");
+
+      const phaseResults = [{
+        name: "no-cost-phase",
+        success: true,
+        durationMs: 2500,
+        usage: {
+          input_tokens: 600,
+          output_tokens: 300
+        }
+        // No costUsd
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBeUndefined();
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(600);
+    });
+
+    it("should persist phase results across store restart", () => {
+      const job = store.create(47, "test/repo");
+
+      const phaseResults = [{
+        name: "persistent-phase",
+        success: true,
+        durationMs: 4000,
+        costUsd: 0.30,
+        usage: {
+          input_tokens: 1200,
+          output_tokens: 600,
+          cache_creation_input_tokens: 50
+        }
+      }];
+
+      store.update(job.id, { phaseResults });
+
+      // Create new store instance (simulating restart)
+      const newStore = new JobStore(dataDir);
+
+      const retrievedJob = newStore.get(job.id);
+      expect(retrievedJob?.phaseResults).toHaveLength(1);
+      expect(retrievedJob?.phaseResults?.[0].name).toBe("persistent-phase");
+      expect(retrievedJob?.phaseResults?.[0].costUsd).toBe(0.30);
+      expect(retrievedJob?.phaseResults?.[0].usage?.input_tokens).toBe(1200);
+      expect(retrievedJob?.phaseResults?.[0].usage?.cache_creation_input_tokens).toBe(50);
+
+      newStore.close();
+    });
+  });
+
   describe("Memory Cache Optimization", () => {
     it("should cache running/queued jobs for fast access", () => {
       // Create jobs in different states

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -701,7 +701,7 @@ describe("JobStore", () => {
     });
   });
 
-  describe("Phase Results and Cost Tracking", () => {
+  describe("Total Usage and Cost Tracking", () => {
     it("should store and retrieve phase results with cost and usage data", () => {
       const job = store.create(42, "test/repo");
 
@@ -870,6 +870,140 @@ describe("JobStore", () => {
       expect(retrievedJob?.phaseResults?.[0].usage?.cache_creation_input_tokens).toBe(50);
 
       newStore.close();
+    });
+  });
+
+  describe("Total Usage and Cost Tracking", () => {
+    it("should store and retrieve totalUsage field", () => {
+      const job = store.create(50, "test/repo");
+
+      const totalUsage = {
+        input_tokens: 2500,
+        output_tokens: 1200,
+        cache_creation_input_tokens: 300,
+        cache_read_input_tokens: 150
+      };
+
+      store.update(job.id, { totalUsage });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.totalUsage).toBeDefined();
+      expect(retrievedJob?.totalUsage?.input_tokens).toBe(2500);
+      expect(retrievedJob?.totalUsage?.output_tokens).toBe(1200);
+      expect(retrievedJob?.totalUsage?.cache_creation_input_tokens).toBe(300);
+      expect(retrievedJob?.totalUsage?.cache_read_input_tokens).toBe(150);
+    });
+
+    it("should store both totalCostUsd and totalUsage together", () => {
+      const job = store.create(51, "test/repo");
+
+      const totalUsage = {
+        input_tokens: 3000,
+        output_tokens: 1500,
+        cache_read_input_tokens: 200
+      };
+
+      store.update(job.id, {
+        totalCostUsd: 0.75,
+        totalUsage
+      });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.totalCostUsd).toBe(0.75);
+      expect(retrievedJob?.totalUsage?.input_tokens).toBe(3000);
+      expect(retrievedJob?.totalUsage?.output_tokens).toBe(1500);
+      expect(retrievedJob?.totalUsage?.cache_read_input_tokens).toBe(200);
+      expect(retrievedJob?.totalUsage?.cache_creation_input_tokens).toBeUndefined();
+    });
+
+    it("should handle totalUsage without cache tokens", () => {
+      const job = store.create(52, "test/repo");
+
+      const totalUsage = {
+        input_tokens: 1800,
+        output_tokens: 900
+        // No cache tokens
+      };
+
+      store.update(job.id, { totalUsage });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.totalUsage?.input_tokens).toBe(1800);
+      expect(retrievedJob?.totalUsage?.output_tokens).toBe(900);
+      expect(retrievedJob?.totalUsage?.cache_creation_input_tokens).toBeUndefined();
+      expect(retrievedJob?.totalUsage?.cache_read_input_tokens).toBeUndefined();
+    });
+
+    it("should handle job with no totalUsage field", () => {
+      const job = store.create(53, "test/repo");
+
+      // Update with other fields but no totalUsage
+      store.update(job.id, {
+        status: "running",
+        startedAt: new Date().toISOString()
+      });
+
+      const retrievedJob = store.get(job.id);
+      expect(retrievedJob?.status).toBe("running");
+      expect(retrievedJob?.totalUsage).toBeUndefined();
+    });
+
+    it("should persist totalUsage across store restart", () => {
+      const job = store.create(54, "test/repo");
+
+      const totalUsage = {
+        input_tokens: 4000,
+        output_tokens: 2000,
+        cache_creation_input_tokens: 500,
+        cache_read_input_tokens: 250
+      };
+
+      store.update(job.id, {
+        totalCostUsd: 1.25,
+        totalUsage
+      });
+
+      // Create new store instance (simulating restart)
+      const newStore = new JobStore(dataDir);
+
+      const retrievedJob = newStore.get(job.id);
+      expect(retrievedJob?.totalCostUsd).toBe(1.25);
+      expect(retrievedJob?.totalUsage?.input_tokens).toBe(4000);
+      expect(retrievedJob?.totalUsage?.output_tokens).toBe(2000);
+      expect(retrievedJob?.totalUsage?.cache_creation_input_tokens).toBe(500);
+      expect(retrievedJob?.totalUsage?.cache_read_input_tokens).toBe(250);
+
+      newStore.close();
+    });
+
+    it("should list all jobs with totalUsage data correctly", () => {
+      const job1 = store.create(55, "test/repo");
+      const job2 = store.create(56, "test/repo");
+
+      const usage1 = {
+        input_tokens: 1000,
+        output_tokens: 500
+      };
+
+      const usage2 = {
+        input_tokens: 2000,
+        output_tokens: 1000,
+        cache_read_input_tokens: 100
+      };
+
+      store.update(job1.id, { totalUsage: usage1 });
+      store.update(job2.id, { totalUsage: usage2 });
+
+      const allJobs = store.list();
+      const jobWithUsage1 = allJobs.find(j => j.id === job1.id);
+      const jobWithUsage2 = allJobs.find(j => j.id === job2.id);
+
+      expect(jobWithUsage1?.totalUsage?.input_tokens).toBe(1000);
+      expect(jobWithUsage1?.totalUsage?.output_tokens).toBe(500);
+
+      expect(jobWithUsage2?.totalUsage?.input_tokens).toBe(2000);
+      expect(jobWithUsage2?.totalUsage?.output_tokens).toBe(1000);
+      expect(jobWithUsage2?.totalUsage?.cache_read_input_tokens).toBe(100);
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves #275 — fix: job-store에 Phase별 costUsd/usage + 전체 비용 집계 저장

현재 phase-executor에서 costUsd/usage를 반환하고 core-loop에서 집계하지만, job-store까지 전달되지 않아 Phase별 비용 정보와 전체 비용 집계가 저장되지 않는 문제입니다. DB 스키마에는 이미 cost_usd 컬럼이 있지만 Job 인터페이스의 phaseResults 타입에서 해당 필드가 누락되어 있습니다.

## Requirements

- phaseResults 저장 시 costUsd, usage(input/output/cache tokens) 필드 포함
- job 완료 시 result에 totalCostUsd, totalUsage 집계하여 저장
- 기존 job-store 직렬화/역직렬화에서 새 필드 호환
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: DB 스키마 확장 및 타입 정의 수정 — SUCCESS (dce6b579)
- Phase 1: JobStore 변환 로직 수정 — SUCCESS (0868bbe3)
- Phase 2: Pipeline totalCostUsd/totalUsage 저장 연동 — SUCCESS (8fa1abfb)
- Phase 3: 테스트 작성 및 검증 — SUCCESS (ba8cc6e8)

## Risks

- 기존 저장된 job 데이터와의 호환성 문제
- Usage 정보 저장을 위한 DB 스키마 변경 필요
- PhaseResult와 Job.phaseResults 타입 불일치

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/275-fix-job-store-phase-costusd-usage` → `develop`
- **Tokens**: 405 input, 29846 output{{#stats.cacheCreationTokens}}, 381815 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2374546 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #275