### PR TITLE
[AQ-#320] refactor: orchestrator 194→140줄 축소 — thin orchestrator 회귀 방지

### DIFF
--- a/docs/refactor/orchestrator-analysis.md
+++ b/docs/refactor/orchestrator-analysis.md
@@ -1,0 +1,161 @@
+# Orchestrator.ts 분석 및 Thin Orchestrator 패턴 회귀 방지
+
+## 개요
+
+`src/pipeline/orchestrator.ts`가 139줄에서 195줄(56줄 증가)로 커져서 God Function 패턴으로 회귀하고 있습니다. Thin Orchestrator 패턴(상태 전환과 모듈 호출만 담당)에 맞지 않는 비즈니스 로직들이 포함되어 있어 이를 적절한 모듈로 분리해야 합니다.
+
+## 현재 상태 분석
+
+### 파일 정보
+- **현재 줄 수**: 195줄 
+- **목표 줄 수**: 140줄 이하
+- **축소 필요**: 55+ 줄
+
+### Git Blame 분석을 통한 추가된 로직 식별
+
+#### 1. Feasibility Check 처리 로직 (22줄) - **분리 필요**
+**위치**: 122-148줄  
+**커밋**: `8a858c3f`, `ab9fc788` (2026-04-04)
+```typescript
+// FEASIBILITY_SKIP 에러 체크
+const isFeasibilitySkip = errorMessage.startsWith("FEASIBILITY_SKIP:");
+if (isFeasibilitySkip) {
+  // basicPlan 생성 로직
+  // formatResult 호출
+  // skipReason 파싱
+}
+```
+**문제**: orchestrator가 특정 에러 타입의 비즈니스 로직을 직접 처리
+
+#### 2. Core Loop Failure 처리 (7줄) - **분리 필요**
+**위치**: 150-156줄  
+**커밋**: `9fc8510a`, `e7607598` (2026-04-03/04)
+```typescript
+const errorWithReport = error as Error & { failureResult?: OrchestratorResult };
+if (errorWithReport.failureResult) {
+  // 특수한 에러 타입 처리
+}
+```
+**문제**: 타입 캐스팅과 특수 에러 처리 로직
+
+#### 3. General Pipeline Failure 처리 (33줄) - **분리 필요**
+**위치**: 158-190줄  
+**커밋**: `9fc8510a`, `59cfa57e`, `9bdfdea6` (2026-04-03)
+```typescript
+const failureContext = {
+  // 복잡한 컨텍스트 생성 (12개 필드)
+};
+const finalErrorMessage = await handlePipelineFailure(failureContext);
+// basicPlan 생성 (중복 코드)
+// formatResult 호출 (중복 코드)
+```
+**문제**: 복잡한 실패 컨텍스트 생성 + 중복된 보고서 생성 로직
+
+#### 4. prUrl 검증 로직 (12줄) - **단순화 필요**
+**위치**: 100-111줄  
+**커밋**: `9ce6968a`, `9c98bfa8` (2026-04-04)
+```typescript
+if (!finalResult.prUrl) {
+  transitionState(runtime, "FAILED");
+  const errorMessage = "Pipeline completed but failed to create PR URL";
+  return {
+    // 복잡한 반환 객체 생성
+  };
+}
+```
+**문제**: 비즈니스 로직 검증이 orchestrator에 포함
+
+#### 5. Validation 로직 (10줄) - **단순화 가능**
+**위치**: 36-45줄  
+**커밋**: `4440366f`, `732bb8d3` (2026-04-04)
+```typescript
+if (!issue) {
+  throw new Error("Issue not fetched during setup");
+}
+if (!mode) {
+  throw new Error("Pipeline mode not determined during setup");
+}
+const checkpointFn = checkpoint || (() => {});
+```
+**문제**: null 체크와 기본값 설정이 orchestrator에 직접 포함
+
+#### 6. Finally 블록 (4줄) - **유지 필요**
+**위치**: 191-194줄  
+**커밋**: `96964e8b` (2026-04-04)
+```typescript
+} finally {
+  clearCache();
+}
+```
+**정당성**: 리소스 정리는 orchestrator의 적절한 책임
+
+## Thin Orchestrator 패턴 위배 사항
+
+### 현재 orchestrator의 책임 (문제점)
+1. ✗ 특정 에러 타입별 처리 로직 (FEASIBILITY_SKIP)
+2. ✗ 복잡한 실패 컨텍스트 생성 
+3. ✗ 중복된 basicPlan 생성 로직 (2군데)
+4. ✗ 중복된 formatResult 호출 (2군데)
+5. ✗ prUrl 비즈니스 검증 로직
+6. ✗ null 체크 및 기본값 설정
+
+### 올바른 Thin Orchestrator 패턴
+- ✓ 상태 전환 (transitionState 호출)
+- ✓ 모듈 간 호출 조율
+- ✓ 기본적인 try-catch 구조
+- ✓ 리소스 정리 (finally)
+
+## 분리 대상 로직 식별
+
+### 1. Pipeline Error Handler 모듈 확장
+**대상**: 122-148줄 (Feasibility Check), 158-190줄 (General Failure)
+**새 파일**: `src/pipeline/pipeline-error-handler.ts` (이미 존재, 확장 필요)
+**분리할 함수**:
+- `handleFeasibilitySkipError()`
+- `handleGeneralPipelineFailure()`
+
+### 2. Pipeline Result Validator 모듈 생성  
+**대상**: 100-111줄 (prUrl 검증)
+**새 파일**: `src/pipeline/pipeline-result-validator.ts`
+**분리할 함수**:
+- `validatePipelineResult()`
+
+### 3. Pipeline Setup Validator 확장
+**대상**: 36-45줄 (Setup 검증)
+**기존 파일**: `src/pipeline/pipeline-setup.ts` 확장
+**분리할 함수**:
+- `validateSetupResult()`
+
+## 중복 코드 제거
+
+### basicPlan 생성 로직 (2회 중복)
+**위치**: 129-139줄, 177-187줄
+**해결**: 공통 유틸리티 함수로 추출
+
+### formatResult 호출 (2회 중복)  
+**위치**: 140줄, 188줄
+**해결**: error handler에서 통합 처리
+
+## 목표 아키텍처
+
+```
+runPipeline() {
+  try {
+    // Phase 1-4: 모듈 호출만
+    // 단순한 결과 반환
+  } catch (error) {
+    // 간단한 에러 라우팅만
+    return await routeError(error, context);
+  } finally {
+    clearCache();
+  }
+}
+```
+
+## 예상 효과
+
+- **줄 수**: 195줄 → 135줄 (60줄 감소, 목표 달성)
+- **책임**: 순수한 상태 전환 + 모듈 호출 조율로 회귀
+- **가독성**: 복잡한 에러 처리 로직 분리로 향상
+- **테스트**: 각 에러 처리 로직을 독립적으로 테스트 가능
+- **유지보수**: 에러 처리 변경 시 orchestrator 수정 불필요

--- a/src/pipeline/orchestrator-helpers.ts
+++ b/src/pipeline/orchestrator-helpers.ts
@@ -1,0 +1,74 @@
+import type {
+  OrchestratorResult,
+} from "./pipeline-context.js";
+import type {
+  PostProcessingContext,
+  InitialSetupResult,
+  EnvironmentSetupResult,
+  CoreLoopExecutionResult
+} from "./pipeline-phases.js";
+import type { PipelineRuntime } from "./pipeline-context.js";
+import type { GitHubIssue } from "../github/issue-fetcher.js";
+import type { PipelineMode } from "../types/config.js";
+import type { PipelineCheckpoint } from "./checkpoint.js";
+import type { JobLogger } from "../queue/job-logger.js";
+
+/**
+ * Handle duplicate PR check and return early result if needed
+ */
+export function handleDuplicatePR(setupResult: InitialSetupResult): OrchestratorResult | null {
+  if (setupResult.duplicatePRUrl) {
+    return { success: true, state: "DONE", prUrl: setupResult.duplicatePRUrl };
+  }
+  return null;
+}
+
+/**
+ * Extract and validate setup values with proper type checking
+ */
+export function extractValidatedSetupValues(setupResult: InitialSetupResult): {
+  issue: GitHubIssue;
+  mode: PipelineMode;
+  checkpointFn: (overrides?: Partial<PipelineCheckpoint>) => void;
+} {
+  const { issue, mode, checkpoint } = setupResult;
+
+  // Validate required values from setup
+  if (!issue) {
+    throw new Error("Issue not fetched during setup");
+  }
+  if (!mode) {
+    throw new Error("Pipeline mode not determined during setup");
+  }
+
+  const checkpointFn = checkpoint || (() => {});
+  return { issue, mode, checkpointFn };
+}
+
+/**
+ * Create PostProcessingContext from setup results
+ */
+export function createPostProcessingContext(params: {
+  issue: GitHubIssue;
+  coreResult: CoreLoopExecutionResult["coreResult"];
+  setupResult: InitialSetupResult;
+  envResult: EnvironmentSetupResult;
+  preset: CoreLoopExecutionResult["preset"];
+  runtime: PipelineRuntime;
+  checkpointFn: (overrides?: Partial<PipelineCheckpoint>) => void;
+  jobLogger?: JobLogger;
+}): PostProcessingContext {
+  return {
+    issue: params.issue,
+    coreResult: params.coreResult,
+    gitConfig: params.setupResult.gitConfig,
+    project: params.setupResult.project,
+    worktreePath: params.runtime.worktreePath!,
+    promptsDir: params.setupResult.promptsDir,
+    skillsContext: params.envResult.skillsContext,
+    preset: params.preset,
+    timer: params.setupResult.timer,
+    checkpoint: params.checkpointFn,
+    jobLogger: params.jobLogger
+  };
+}

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,6 +1,6 @@
-import { handlePipelineFailure } from "./pipeline-publish.js";
-import { initializePipelineState, transitionState } from "./pipeline-context.js";
-import { getErrorMessage } from "../utils/error-utils.js";
+import { initializePipelineState } from "./pipeline-context.js";
+import { routeError } from "./pipeline-error-handler.js";
+import { validatePipelineResult } from "./pipeline-result-validator.js";
 import {
   executeInitialSetupPhases,
   executeEnvironmentSetup,
@@ -33,7 +33,7 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
 
     const { issue, mode, checkpoint } = setupResult;
 
-    // Validate required values from setup
+    // Validate required values from setup (moved to pipeline-phases but needed here for types)
     if (!issue) {
       throw new Error("Issue not fetched during setup");
     }
@@ -41,7 +41,6 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       throw new Error("Pipeline mode not determined during setup");
     }
 
-    // Provide default checkpoint function if not available
     const checkpointFn = checkpoint || (() => {});
 
     // Phase 2: Environment Setup (Git + Work environment)
@@ -97,17 +96,10 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       startTime
     );
 
-    // Verify that prUrl was successfully created
-    if (!finalResult.prUrl) {
-      transitionState(runtime, "FAILED");
-      const errorMessage = "Pipeline completed but failed to create PR URL";
-      return {
-        success: false,
-        state: "FAILED",
-        error: errorMessage,
-        report: finalResult.report,
-        totalCostUsd: finalResult.totalCostUsd
-      };
+    // Validate pipeline result
+    const validationError = validatePipelineResult({ finalResult, runtime });
+    if (validationError) {
+      return validationError;
     }
 
     return {
@@ -119,75 +111,12 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     };
 
   } catch (error: unknown) {
-    // Check if this is a skipped issue due to feasibility check
-    const errorMessage = getErrorMessage(error);
-    const isFeasibilitySkip = errorMessage.startsWith("FEASIBILITY_SKIP:");
-
-    if (isFeasibilitySkip) {
-      const { formatResult } = await import("./result-reporter.js");
-      const skipReason = errorMessage.slice("FEASIBILITY_SKIP:".length).trim();
-      const basicPlan = {
-        issueNumber,
-        title: `Issue #${issueNumber} skipped`,
-        problemDefinition: skipReason,
-        requirements: [],
-        affectedFiles: [],
-        risks: [],
-        phases: [],
-        verificationPoints: [],
-        stopConditions: []
-      };
-      const report = formatResult(issueNumber, repo, basicPlan, [], startTime);
-
-      return {
-        success: true,
-        state: "SKIPPED" as const,
-        report,
-        error: skipReason
-      };
-    }
-
-    // Check if this is a core loop failure with detailed results
-    const errorWithReport = error as Error & { failureResult?: OrchestratorResult };
-    if (errorWithReport.failureResult) {
-      // Core loop failure already handled by handleCoreLoopFailure
-      transitionState(runtime, "FAILED");
-      return errorWithReport.failureResult;
-    }
-
-    // General pipeline failure
-    const failureContext = {
-      error,
-      state: runtime.state,
-      worktreePath: runtime.worktreePath,
-      branchName: runtime.branchName,
-      rollbackHash: runtime.rollbackHash,
-      rollbackStrategy: runtime.rollbackStrategy,
-      gitConfig: runtime.gitConfig,
-      projectRoot: runtime.projectRoot,
-      cleanupOnFailure: config.worktree.cleanupOnFailure,
-      jl: input.jobLogger,
-    };
-
-    const finalErrorMessage = await handlePipelineFailure(failureContext);
-    transitionState(runtime, "FAILED");
-
-    // Generate a basic report for failed pipelines
-    const { formatResult } = await import("./result-reporter.js");
-    const basicPlan = {
-      issueNumber,
-      title: "Pipeline failed",
-      problemDefinition: "Pipeline execution failed",
-      requirements: [],
-      affectedFiles: [],
-      risks: [],
-      phases: [],
-      verificationPoints: [],
-      stopConditions: []
-    };
-    const report = formatResult(issueNumber, repo, basicPlan, [], startTime);
-
-    return { success: false, state: "FAILED", error: finalErrorMessage, report };
+    return await routeError(error, {
+      runtime,
+      input,
+      config,
+      startTime
+    });
   } finally {
     // 파이프라인 종료 시 캐시 정리 - 성공/실패 모두 메모리 누수 방지
     clearCache();

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -5,18 +5,22 @@ import {
   executeInitialSetupPhases,
   executeEnvironmentSetup,
   executeCoreLoopPhase,
-  executePostProcessingPhases,
-  type PostProcessingContext
+  executePostProcessingPhases
 } from "./pipeline-phases.js";
 import type {
   OrchestratorInput,
   OrchestratorResult,
 } from "./pipeline-context.js";
 import { clearCache } from "../github/github-cache.js";
+import {
+  handleDuplicatePR,
+  extractValidatedSetupValues,
+  createPostProcessingContext
+} from "./orchestrator-helpers.js";
 
 
 export async function runPipeline(input: OrchestratorInput): Promise<OrchestratorResult> {
-  const { issueNumber, repo, config, aqRoot } = input;
+  const { config, aqRoot } = input;
   const startTime = Date.now();
 
   // Initialize pipeline state
@@ -26,22 +30,14 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     // Phase 1: Initial Setup (Project, Duplicate PR check, Issue validation)
     const setupResult = await executeInitialSetupPhases(input, runtime, config, aqRoot);
 
-    // Early return for duplicate PR
-    if (setupResult.duplicatePRUrl) {
-      return { success: true, state: "DONE", prUrl: setupResult.duplicatePRUrl };
+    // Handle duplicate PR early return
+    const duplicateResult = handleDuplicatePR(setupResult);
+    if (duplicateResult) {
+      return duplicateResult;
     }
 
-    const { issue, mode, checkpoint } = setupResult;
-
-    // Validate required values from setup (moved to pipeline-phases but needed here for types)
-    if (!issue) {
-      throw new Error("Issue not fetched during setup");
-    }
-    if (!mode) {
-      throw new Error("Pipeline mode not determined during setup");
-    }
-
-    const checkpointFn = checkpoint || (() => {});
+    // Extract validated setup values
+    const { issue, mode, checkpointFn } = extractValidatedSetupValues(setupResult);
 
     // Phase 2: Environment Setup (Git + Work environment)
     const envResult = await executeEnvironmentSetup(
@@ -74,19 +70,16 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     checkpointFn({ plan: coreResult.coreResult.plan, phaseResults: coreResult.coreResult.phaseResults });
 
     // Phase 4: Post-processing (Review, Simplify, Validation, Publish)
-    const postProcessingContext: PostProcessingContext = {
+    const postProcessingContext = createPostProcessingContext({
       issue,
       coreResult: coreResult.coreResult,
-      gitConfig: setupResult.gitConfig,
-      project: setupResult.project,
-      worktreePath: runtime.worktreePath!,
-      promptsDir: setupResult.promptsDir,
-      skillsContext: envResult.skillsContext,
+      setupResult,
+      envResult,
       preset: coreResult.preset,
-      timer: setupResult.timer,
-      checkpoint: checkpointFn,
+      runtime,
+      checkpointFn,
       jobLogger: input.jobLogger
-    };
+    });
 
     const finalResult = await executePostProcessingPhases(
       postProcessingContext,

--- a/src/pipeline/pipeline-error-handler.ts
+++ b/src/pipeline/pipeline-error-handler.ts
@@ -1,14 +1,17 @@
 import { formatResult, printResult } from "./result-reporter.js";
 import { rollbackToCheckpoint as doRollback } from "../safety/rollback-manager.js";
-import { saveResult } from "./pipeline-context.js";
+import { saveResult, transitionState } from "./pipeline-context.js";
 import { PatternStore } from "../learning/pattern-store.js";
 import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import { handlePipelineFailure } from "./pipeline-publish.js";
 import type { PipelineState } from "../types/pipeline.js";
 import type { PipelineCheckpoint } from "./checkpoint.js";
 import type { JobLogger } from "../queue/job-logger.js";
 import type { PipelineReport } from "./result-reporter.js";
 import type { CoreLoopResult } from "./core-loop.js";
 import type { AQConfig, GitConfig } from "../types/config.js";
+import type { PipelineRuntime, OrchestratorResult } from "./pipeline-context.js";
 
 const logger = getLogger();
 
@@ -122,4 +125,133 @@ export async function handleCoreLoopFailure(context: CoreLoopFailureContext): Pr
     error: errorMessage,
     report
   };
+}
+
+export interface FeasibilitySkipContext {
+  issueNumber: number;
+  repo: string;
+  errorMessage: string;
+  startTime: number;
+}
+
+/**
+ * Handle feasibility skip error (FEASIBILITY_SKIP:)
+ */
+export async function handleFeasibilitySkipError(context: FeasibilitySkipContext): Promise<OrchestratorResult> {
+  const { issueNumber, repo, errorMessage, startTime } = context;
+
+  const skipReason = errorMessage.slice("FEASIBILITY_SKIP:".length).trim();
+  const basicPlan = createBasicPlan(issueNumber, `Issue #${issueNumber} skipped`, skipReason);
+  const report = formatResult(issueNumber, repo, basicPlan, [], startTime);
+
+  return {
+    success: true,
+    state: "SKIPPED" as const,
+    report,
+    error: skipReason
+  };
+}
+
+export interface GeneralPipelineFailureContext {
+  error: unknown;
+  runtime: PipelineRuntime;
+  input: { issueNumber: number; repo: string; jobLogger?: JobLogger };
+  config: AQConfig;
+  startTime: number;
+}
+
+/**
+ * Handle general pipeline failure with proper context and cleanup
+ */
+export async function handleGeneralPipelineError(context: GeneralPipelineFailureContext): Promise<OrchestratorResult> {
+  const { error, runtime, input, config, startTime } = context;
+  const { issueNumber, repo } = input;
+
+  // General pipeline failure
+  const failureContext = {
+    error,
+    state: runtime.state,
+    worktreePath: runtime.worktreePath,
+    branchName: runtime.branchName,
+    rollbackHash: runtime.rollbackHash,
+    rollbackStrategy: runtime.rollbackStrategy,
+    gitConfig: runtime.gitConfig,
+    projectRoot: runtime.projectRoot,
+    cleanupOnFailure: config.worktree.cleanupOnFailure,
+    jl: input.jobLogger,
+  };
+
+  const finalErrorMessage = await handlePipelineFailure(failureContext);
+  transitionState(runtime, "FAILED");
+
+  // Generate a basic report for failed pipelines
+  const basicPlan = createBasicPlan(issueNumber, "Pipeline failed", "Pipeline execution failed");
+  const report = formatResult(issueNumber, repo, basicPlan, [], startTime);
+
+  return {
+    success: false,
+    state: "FAILED",
+    error: finalErrorMessage,
+    report
+  };
+}
+
+/**
+ * Create a basic plan structure for error reporting
+ */
+function createBasicPlan(issueNumber: number, title: string, problemDefinition: string) {
+  return {
+    issueNumber,
+    title,
+    problemDefinition,
+    requirements: [],
+    affectedFiles: [],
+    risks: [],
+    phases: [],
+    verificationPoints: [],
+    stopConditions: []
+  };
+}
+
+/**
+ * Route errors to appropriate handlers
+ */
+export async function routeError(
+  error: unknown,
+  context: {
+    runtime: PipelineRuntime;
+    input: { issueNumber: number; repo: string; jobLogger?: JobLogger };
+    config: AQConfig;
+    startTime: number;
+  }
+): Promise<OrchestratorResult> {
+  const errorMessage = getErrorMessage(error);
+
+  // Check if this is a skipped issue due to feasibility check
+  const isFeasibilitySkip = errorMessage.startsWith("FEASIBILITY_SKIP:");
+  if (isFeasibilitySkip) {
+    return handleFeasibilitySkipError({
+      issueNumber: context.input.issueNumber,
+      repo: context.input.repo,
+      errorMessage,
+      startTime: context.startTime
+    });
+  }
+
+  // Check if this is a core loop failure with detailed results
+  const errorWithReport = error as Error & { failureResult?: OrchestratorResult };
+  if (errorWithReport.failureResult) {
+    // Core loop failure already handled by handleCoreLoopFailure
+    transitionState(context.runtime, "FAILED");
+    return errorWithReport.failureResult;
+  }
+
+  // General pipeline failure
+  return handleGeneralPipelineError({
+    error,
+    runtime: context.runtime,
+    input: context.input,
+    config: context.config,
+    startTime: context.startTime
+  });
 }

--- a/src/pipeline/pipeline-phases.ts
+++ b/src/pipeline/pipeline-phases.ts
@@ -144,6 +144,10 @@ export async function executeInitialSetupPhases(
   const { issue, checkpoint } = issueResult;
   const mode = issueResult.mode;
   const executionMode = issueResult.executionMode;
+
+  // Validate setup results
+  validateSetupResult(issue, mode, checkpoint);
+
   transitionState(runtime, "VALIDATED");
 
   return {
@@ -661,4 +665,30 @@ export async function executePostProcessingPhases(
     report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl),
     totalCostUsd: coreResult.totalCostUsd
   };
+}
+
+/**
+ * Validate setup result values and provide defaults
+ */
+function validateSetupResult(
+  issue: GitHubIssue | undefined,
+  mode: PipelineMode | undefined,
+  checkpoint: ((overrides?: Partial<PipelineCheckpoint>) => void) | undefined
+): {
+  issue: GitHubIssue;
+  mode: PipelineMode;
+  checkpoint: (overrides?: Partial<PipelineCheckpoint>) => void
+} {
+  // Validate required values from setup
+  if (!issue) {
+    throw new Error("Issue not fetched during setup");
+  }
+  if (!mode) {
+    throw new Error("Pipeline mode not determined during setup");
+  }
+
+  // Provide default checkpoint function if not available
+  const checkpointFn = checkpoint || (() => {});
+
+  return { issue, mode, checkpoint: checkpointFn };
 }

--- a/src/pipeline/pipeline-result-validator.ts
+++ b/src/pipeline/pipeline-result-validator.ts
@@ -1,0 +1,31 @@
+import { transitionState } from "./pipeline-context.js";
+import type { PipelineRuntime, OrchestratorResult } from "./pipeline-context.js";
+import type { PipelineReport } from "./result-reporter.js";
+
+export interface PipelineResultValidationContext {
+  finalResult: { prUrl?: string; report: PipelineReport; totalCostUsd?: number };
+  runtime: PipelineRuntime;
+}
+
+/**
+ * Validate pipeline result and ensure prUrl is present
+ */
+export function validatePipelineResult(context: PipelineResultValidationContext): OrchestratorResult | null {
+  const { finalResult, runtime } = context;
+
+  // Verify that prUrl was successfully created
+  if (!finalResult.prUrl) {
+    transitionState(runtime, "FAILED");
+    const errorMessage = "Pipeline completed but failed to create PR URL";
+    return {
+      success: false,
+      state: "FAILED",
+      error: errorMessage,
+      report: finalResult.report,
+      totalCostUsd: finalResult.totalCostUsd
+    };
+  }
+
+  // Validation passed
+  return null;
+}


### PR DESCRIPTION
## Summary

Resolves #320 — refactor: orchestrator 194→140줄 축소 — thin orchestrator 회귀 방지

orchestrator.ts가 139줄에서 194줄로 55줄 증가하여 God Function 패턴으로 회귀하고 있다. 상태 전환과 모듈 호출만 담당해야 하는 thin orchestrator 패턴을 위반하여 비즈니스 로직이 포함되었으므로, 이를 적절한 모듈로 분리하여 140줄 이하로 축소해야 한다.

## Requirements

- orchestrator.ts의 신규 로직을 적절한 모듈로 위임 (139줄 → 194줄로 회귀한 부분 식별)
- orchestrator는 상태 전환 + 모듈 호출만 담당하는 thin orchestrator 유지
- 140줄 이하로 축소
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: 현재 orchestrator.ts 분석 및 분리 대상 로직 식별 — SUCCESS (394cad88)
- Phase 1: 비즈니스 로직을 pipeline-phases.ts로 이동 — SUCCESS (07d817ec)
- Phase 2: orchestrator.ts를 thin orchestrator로 리팩터링 — SUCCESS (10e00e92)
- Phase 3: 타입 검증 및 테스트 실행 — SUCCESS (10e00e92)

## Risks

- 리팩터링 중 기존 기능 손실 가능성
- 모듈 간 인터페이스 변경으로 인한 호환성 문제
- 과도한 분리로 인한 복잡성 증가
- 테스트 케이스 업데이트 누락

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/320-refactor-orchestrator-194-140-thin-orchestrator` → `develop`
- **Tokens**: 185 input, 17693 output{{#stats.cacheCreationTokens}}, 230699 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 741111 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #320