### PR TITLE
[AQ-#319] fix: 폴러 중복 이슈 감지 방지 — running/queued 잡 필터링

### DIFF
--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -178,7 +178,19 @@ export class IssuePoller {
 
     for (const issue of issues) {
       if (this.store.shouldBlockRepickup(issue.number, repo)) {
-        logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (성공한 잡 존재), 건너뜀`);
+        // 차단 이유를 상태별로 구분하여 로그 출력
+        const existingJob = this.store.findAnyByIssue(issue.number, repo);
+        if (existingJob) {
+          if (existingJob.status === "running" || existingJob.status === "queued") {
+            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 처리 중), 건너뜀`);
+          } else if (existingJob.status === "success") {
+            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (성공 완료된 잡 존재), 건너뜀`);
+          } else {
+            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 존재), 건너뜀`);
+          }
+        } else {
+          logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단, 건너뜀`);
+        }
         continue;
       }
       logger.info(`새 이슈 발견 — #${issue.number} "${issue.title}" (${repo}), 큐에 추가`);

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -423,7 +423,14 @@ export class JobStore extends EventEmitter {
   }
 
   shouldBlockRepickup(issueNumber: number, repo: string): boolean {
-    return this.findCompletedByIssue(issueNumber, repo) !== undefined;
+    const existingJob = this.findAnyByIssue(issueNumber, repo);
+    if (!existingJob) return false;
+
+    // queued, running, success 상태의 잡이 있으면 차단
+    // failure, cancelled, archived 상태는 재시도 가능하므로 차단하지 않음
+    return existingJob.status === "queued" ||
+           existingJob.status === "running" ||
+           existingJob.status === "success";
   }
 
   findFailedJobsForRetry(): Job[] {

--- a/tests/polling/issue-poller.test.ts
+++ b/tests/polling/issue-poller.test.ts
@@ -25,6 +25,7 @@ const mockListOpenPrs = vi.mocked(listOpenPrs);
 const mockStore = {
   shouldBlockRepickup: vi.fn(),
   findFailedJobsForRetry: vi.fn().mockReturnValue([]),
+  findAnyByIssue: vi.fn(),
 };
 
 const mockQueue = {
@@ -559,6 +560,198 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       } finally {
         vi.spyOn(Date, 'now').mockImplementation(originalDateNow);
       }
+    });
+  });
+
+  describe("shouldBlockRepickup integration", () => {
+    it("should skip issues blocked by shouldBlockRepickup", async () => {
+      const config = makeConfig();
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // Mock shouldBlockRepickup to return true for specific issue
+      mockStore.shouldBlockRepickup.mockImplementation((issueNumber: number) =>
+        issueNumber === 123
+      );
+
+      // Mock findAnyByIssue to return a running job for blocked issue
+      mockStore.findAnyByIssue.mockImplementation((issueNumber: number) =>
+        issueNumber === 123 ? { id: "job-123", status: "running", issueNumber: 123, repo: "test/repo" } : null
+      );
+
+      // Mock issues response
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([
+          { number: 123, title: "Blocked issue", state: "open" },
+          { number: 124, title: "New issue", state: "open" }
+        ]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+
+      // Verify shouldBlockRepickup was called for both issues
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(123, "test/repo");
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(124, "test/repo");
+
+      // Verify only non-blocked issue was enqueued
+      expect(mockQueue.enqueue).toHaveBeenCalledWith(124, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(123, "test/repo");
+    });
+
+    it("should handle different blocking job statuses", async () => {
+      const config = makeConfig();
+
+      // Test queued status blocking
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
+      mockStore.findAnyByIssue.mockReturnValueOnce({
+        id: "job-100", status: "queued", issueNumber: 100, repo: "test/repo"
+      });
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([{ number: 100, title: "Queued job", state: "open" }]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(100, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(100, "test/repo");
+
+      // Reset and test running status blocking
+      vi.clearAllMocks();
+      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
+      mockStore.findAnyByIssue.mockReturnValueOnce({
+        id: "job-101", status: "running", issueNumber: 101, repo: "test/repo"
+      });
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([{ number: 101, title: "Running job", state: "open" }]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(101, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(101, "test/repo");
+
+      // Reset and test success status blocking
+      vi.clearAllMocks();
+      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
+      mockStore.findAnyByIssue.mockReturnValueOnce({
+        id: "job-102", status: "success", issueNumber: 102, repo: "test/repo"
+      });
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([{ number: 102, title: "Success job", state: "open" }]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(102, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(102, "test/repo");
+    });
+
+    it("should enqueue available issues when shouldBlockRepickup returns false", async () => {
+      const config = makeConfig();
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // Mock shouldBlockRepickup to allow all issues
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockStore.findAnyByIssue.mockReturnValue(null);
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([
+          { number: 200, title: "Available task 1", state: "open" },
+          { number: 201, title: "Available task 2", state: "open" }
+        ]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+
+      // Verify shouldBlockRepickup was called for all issues
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(200, "test/repo");
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(201, "test/repo");
+
+      // Verify all issues were enqueued
+      expect(mockQueue.enqueue).toHaveBeenCalledWith(200, "test/repo");
+      expect(mockQueue.enqueue).toHaveBeenCalledWith(201, "test/repo");
+    });
+
+    it("should handle mixed blocked and available issues correctly", async () => {
+      const config = makeConfig();
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // Mock mixed scenarios: block 300 and 302, allow 301
+      mockStore.shouldBlockRepickup
+        .mockReturnValueOnce(true)  // issue 300 blocked
+        .mockReturnValueOnce(false) // issue 301 available
+        .mockReturnValueOnce(true); // issue 302 blocked
+
+      mockStore.findAnyByIssue
+        .mockReturnValueOnce({ id: "job-300", status: "running", issueNumber: 300, repo: "test/repo" })
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce({ id: "job-302", status: "queued", issueNumber: 302, repo: "test/repo" });
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([
+          { number: 300, title: "Blocked by running", state: "open" },
+          { number: 301, title: "Available task", state: "open" },
+          { number: 302, title: "Blocked by queued", state: "open" }
+        ]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+
+      // Verify shouldBlockRepickup was called for all issues
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(300, "test/repo");
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(301, "test/repo");
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(302, "test/repo");
+
+      // Verify only available issue was enqueued
+      expect(mockQueue.enqueue).toHaveBeenCalledWith(301, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(300, "test/repo");
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(302, "test/repo");
+
+      // Verify findAnyByIssue was called for blocked issues to get job details
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(300, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(302, "test/repo");
+    });
+
+    it("should correctly integrate shouldBlockRepickup with existing job lookup", async () => {
+      const config = makeConfig();
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // Mock shouldBlockRepickup to return true and verify findAnyByIssue integration
+      mockStore.shouldBlockRepickup.mockReturnValue(true);
+      mockStore.findAnyByIssue.mockReturnValue({
+        id: "job-400",
+        status: "success",
+        issueNumber: 400,
+        repo: "test/repo",
+        completedAt: new Date().toISOString()
+      });
+
+      mockRunCli.mockResolvedValue({
+        stdout: JSON.stringify([{ number: 400, title: "Completed task", state: "open" }]),
+        stderr: "",
+        exitCode: 0
+      });
+
+      await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
+
+      // Verify the integration flow: shouldBlockRepickup -> findAnyByIssue for job details
+      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(400, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(400, "test/repo");
+
+      // Verify issue was not enqueued due to blocking
+      expect(mockQueue.enqueue).not.toHaveBeenCalledWith(400, "test/repo");
     });
   });
 });

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -128,19 +128,19 @@ describe("JobStore", () => {
       expect(result).toBe(false);
     });
 
-    it("should return false when only queued job exists for the issue", () => {
+    it("should return true when queued job exists for the issue", () => {
       store.create(42, "test/repo"); // default status is "queued"
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
-    it("should return false when only running job exists for the issue", () => {
+    it("should return true when running job exists for the issue", () => {
       const job = store.create(42, "test/repo");
       store.update(job.id, { status: "running", startedAt: new Date().toISOString() });
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
     it("should return false when only archived job exists for the issue", () => {


### PR DESCRIPTION
## Summary

Resolves #319 — fix: 폴러 중복 이슈 감지 방지 — running/queued 잡 필터링

현재 GitHub 이슈 폴링 시스템에서 running/queued 상태의 잡이 있는 이슈를 중복으로 감지하여 "새 이슈 발견" 로그가 대량 발생한다. shouldBlockRepickup 메서드가 success 상태만 체크하고 running/queued 상태는 무시하여 로그 스팸과 GitHub API rate limit 낭비가 발생하고 있다.

## Requirements

- shouldBlockRepickup 메서드가 running/queued 상태 잡도 차단하도록 확장
- 이미 처리 중인 이슈의 로그 레벨을 debug로 변경하여 info 스팸 방지
- 기존 잡 처리 로직의 안정성 유지
- TypeScript 컴파일 및 테스트 통과 보장

## Implementation Phases

- Phase 0: shouldBlockRepickup 메서드 확장 — SUCCESS (1331018f)
- Phase 1: 폴러 로그 레벨 최적화 — SUCCESS (d8e41ad2)
- Phase 2: 테스트 업데이트 및 검증 — SUCCESS (0940905f)

## Risks

- shouldBlockRepickup 로직 변경으로 인한 예상치 못한 이슈 차단
- 기존 성공 잡 재처리 방지 로직 손상
- 테스트 커버리지 부족으로 인한 회귀 버그

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/319-fix-running-queued` → `develop`
- **Tokens**: 160 input, 12802 output{{#stats.cacheCreationTokens}}, 204983 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 658388 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #319