### PR TITLE
[AQ-#318] feat: 병렬 Phase 실행 — 독립 Phase 동시 처리 (피처 플래그)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -153,5 +153,8 @@ export const DEFAULT_CONFIG: AQConfig = {
     },
     strict: true,
   },
+  features: {
+    parallelPhases: false,  // 안정성을 위해 기본값은 false
+  },
   executionMode: "standard",
 };

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -278,6 +278,10 @@ const safetyConfigSchema = z.object({
   strict: z.boolean().default(true),
 });
 
+const featuresConfigSchema = z.object({
+  parallelPhases: z.boolean(),
+});
+
 const projectConfigSchema = z.object({
   repo: z.string().min(1),
   path: z.string().min(1),
@@ -332,6 +336,8 @@ const aqConfigSchema = z.object({
   review: reviewConfigSchema,
   pr: prConfigSchema,
   safety: safetyConfigSchema,
+  features: featuresConfigSchema,
+  executionMode: z.enum(["economy", "standard", "thorough"]),
   hooks: hooksConfigSchema,
   projects: z.array(projectConfigSchema).optional(),
 }).superRefine((data, ctx) => {

--- a/src/pipeline/core-loop.ts
+++ b/src/pipeline/core-loop.ts
@@ -205,6 +205,9 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
 
   // Schedule phases for parallel execution based on dependencies
   const enableParallelPhases = ctx.config.features?.parallelPhases ?? false;
+  logger.info(`Parallel phases feature: ${enableParallelPhases ? 'enabled' : 'disabled'}`);
+  jl?.log(`병렬 Phase 실행: ${enableParallelPhases ? '활성화' : '비활성화'}`);
+
   const scheduleResult = schedulePhases(plan.phases, enableParallelPhases);
   if (!scheduleResult.success) {
     logger.error(`Failed to schedule phases: ${scheduleResult.error}`);
@@ -218,8 +221,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     };
   }
 
-  logger.info(`Scheduled ${plan.phases.length} phases in ${scheduleResult.groups.length} parallel levels`);
-  jl?.log(`${scheduleResult.groups.length}개 레벨로 병렬 실행 스케줄링`);
+  logger.info(`Scheduled ${plan.phases.length} phases in ${scheduleResult.groups.length} parallel levels (parallel: ${enableParallelPhases})`);
+  jl?.log(`${scheduleResult.groups.length}개 레벨로 병렬 실행 스케줄링 (병렬: ${enableParallelPhases ? 'ON' : 'OFF'})`);
 
   // Track error history for each phase (phase index -> error history)
   const phaseErrorHistories = new Map<number, ErrorHistoryEntry[]>();

--- a/src/pipeline/core-loop.ts
+++ b/src/pipeline/core-loop.ts
@@ -204,7 +204,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
   }
 
   // Schedule phases for parallel execution based on dependencies
-  const scheduleResult = schedulePhases(plan.phases);
+  const enableParallelPhases = ctx.config.features?.parallelPhases ?? false;
+  const scheduleResult = schedulePhases(plan.phases, enableParallelPhases);
   if (!scheduleResult.success) {
     logger.error(`Failed to schedule phases: ${scheduleResult.error}`);
     jl?.log(`Phase 스케줄링 실패: ${scheduleResult.error}`);

--- a/src/pipeline/phase-scheduler.ts
+++ b/src/pipeline/phase-scheduler.ts
@@ -74,10 +74,39 @@ export function detectCircularDependencies(phases: Phase[]): number[] {
 }
 
 /**
+ * Detects file conflicts between phases by checking for overlapping targetFiles
+ * Returns conflicting phase indices grouped by file path
+ */
+export function detectFileConflicts(phases: Phase[]): Map<string, number[]> {
+  const fileToPhases = new Map<string, number[]>();
+
+  // Group phases by each target file they modify
+  for (const phase of phases) {
+    for (const file of phase.targetFiles) {
+      if (!fileToPhases.has(file)) {
+        fileToPhases.set(file, []);
+      }
+      fileToPhases.get(file)!.push(phase.index);
+    }
+  }
+
+  // Filter to only return files that have conflicts (>1 phase)
+  const conflicts = new Map<string, number[]>();
+  for (const [file, phaseIndices] of fileToPhases) {
+    if (phaseIndices.length > 1) {
+      conflicts.set(file, phaseIndices);
+    }
+  }
+
+  return conflicts;
+}
+
+/**
  * Performs topological sorting of phases based on their dependencies
  * Returns phases grouped by execution level for parallel execution
+ * File conflicts are resolved by forcing conflicting phases into serial execution
  */
-export function schedulePhases(phases: Phase[]): ScheduleResult {
+export function schedulePhases(phases: Phase[], enableParallelPhases: boolean = true): ScheduleResult {
   if (phases.length === 0) {
     return { success: true, groups: [] };
   }
@@ -124,6 +153,36 @@ export function schedulePhases(phases: Phase[]): ScheduleResult {
         const deps = dependents.get(depIndex) || [];
         deps.push(phase.index);
         dependents.set(depIndex, deps);
+      }
+    }
+  }
+
+  // Handle file conflicts if parallel phases are enabled
+  if (enableParallelPhases) {
+    const fileConflicts = detectFileConflicts(phases);
+
+    if (fileConflicts.size > 0) {
+      // Add serial dependencies for conflicting phases
+      for (const [file, conflictingPhases] of fileConflicts) {
+        // Sort conflicting phases by index to ensure consistent ordering
+        conflictingPhases.sort((a, b) => a - b);
+
+        // Create serial chain: each phase depends on the previous one
+        for (let i = 1; i < conflictingPhases.length; i++) {
+          const currentPhaseIndex = conflictingPhases[i];
+          const previousPhaseIndex = conflictingPhases[i - 1];
+
+          // Add dependency: current phase depends on previous phase
+          const currentInDegree = inDegree.get(currentPhaseIndex) || 0;
+          inDegree.set(currentPhaseIndex, currentInDegree + 1);
+
+          // Add to dependents list of previous phase
+          const deps = dependents.get(previousPhaseIndex) || [];
+          if (!deps.includes(currentPhaseIndex)) {
+            deps.push(currentPhaseIndex);
+            dependents.set(previousPhaseIndex, deps);
+          }
+        }
       }
     }
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -158,6 +158,11 @@ export interface SafetyConfig {
   strict: boolean;
 }
 
+export interface FeaturesConfig {
+  /** 병렬 Phase 실행 활성화 여부 (안정성을 위해 기본값은 false) */
+  parallelPhases: boolean;
+}
+
 export interface ExecutionModePreset {
   reviewRounds: number;
   enableAdvancedReview: boolean;
@@ -236,6 +241,7 @@ export interface AQConfig {
   review: ReviewConfig;
   pr: PrConfig;
   safety: SafetyConfig;
+  features: FeaturesConfig;
   executionMode: ExecutionMode;
   hooks?: HooksConfig;        // pipeline hooks configuration
   projects?: ProjectConfig[];  // per-project overrides

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -117,6 +117,10 @@ describe("validateConfig", () => {
       rollbackStrategy: "none",
       strict: false,
     },
+    features: {
+      parallelPhases: false,
+    },
+    executionMode: "standard",
   };
 
   it("should validate and return a valid config", () => {

--- a/tests/pipeline/core-loop.test.ts
+++ b/tests/pipeline/core-loop.test.ts
@@ -87,6 +87,9 @@ function makeContext(overrides: Partial<CoreLoopContext> = {}): CoreLoopContext 
         port: 3000,
         host: "localhost",
       },
+      features: {
+        parallelPhases: false,
+      },
     },
     promptsDir: "/tmp/prompts",
     cwd: "/tmp/project",
@@ -1016,6 +1019,124 @@ describe("runCoreLoop", () => {
         claudeConfig: expect.any(Object),
         promptsDir: expect.any(String),
         cwd: expect.any(String),
+      });
+    });
+  });
+
+  describe("feature flags", () => {
+    describe("parallelPhases", () => {
+      it("should pass feature flag state to schedulePhases", async () => {
+        const phases = [makePhase(0, "Test")];
+        const plan = makePlan(phases);
+
+        mockGeneratePlan.mockResolvedValue({ plan });
+        mockSchedulePhases.mockReturnValue({
+          success: true,
+          groups: [{ level: 0, phases: phases }],
+        });
+        mockExecutePhase.mockResolvedValue(makeSuccessResult(0, "Test"));
+
+        // Test with parallelPhases enabled
+        const contextWithParallel = makeContext({
+          config: {
+            ...makeContext().config,
+            features: { parallelPhases: true },
+          },
+        });
+
+        await runCoreLoop(contextWithParallel);
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, true);
+
+        // Reset mocks
+        mockSchedulePhases.mockClear();
+
+        // Test with parallelPhases disabled (default)
+        await runCoreLoop(makeContext());
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
+      });
+
+      it("should handle undefined features config gracefully", async () => {
+        const phases = [makePhase(0, "Test")];
+        const plan = makePlan(phases);
+
+        mockGeneratePlan.mockResolvedValue({ plan });
+        mockSchedulePhases.mockReturnValue({
+          success: true,
+          groups: [{ level: 0, phases: phases }],
+        });
+        mockExecutePhase.mockResolvedValue(makeSuccessResult(0, "Test"));
+
+        // Test with features config undefined
+        const contextWithoutFeatures = makeContext({
+          config: {
+            ...makeContext().config,
+            features: undefined as any,
+          },
+        });
+
+        await runCoreLoop(contextWithoutFeatures);
+
+        // Should default to false when features is undefined
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
+      });
+    });
+  });
+
+  describe("feature flags", () => {
+    describe("parallelPhases", () => {
+      it("should pass feature flag state to schedulePhases", async () => {
+        const phases = [makePhase(0, "Test")];
+        const plan = makePlan(phases);
+
+        mockGeneratePlan.mockResolvedValue({ plan });
+        mockSchedulePhases.mockReturnValue({
+          success: true,
+          groups: [{ level: 0, phases: phases }],
+        });
+        mockExecutePhase.mockResolvedValue(makeSuccessResult(0, "Test"));
+
+        // Test with parallelPhases enabled
+        const contextWithParallel = makeContext({
+          config: {
+            ...makeContext().config,
+            features: { parallelPhases: true },
+          },
+        });
+
+        await runCoreLoop(contextWithParallel);
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, true);
+
+        // Reset mocks
+        mockSchedulePhases.mockClear();
+
+        // Test with parallelPhases disabled (default)
+        await runCoreLoop(makeContext());
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
+      });
+
+      it("should handle undefined features config gracefully", async () => {
+        const phases = [makePhase(0, "Test")];
+        const plan = makePlan(phases);
+
+        mockGeneratePlan.mockResolvedValue({ plan });
+        mockSchedulePhases.mockReturnValue({
+          success: true,
+          groups: [{ level: 0, phases: phases }],
+        });
+        mockExecutePhase.mockResolvedValue(makeSuccessResult(0, "Test"));
+
+        // Test with features config undefined
+        const contextWithoutFeatures = makeContext({
+          config: {
+            ...makeContext().config,
+            features: undefined as any,
+          },
+        });
+
+        await runCoreLoop(contextWithoutFeatures);
+
+        // Should default to false when features is undefined
+        expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
       });
     });
   });

--- a/tests/pipeline/core-loop.test.ts
+++ b/tests/pipeline/core-loop.test.ts
@@ -196,7 +196,7 @@ describe("runCoreLoop", () => {
 
       expect(result.success).toBe(true);
       expect(result.phaseResults).toHaveLength(3);
-      expect(mockSchedulePhases).toHaveBeenCalledWith(phases);
+      expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
       expect(mockExecutePhase).toHaveBeenCalledTimes(3);
 
       // All phases should have been called (order may vary due to parallel execution)
@@ -238,7 +238,7 @@ describe("runCoreLoop", () => {
 
       expect(result.success).toBe(true);
       expect(result.phaseResults).toHaveLength(4);
-      expect(mockSchedulePhases).toHaveBeenCalledWith(phases);
+      expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
       expect(mockExecutePhase).toHaveBeenCalledTimes(4);
     });
 

--- a/tests/pipeline/phase-scheduler.test.ts
+++ b/tests/pipeline/phase-scheduler.test.ts
@@ -362,23 +362,17 @@ describe("phase-scheduler", () => {
       ];
 
       const result = schedulePhases(phases, true);
-      console.log('Complex test result groups:', result.groups.map(g => ({ level: g.level, phases: g.phases.map(p => p.index) })));
       expect(result.success).toBe(true);
 
       // Expected behavior:
       // Level 0: Phase 0 (init, no deps)
-      // Level 1: Phase 2 (no explicit deps, but has conflict serialization), Phase 1 (depends on 0)
-      // OR serialized completely depending on conflict resolution
-      expect(result.groups.length).toBeGreaterThan(0);
+      // Level 1: Phase 1 (depends on 0)
+      // Level 2: Phase 2 (serialized due to file conflict with Phase 1)
+      expect(result.groups).toHaveLength(3);
 
       expect(result.groups[0].phases.map(p => p.index)).toEqual([0]);
-      // The exact layout may vary, let's see what we get
-      if (result.groups.length >= 2) {
-        console.log('Level 1 phases:', result.groups[1].phases.map(p => p.index));
-      }
-      if (result.groups.length >= 3) {
-        console.log('Level 2 phases:', result.groups[2].phases.map(p => p.index));
-      }
+      expect(result.groups[1].phases.map(p => p.index)).toEqual([1]); // Phase 1 depends on 0
+      expect(result.groups[2].phases.map(p => p.index)).toEqual([2]); // Phase 2 serialized after 1 due to conflict
     });
   });
 });

--- a/tests/pipeline/phase-scheduler.test.ts
+++ b/tests/pipeline/phase-scheduler.test.ts
@@ -375,4 +375,56 @@ describe("phase-scheduler", () => {
       expect(result.groups[2].phases.map(p => p.index)).toEqual([2]); // Phase 2 serialized after 1 due to conflict
     });
   });
+
+  describe("feature flag integration", () => {
+    it("should respect enableParallelPhases parameter", () => {
+      const phases = [
+        createPhase(0, "Update shared", undefined, ["src/shared.ts"]),
+        createPhase(1, "Update other", undefined, ["src/shared.ts"]),
+      ];
+
+      // When parallel phases enabled, should serialize conflicting phases
+      const resultEnabled = schedulePhases(phases, true);
+      expect(resultEnabled.success).toBe(true);
+      expect(resultEnabled.groups).toHaveLength(2);
+      expect(resultEnabled.groups[0].phases.map(p => p.index)).toEqual([0]);
+      expect(resultEnabled.groups[1].phases.map(p => p.index)).toEqual([1]);
+
+      // When parallel phases disabled, should allow parallel execution despite conflicts
+      const resultDisabled = schedulePhases(phases, false);
+      expect(resultDisabled.success).toBe(true);
+      expect(resultDisabled.groups).toHaveLength(1);
+      expect(resultDisabled.groups[0].phases.map(p => p.index).sort()).toEqual([0, 1]);
+    });
+
+    it("should default to enableParallelPhases=true when parameter omitted", () => {
+      const phases = [
+        createPhase(0, "Test A", undefined, ["src/test.ts"]),
+        createPhase(1, "Test B", undefined, ["src/test.ts"]),
+      ];
+
+      // Default behavior (enableParallelPhases omitted) should be true
+      const result = schedulePhases(phases);
+      expect(result.success).toBe(true);
+      expect(result.groups).toHaveLength(2); // Should serialize conflicting phases
+    });
+
+    it("should not affect scheduling when no file conflicts exist", () => {
+      const phases = [
+        createPhase(0, "Test A", undefined, ["src/a.ts"]),
+        createPhase(1, "Test B", undefined, ["src/b.ts"]),
+      ];
+
+      const resultEnabled = schedulePhases(phases, true);
+      const resultDisabled = schedulePhases(phases, false);
+
+      // Both should have same result when no conflicts
+      expect(resultEnabled.success).toBe(true);
+      expect(resultDisabled.success).toBe(true);
+      expect(resultEnabled.groups).toHaveLength(1);
+      expect(resultDisabled.groups).toHaveLength(1);
+      expect(resultEnabled.groups[0].phases.map(p => p.index).sort()).toEqual([0, 1]);
+      expect(resultDisabled.groups[0].phases.map(p => p.index).sort()).toEqual([0, 1]);
+    });
+  });
 });

--- a/tests/pipeline/phase-scheduler.test.ts
+++ b/tests/pipeline/phase-scheduler.test.ts
@@ -2,17 +2,18 @@ import { describe, it, expect } from "vitest";
 import {
   schedulePhases,
   detectCircularDependencies,
+  detectFileConflicts,
   getExecutablePhases,
   validatePhaseDependencies,
 } from "../../src/pipeline/phase-scheduler.js";
 import type { Phase } from "../../src/types/pipeline.js";
 
 describe("phase-scheduler", () => {
-  const createPhase = (index: number, name: string, dependsOn?: number[]): Phase => ({
+  const createPhase = (index: number, name: string, dependsOn?: number[], targetFiles?: string[]): Phase => ({
     index,
     name,
     description: `Phase ${index}: ${name}`,
-    targetFiles: [`file${index}.ts`],
+    targetFiles: targetFiles || [`file${index}.ts`],
     commitStrategy: "single",
     verificationCriteria: [`verify ${index}`],
     dependsOn,
@@ -265,6 +266,119 @@ describe("phase-scheduler", () => {
       const result = validatePhaseDependencies(phases);
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe("detectFileConflicts", () => {
+    it("should detect no conflicts when phases target different files", () => {
+      const phases = [
+        createPhase(0, "Component A", undefined, ["src/a.ts"]),
+        createPhase(1, "Component B", undefined, ["src/b.ts"]),
+        createPhase(2, "Component C", undefined, ["src/c.ts"]),
+      ];
+
+      const conflicts = detectFileConflicts(phases);
+      expect(conflicts.size).toBe(0);
+    });
+
+    it("should detect conflicts when phases target the same file", () => {
+      const phases = [
+        createPhase(0, "Update A", undefined, ["src/shared.ts"]),
+        createPhase(1, "Update B", undefined, ["src/shared.ts"]),
+        createPhase(2, "Different", undefined, ["src/other.ts"]),
+      ];
+
+      const conflicts = detectFileConflicts(phases);
+      expect(conflicts.size).toBe(1);
+      expect(conflicts.get("src/shared.ts")).toEqual([0, 1]);
+    });
+
+    it("should handle multiple file conflicts", () => {
+      const phases = [
+        createPhase(0, "Update config", undefined, ["src/config.ts", "src/utils.ts"]),
+        createPhase(1, "Update config2", undefined, ["src/config.ts"]),
+        createPhase(2, "Update utils", undefined, ["src/utils.ts"]),
+      ];
+
+      const conflicts = detectFileConflicts(phases);
+      expect(conflicts.size).toBe(2);
+      expect(conflicts.get("src/config.ts")).toEqual([0, 1]);
+      expect(conflicts.get("src/utils.ts")).toEqual([0, 2]);
+    });
+
+    it("should handle three-way conflicts", () => {
+      const phases = [
+        createPhase(0, "Fix A", undefined, ["src/main.ts"]),
+        createPhase(1, "Fix B", undefined, ["src/main.ts"]),
+        createPhase(2, "Fix C", undefined, ["src/main.ts"]),
+      ];
+
+      const conflicts = detectFileConflicts(phases);
+      expect(conflicts.size).toBe(1);
+      expect(conflicts.get("src/main.ts")).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe("schedulePhases with file conflict resolution", () => {
+    it("should serialize conflicting phases when parallel enabled", () => {
+      const phases = [
+        createPhase(0, "Update A", undefined, ["src/shared.ts"]),
+        createPhase(1, "Update B", undefined, ["src/shared.ts"]),
+        createPhase(2, "Update C", undefined, ["src/other.ts"]), // No conflict
+      ];
+
+      const result = schedulePhases(phases, true); // Enable parallel phases
+      expect(result.success).toBe(true);
+
+      // With file conflict, phases 0 and 1 should be serialized
+      // Phase 2 has no conflicts so can run in parallel with Phase 0
+      expect(result.groups).toHaveLength(2);
+
+      // Phase 0 and 2 can run in parallel (level 0)
+      expect(result.groups[0].phases.map(p => p.index).sort()).toEqual([0, 2]);
+      // Phase 1 must wait for Phase 0 (level 1)
+      expect(result.groups[1].phases.map(p => p.index)).toEqual([1]);
+    });
+
+    it("should allow parallel execution when parallel disabled", () => {
+      const phases = [
+        createPhase(0, "Update A", undefined, ["src/shared.ts"]),
+        createPhase(1, "Update B", undefined, ["src/shared.ts"]),
+      ];
+
+      const result = schedulePhases(phases, false); // Disable parallel phases
+      expect(result.success).toBe(true);
+      expect(result.groups).toHaveLength(1); // Should run in parallel when disabled
+
+      // Both phases run in parallel when feature disabled
+      expect(result.groups[0].phases.map(p => p.index)).toEqual([0, 1]);
+    });
+
+    it("should respect existing dependencies with file conflicts", () => {
+      const phases = [
+        createPhase(0, "Init", [], ["src/init.ts"]),
+        createPhase(1, "Update A", [0], ["src/shared.ts"]),
+        createPhase(2, "Update B", undefined, ["src/shared.ts"]), // Conflicts with phase 1
+      ];
+
+      const result = schedulePhases(phases, true);
+      console.log('Complex test result groups:', result.groups.map(g => ({ level: g.level, phases: g.phases.map(p => p.index) })));
+      expect(result.success).toBe(true);
+
+      // Expected behavior:
+      // Level 0: Phase 0 (init, no deps)
+      // Level 1: Phase 2 (no explicit deps, but has conflict serialization), Phase 1 (depends on 0)
+      // OR serialized completely depending on conflict resolution
+      expect(result.groups.length).toBeGreaterThan(0);
+
+      expect(result.groups[0].phases.map(p => p.index)).toEqual([0]);
+      // The exact layout may vary, let's see what we get
+      if (result.groups.length >= 2) {
+        console.log('Level 1 phases:', result.groups[1].phases.map(p => p.index));
+      }
+      if (result.groups.length >= 3) {
+        console.log('Level 2 phases:', result.groups[2].phases.map(p => p.index));
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #318 — feat: 병렬 Phase 실행 — 독립 Phase 동시 처리 (피처 플래그)

현재 Phase 병렬 실행 기능이 이미 구현되어 있지만 항상 활성화되어 있어 안정성 문제가 있을 수 있습니다. 피처 플래그를 통한 선택적 활성화와 파일 충돌 감지 및 직렬 폴백 메커니즘을 추가하여 더 안전하고 제어 가능한 병렬 실행 기능을 제공해야 합니다.

## Requirements

- config.yml에 features.parallelPhases: false 피처 플래그 추가 (기본값 false)
- types, defaults, validator에서 features 섹션 지원
- 동일 파일 대상 Phase 충돌 감지 로직 구현
- 파일 충돌 발생 시 직렬 실행으로 자동 폴백
- 피처 플래그 비활성화 시 기존 순차 실행 방식 유지
- npx tsc --noEmit 및 npx vitest run 통과

## Implementation Phases

- Phase 0: 피처 플래그 설정 추가 — SUCCESS (28f3d746)
- Phase 1: 파일 충돌 감지 로직 구현 — SUCCESS (28f3d746)
- Phase 2: Core Loop 피처 플래그 통합 — SUCCESS (6609cc3f)
- Phase 3: 테스트 추가 및 기존 테스트 수정 — SUCCESS (609cdbf3)

## Risks

- 피처 플래그 추가 시 기존 설정 호환성 문제
- 파일 충돌 감지 로직의 정확성 및 성능 오버헤드
- 직렬 폴백 시 성능 저하 가능성
- 기존 병렬 실행 로직 변경으로 인한 회귀 위험

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/318-feat-phase-phase` → `develop`
- **Tokens**: 148 input, 15581 output{{#stats.cacheCreationTokens}}, 105541 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 792005 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #318