### PR TITLE
[AQ-#265] refactor: Result Type — Phase 부분 성공 지원

### DIFF
--- a/prompts/phase-retry.md
+++ b/prompts/phase-retry.md
@@ -13,6 +13,26 @@
 - **Phase**: {{phase.index}}/{{phase.totalCount}} -- {{phase.name}}
 - **설명**: {{phase.description}}
 - **대상 파일**: {{phase.files}}
+{{#retry.isPartialRetry}}
+
+## 부분 성공 재시도 안내
+
+⚠️ **이전 구현이 부분적으로 성공했습니다.**
+
+### 이미 성공한 파일들 (보존 필요)
+다음 파일들은 이미 성공적으로 변경되었으므로 **수정하지 마세요**:
+{{#retry.succeededFiles}}
+- {{.}}
+{{/retry.succeededFiles}}
+
+### 재시도 대상 파일들
+다음 파일들만 수정하거나 재작업하세요:
+{{#retry.failedFiles}}
+- {{.}}
+{{/retry.failedFiles}}
+
+**중요**: 성공한 파일들의 변경사항을 유지하면서 실패한 부분만 수정하세요.
+{{/retry.isPartialRetry}}
 
 ## 이전 시도 실패 정보
 

--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -13,6 +13,7 @@ import type { JobLogger } from "../queue/job-logger.js";
 import { autoCommitIfDirty, getHeadHash } from "../git/commit-helper.js";
 import { phaseProgress } from "./progress-tracker.js";
 import { analyzeTokenUsage, summarizeForBudget } from "../review/token-estimator.js";
+import { collectDiff } from "../git/diff-collector.js";
 
 const logger = getLogger();
 
@@ -163,26 +164,72 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       logger.info(`Auto-committing uncommitted changes for phase ${ctx.phase.index}`);
     }
 
-    // 4. Run verification (test + lint) — skip if command is empty
+    // 4. Collect succeeded files after Claude implementation
+    let succeededFiles: string[] = [];
+    try {
+      const baseBranch = ctx.gitConfig.defaultBaseBranch || 'main';
+      const diffStats = await collectDiff(ctx.gitConfig, baseBranch, { cwd: ctx.cwd });
+      succeededFiles = diffStats.changedFiles;
+      jl?.log(`Claude 구현으로 ${succeededFiles.length}개 파일 변경됨: ${succeededFiles.join(', ')}`);
+    } catch (error: unknown) {
+      logger.warn(`Failed to collect diff after Claude implementation: ${getErrorMessage(error)}`);
+    }
+
+    // 5. Run verification (test + lint) — skip if command is empty
+    let testPassed = true;
+    let testError: string | undefined;
     if (ctx.testCommand) {
       logger.info(`Running verification for phase ${ctx.phase.index}: ${ctx.phase.name}`);
       const testResult = await runShell(ctx.testCommand, { cwd: ctx.cwd, timeout: 120000 });
       if (testResult.exitCode !== 0) {
-        throw new Error(`Tests failed:\n${testResult.stdout}\n${testResult.stderr}`);
+        testPassed = false;
+        testError = `Tests failed:\n${testResult.stdout}\n${testResult.stderr}`;
+
+        // If Claude succeeded but tests failed, this is a partial success
+        if (succeededFiles.length > 0) {
+          const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
+          jl?.log(`부분 성공: Claude 구현은 완료됐지만 테스트 실패`);
+
+          return {
+            phaseIndex: ctx.phase.index,
+            phaseName: ctx.phase.name,
+            success: false,
+            status: "partial",
+            error: testError,
+            errorCategory: classifyError(testError),
+            partial: {
+              succeededFiles,
+              failedFiles: [] // 테스트 실패는 전체 검증 실패로 처리
+            },
+            commitHash,
+            durationMs: Date.now() - startTime,
+            costUsd: claudeResult.costUsd,
+            usage: claudeResult.usage,
+            warnings: [],
+            errors: [testError],
+          };
+        } else {
+          // No files were changed, treat as complete failure
+          throw new Error(testError);
+        }
       }
     }
 
-    // 5. Get latest commit hash
+    // 6. Get latest commit hash
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
+    // Full success
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: true,
+      status: "success",
       commitHash,
       durationMs: Date.now() - startTime,
       costUsd: claudeResult.costUsd,
       usage: claudeResult.usage,
+      warnings: [],
+      errors: [],
     };
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
@@ -190,12 +237,36 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: false,
+      status: "failure",
       error: errMsg,
       errorCategory: classifyError(errMsg),
       lastOutput: errMsg.slice(-2000),
       durationMs: Date.now() - startTime,
       costUsd: claudeResult?.costUsd,
       usage: claudeResult?.usage,
+      warnings: [],
+      errors: [errMsg],
     };
   }
+}
+
+/**
+ * PhaseResult가 완전한 성공인지 확인합니다.
+ */
+export function isFullSuccess(result: PhaseResult): boolean {
+  return result.success === true && result.status === "success";
+}
+
+/**
+ * PhaseResult가 부분 성공인지 확인합니다.
+ */
+export function isPartialSuccess(result: PhaseResult): boolean {
+  return result.success === false && result.status === "partial";
+}
+
+/**
+ * PhaseResult가 완전한 실패인지 확인합니다.
+ */
+export function isFailure(result: PhaseResult): boolean {
+  return result.success === false && result.status === "failure";
 }

--- a/src/pipeline/phase-retry.ts
+++ b/src/pipeline/phase-retry.ts
@@ -14,6 +14,7 @@ import { autoCommitIfDirty, getHeadHash } from "../git/commit-helper.js";
 import { phaseProgress } from "./progress-tracker.js";
 import { ensureCleanState, type WorktreeManager } from "../safety/rollback-manager.js";
 import type { WorktreeInfo } from "../git/worktree-manager.js";
+import { collectDiff } from "../git/diff-collector.js";
 
 const logger = getLogger();
 
@@ -85,6 +86,12 @@ export interface PhaseRetryContext {
   gitConfig: GitConfig;
   worktreeConfig: WorktreeConfig;
   slug: string;
+  // 부분 성공 재시도 지원
+  partialResult?: {
+    succeededFiles: string[];
+    failedFiles: string[];
+  };
+  isPartialRetry?: boolean;
 }
 
 export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
@@ -119,6 +126,11 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       : ctx.previousError.slice(-1500);
     const errorHistory = hasErrorHistory ? prepareErrorHistoryForTemplate(ctx.errorHistory!) : undefined;
 
+    // 부분 성공 재시도를 위한 대상 파일 결정
+    const targetFiles = ctx.isPartialRetry && ctx.partialResult
+      ? ctx.partialResult.failedFiles
+      : ctx.phase.targetFiles;
+
     const rendered = renderTemplate(template, {
       issue: {
         number: String(ctx.issue.number),
@@ -128,7 +140,7 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
         index: String(ctx.phase.index + 1),
         name: ctx.phase.name,
         description: ctx.phase.description,
-        files: ctx.phase.targetFiles,
+        files: targetFiles,
         totalCount: String(ctx.plan.phases.length),
       },
       retry: {
@@ -138,6 +150,10 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
         errorMessage,
         errorHistory: errorHistory as unknown as import("../prompt/template-renderer.js").TemplateVariables,
         lastOutput: ctx.lastOutput || "",
+        // 부분 성공 정보 추가
+        isPartialRetry: ctx.isPartialRetry || false,
+        succeededFiles: ctx.partialResult?.succeededFiles || [],
+        failedFiles: ctx.partialResult?.failedFiles || [],
       },
       config: {
         testCommand: ctx.testCommand,
@@ -179,24 +195,71 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       logger.info(`Auto-committing retry changes for phase ${ctx.phase.index + 1}`);
     }
 
+    // Collect succeeded files after Claude retry
+    let succeededFiles: string[] = [];
+    try {
+      const baseBranch = ctx.gitConfig.defaultBaseBranch || 'main';
+      const diffStats = await collectDiff(ctx.gitConfig, baseBranch, { cwd: ctx.cwd });
+      succeededFiles = diffStats.changedFiles;
+      jl?.log(`Claude 재시도로 ${succeededFiles.length}개 파일 변경됨: ${succeededFiles.join(', ')}`);
+    } catch (error: unknown) {
+      logger.warn(`Failed to collect diff after Claude retry: ${getErrorMessage(error)}`);
+    }
+
     // Run verification
+    let testPassed = true;
+    let testError: string | undefined;
     if (ctx.testCommand) {
       logger.info(`Running verification after retry for phase ${ctx.phase.index + 1}`);
       const testResult = await runShell(ctx.testCommand, { cwd: ctx.cwd, timeout: 120000 });
       if (testResult.exitCode !== 0) {
-        throw new Error(`Tests failed after retry:\n${testResult.stdout}\n${testResult.stderr}`);
+        testPassed = false;
+        testError = `Tests failed after retry:\n${testResult.stdout}\n${testResult.stderr}`;
+
+        // If Claude succeeded but tests failed, this is a partial success
+        if (succeededFiles.length > 0) {
+          const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
+          jl?.log(`부분 성공: Claude 재시도는 완료됐지만 테스트 실패`);
+
+          return {
+            phaseIndex: ctx.phase.index,
+            phaseName: ctx.phase.name,
+            success: false,
+            status: "partial",
+            error: testError,
+            errorCategory: classifyError(testError),
+            partial: {
+              succeededFiles,
+              failedFiles: [] // 테스트 실패는 전체 검증 실패로 처리
+            },
+            commitHash,
+            durationMs: Date.now() - startTime,
+            costUsd: claudeResult.costUsd,
+            usage: claudeResult.usage,
+            warnings: [],
+            errors: [testError],
+          };
+        } else {
+          // No files were changed, treat as complete failure
+          throw new Error(testError);
+        }
       }
     }
 
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
+    // Full success
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: true,
+      status: "success",
       commitHash,
       durationMs: Date.now() - startTime,
       costUsd: claudeResult.costUsd,
+      usage: claudeResult.usage,
+      warnings: [],
+      errors: [],
     };
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
@@ -204,11 +267,15 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
       success: false,
+      status: "failure",
       error: errMsg,
       errorCategory: classifyError(errMsg),
       lastOutput: errMsg.slice(-2000),
       durationMs: Date.now() - startTime,
       costUsd: claudeResult?.costUsd,
+      usage: claudeResult?.usage,
+      warnings: [],
+      errors: [errMsg],
     };
   }
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -87,6 +87,7 @@ export interface ErrorHistoryEntry {
   timestamp: string;
 }
 
+// 기존 PhaseResult 인터페이스 (호환성 유지)
 export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
@@ -98,7 +99,78 @@ export interface PhaseResult {
   durationMs: number;
   costUsd?: number;
   usage?: UsageInfo;
+  // 확장 필드들 (선택적으로 추가)
+  warnings?: string[];
+  errors?: string[];
+  status?: "success" | "failure" | "partial";
+  partial?: {
+    succeededFiles: string[];
+    failedFiles: string[];
+  };
 }
+
+// 확장된 PhaseResult Discriminated Union Types
+
+export type ExtendedPhaseResultStatus = "success" | "failure" | "partial";
+
+/**
+ * 확장된 PhaseResult의 공통 필드들
+ */
+export interface BaseExtendedPhaseResult {
+  phaseIndex: number;
+  phaseName: string;
+  commitHash?: string;
+  lastOutput?: string;
+  durationMs: number;
+  costUsd?: number;
+  usage?: UsageInfo;
+  warnings: string[];
+  errors: string[];
+}
+
+/**
+ * 성공한 Phase 결과 (확장 버전)
+ */
+export interface SuccessExtendedPhaseResult extends BaseExtendedPhaseResult {
+  status: "success";
+  success: true;
+  // 성공했으므로 에러 없음
+  error?: never;
+  errorCategory?: never;
+  // 성공했으므로 부분 성공 정보 없음
+  partial?: never;
+}
+
+/**
+ * 실패한 Phase 결과 (확장 버전)
+ */
+export interface FailureExtendedPhaseResult extends BaseExtendedPhaseResult {
+  status: "failure";
+  success: false;
+  error: string; // 실패했으므로 에러 메시지 필수
+  errorCategory?: ErrorCategory;
+  // 실패했으므로 부분 성공 정보 없음
+  partial?: never;
+}
+
+/**
+ * 부분 성공한 Phase 결과 (확장 버전)
+ */
+export interface PartialExtendedPhaseResult extends BaseExtendedPhaseResult {
+  status: "partial";
+  success: false; // 완전히 성공하지 않았으므로 false
+  error?: string; // 부분 성공 시에도 에러 정보가 있을 수 있음
+  errorCategory?: ErrorCategory;
+  partial: {
+    succeededFiles: string[];
+    failedFiles: string[];
+  };
+}
+
+/**
+ * 모든 확장된 PhaseResult 상태의 Union 타입
+ */
+export type ExtendedPhaseResult = SuccessExtendedPhaseResult | FailureExtendedPhaseResult | PartialExtendedPhaseResult;
 
 export interface PipelineResult {
   issueNumber: number;
@@ -536,4 +608,50 @@ export function isCompletedJob(job: Job): job is SuccessJob | FailureJob | Cance
  */
 export function isActiveJob(job: Job): job is QueuedJob | RunningJob {
   return job.status === "queued" || job.status === "running";
+}
+
+// PhaseResult 타입 가드 함수들
+
+/**
+ * PhaseResult가 성공 상태인지 확인
+ */
+export function isSuccessPhaseResult(result: PhaseResult): boolean {
+  return result.success === true || result.status === "success";
+}
+
+/**
+ * PhaseResult가 실패 상태인지 확인
+ */
+export function isFailurePhaseResult(result: PhaseResult): boolean {
+  return result.success === false && result.status !== "partial";
+}
+
+/**
+ * PhaseResult가 부분 성공 상태인지 확인
+ */
+export function isPartialPhaseResult(result: PhaseResult): boolean {
+  return result.status === "partial";
+}
+
+// ExtendedPhaseResult 타입 가드 함수들
+
+/**
+ * SuccessExtendedPhaseResult 타입 가드
+ */
+export function isSuccessExtendedPhaseResult(result: ExtendedPhaseResult): result is SuccessExtendedPhaseResult {
+  return result.status === "success";
+}
+
+/**
+ * FailureExtendedPhaseResult 타입 가드
+ */
+export function isFailureExtendedPhaseResult(result: ExtendedPhaseResult): result is FailureExtendedPhaseResult {
+  return result.status === "failure";
+}
+
+/**
+ * PartialExtendedPhaseResult 타입 가드
+ */
+export function isPartialExtendedPhaseResult(result: ExtendedPhaseResult): result is PartialExtendedPhaseResult {
+  return result.status === "partial";
 }

--- a/tests/pipeline/phase-executor.test.ts
+++ b/tests/pipeline/phase-executor.test.ts
@@ -22,7 +22,15 @@ vi.mock("../../src/git/diff-collector.js", () => ({
   collectDiff: vi.fn(),
 }));
 
-import { executePhase } from "../../src/pipeline/phase-executor.js";
+import { executePhase, isFullSuccess, isPartialSuccess, isFailure } from "../../src/pipeline/phase-executor.js";
+import {
+  isSuccessPhaseResult,
+  isFailurePhaseResult,
+  isPartialPhaseResult,
+  isSuccessExtendedPhaseResult,
+  isFailureExtendedPhaseResult,
+  isPartialExtendedPhaseResult,
+} from "../../src/types/pipeline.js";
 import { runClaude } from "../../src/claude/claude-runner.js";
 import { runCli, runShell } from "../../src/utils/cli-runner.js";
 import type { PhaseExecutorContext } from "../../src/pipeline/phase-executor.js";
@@ -655,5 +663,313 @@ describe("executePhase", () => {
     // Verify correct commit message template was used
     const commitCall = gitCommitCalls[0];
     expect(commitCall[1]).toContain("[#42] Phase 1: Phase One");
+  });
+
+  describe("partial success scenarios", () => {
+    it("returns partial success when Claude succeeds but tests fail with changed files", async () => {
+      mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+        .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+      // Tests fail
+      mockRunShell.mockResolvedValue({ stdout: "3 tests failed", stderr: "", exitCode: 1 });
+      // Mock collectDiff to return changed files
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 2,
+        insertions: 10,
+        deletions: 5,
+        changedFiles: ["src/component.ts", "src/utils.ts"],
+      });
+
+      const result = await executePhase(makeCtx());
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("partial");
+      expect(result.error).toContain("Tests failed");
+      expect(result.errorCategory).toBe("VERIFICATION_FAILED");
+      expect(result.partial).toEqual({
+        succeededFiles: ["src/component.ts", "src/utils.ts"],
+        failedFiles: []
+      });
+      expect(result.warnings).toEqual([]);
+      expect(result.errors).toEqual([expect.stringContaining("Tests failed")]);
+    });
+
+    it("returns failure when Claude succeeds but tests fail with no changed files", async () => {
+      mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+        .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+      // Tests fail
+      mockRunShell.mockResolvedValue({ stdout: "3 tests failed", stderr: "", exitCode: 1 });
+      // Mock collectDiff to return no changed files
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 0,
+        insertions: 0,
+        deletions: 0,
+        changedFiles: [],
+      });
+
+      const result = await executePhase(makeCtx());
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("failure");
+      expect(result.error).toContain("Tests failed");
+      expect(result.errorCategory).toBe("VERIFICATION_FAILED");
+      expect(result.partial).toBeUndefined();
+      expect(result.warnings).toEqual([]);
+      expect(result.errors).toEqual([expect.stringContaining("Tests failed")]);
+    });
+
+    it("handles collectDiff error gracefully and continues with empty succeeded files", async () => {
+      mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+        .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+      // Tests fail
+      mockRunShell.mockResolvedValue({ stdout: "3 tests failed", stderr: "", exitCode: 1 });
+      // Mock collectDiff to throw error
+      mockCollectDiff.mockRejectedValue(new Error("Git diff failed"));
+
+      const result = await executePhase(makeCtx());
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("failure");
+      expect(result.error).toContain("Tests failed");
+      expect(result.partial).toBeUndefined();
+    });
+  });
+
+  describe("helper functions", () => {
+    it("isFullSuccess returns true for success status", () => {
+      const result = {
+        success: true,
+        status: "success"
+      };
+      expect(isFullSuccess(result)).toBe(true);
+    });
+
+    it("isFullSuccess returns false for partial or failure status", () => {
+      
+
+      const partialResult = {
+        success: false,
+        status: "partial"
+      };
+      expect(isFullSuccess(partialResult)).toBe(false);
+
+      const failureResult = {
+        success: false,
+        status: "failure"
+      };
+      expect(isFullSuccess(failureResult)).toBe(false);
+    });
+
+    it("isPartialSuccess returns true only for partial status", () => {
+      
+
+      const partialResult = {
+        success: false,
+        status: "partial"
+      };
+      expect(isPartialSuccess(partialResult)).toBe(true);
+
+      const successResult = {
+        success: true,
+        status: "success"
+      };
+      expect(isPartialSuccess(successResult)).toBe(false);
+
+      const failureResult = {
+        success: false,
+        status: "failure"
+      };
+      expect(isPartialSuccess(failureResult)).toBe(false);
+    });
+
+    it("isFailure returns true only for failure status", () => {
+      
+
+      const failureResult = {
+        success: false,
+        status: "failure"
+      };
+      expect(isFailure(failureResult)).toBe(true);
+
+      const successResult = {
+        success: true,
+        status: "success"
+      };
+      expect(isFailure(successResult)).toBe(false);
+
+      const partialResult = {
+        success: false,
+        status: "partial"
+      };
+      expect(isFailure(partialResult)).toBe(false);
+    });
+  });
+
+  describe("ExtendedPhaseResult type guards", () => {
+    it("should correctly identify SuccessExtendedPhaseResult", () => {
+      const successResult = {
+        status: "success",
+        success: true,
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: [],
+      };
+
+      expect(isSuccessExtendedPhaseResult(successResult)).toBe(true);
+      expect(isFailureExtendedPhaseResult(successResult)).toBe(false);
+      expect(isPartialExtendedPhaseResult(successResult)).toBe(false);
+    });
+
+    it("should correctly identify FailureExtendedPhaseResult", () => {
+      const failureResult = {
+        status: "failure",
+        success: false,
+        error: "Something went wrong",
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: ["Something went wrong"],
+      };
+
+      expect(isSuccessExtendedPhaseResult(failureResult)).toBe(false);
+      expect(isFailureExtendedPhaseResult(failureResult)).toBe(true);
+      expect(isPartialExtendedPhaseResult(failureResult)).toBe(false);
+    });
+
+    it("should correctly identify PartialExtendedPhaseResult", () => {
+      const partialResult = {
+        status: "partial",
+        success: false,
+        partial: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: [],
+      };
+
+      expect(isSuccessExtendedPhaseResult(partialResult)).toBe(false);
+      expect(isFailureExtendedPhaseResult(partialResult)).toBe(false);
+      expect(isPartialExtendedPhaseResult(partialResult)).toBe(true);
+    });
+  });
+
+  describe("PhaseResult type guards", () => {
+    it("should correctly identify success PhaseResult", () => {
+      const successResult = {
+        success: true,
+        status: "success"
+      };
+
+      expect(isSuccessPhaseResult(successResult)).toBe(true);
+      expect(isFailurePhaseResult(successResult)).toBe(false);
+      expect(isPartialPhaseResult(successResult)).toBe(false);
+
+      // Test legacy success (success: true, no status)
+      const legacySuccessResult = {
+        success: true
+      };
+
+      expect(isSuccessPhaseResult(legacySuccessResult)).toBe(true);
+      expect(isFailurePhaseResult(legacySuccessResult)).toBe(false);
+      expect(isPartialPhaseResult(legacySuccessResult)).toBe(false);
+    });
+
+    it("should correctly identify failure PhaseResult", () => {
+      const failureResult = {
+        success: false,
+        status: "failure"
+      };
+
+      expect(isSuccessPhaseResult(failureResult)).toBe(false);
+      expect(isFailurePhaseResult(failureResult)).toBe(true);
+      expect(isPartialPhaseResult(failureResult)).toBe(false);
+
+      // Test legacy failure (success: false, no status)
+      const legacyFailureResult = {
+        success: false
+      };
+
+      expect(isSuccessPhaseResult(legacyFailureResult)).toBe(false);
+      expect(isFailurePhaseResult(legacyFailureResult)).toBe(true);
+      expect(isPartialPhaseResult(legacyFailureResult)).toBe(false);
+    });
+
+    it("should correctly identify partial PhaseResult", () => {
+      const partialResult = {
+        success: false,
+        status: "partial"
+      };
+
+      expect(isSuccessPhaseResult(partialResult)).toBe(false);
+      expect(isFailurePhaseResult(partialResult)).toBe(false);
+      expect(isPartialPhaseResult(partialResult)).toBe(true);
+    });
+  });
+
+  describe("ExtendedPhaseResult type guards", () => {
+    it("should correctly identify SuccessExtendedPhaseResult", () => {
+      const successResult = {
+        status: "success",
+        success: true,
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: [],
+      };
+
+      expect(isSuccessExtendedPhaseResult(successResult)).toBe(true);
+      expect(isFailureExtendedPhaseResult(successResult)).toBe(false);
+      expect(isPartialExtendedPhaseResult(successResult)).toBe(false);
+    });
+
+    it("should correctly identify FailureExtendedPhaseResult", () => {
+      const failureResult = {
+        status: "failure",
+        success: false,
+        error: "Something went wrong",
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: ["Something went wrong"],
+      };
+
+      expect(isSuccessExtendedPhaseResult(failureResult)).toBe(false);
+      expect(isFailureExtendedPhaseResult(failureResult)).toBe(true);
+      expect(isPartialExtendedPhaseResult(failureResult)).toBe(false);
+    });
+
+    it("should correctly identify PartialExtendedPhaseResult", () => {
+      const partialResult = {
+        status: "partial",
+        success: false,
+        partial: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+        phaseIndex: 0,
+        phaseName: "Test",
+        durationMs: 1000,
+        warnings: [],
+        errors: [],
+      };
+
+      expect(isSuccessExtendedPhaseResult(partialResult)).toBe(false);
+      expect(isFailureExtendedPhaseResult(partialResult)).toBe(false);
+      expect(isPartialExtendedPhaseResult(partialResult)).toBe(true);
+    });
   });
 });

--- a/tests/pipeline/phase-executor.test.ts
+++ b/tests/pipeline/phase-executor.test.ts
@@ -18,6 +18,9 @@ vi.mock("../../src/review/token-estimator.js", () => ({
   analyzeTokenUsage: vi.fn(),
   summarizeForBudget: vi.fn(),
 }));
+vi.mock("../../src/git/diff-collector.js", () => ({
+  collectDiff: vi.fn(),
+}));
 
 import { executePhase } from "../../src/pipeline/phase-executor.js";
 import { runClaude } from "../../src/claude/claude-runner.js";
@@ -26,6 +29,7 @@ import type { PhaseExecutorContext } from "../../src/pipeline/phase-executor.js"
 
 import { renderTemplate, loadTemplate } from "../../src/prompt/template-renderer.js";
 import { analyzeTokenUsage, summarizeForBudget } from "../../src/review/token-estimator.js";
+import { collectDiff } from "../../src/git/diff-collector.js";
 
 const mockRunClaude = vi.mocked(runClaude);
 const mockRunCli = vi.mocked(runCli);
@@ -34,6 +38,7 @@ const mockRenderTemplate = vi.mocked(renderTemplate);
 const mockLoadTemplate = vi.mocked(loadTemplate);
 const mockAnalyzeTokenUsage = vi.mocked(analyzeTokenUsage);
 const mockSummarizeForBudget = vi.mocked(summarizeForBudget);
+const mockCollectDiff = vi.mocked(collectDiff);
 
 function makeCtx(overrides: Partial<PhaseExecutorContext> = {}): PhaseExecutorContext {
   return {
@@ -76,7 +81,14 @@ function makeCtx(overrides: Partial<PhaseExecutorContext> = {}): PhaseExecutorCo
     lintCommand: "",
     gitPath: "git",
     gitConfig: {
-      commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}"
+      commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}",
+      defaultBaseBranch: "main",
+      branchTemplate: "aqm-{{issueNumber}}-{{slug}}",
+      remoteAlias: "origin",
+      allowedRepos: [],
+      gitPath: "git",
+      fetchDepth: 50,
+      signCommits: false,
     },
     ...overrides,
   };
@@ -96,6 +108,12 @@ describe("executePhase", () => {
       usagePercentage: 0.6,
     });
     mockSummarizeForBudget.mockReturnValue("summarized content");
+    mockCollectDiff.mockResolvedValue({
+      filesChanged: 2,
+      insertions: 10,
+      deletions: 5,
+      changedFiles: ["src/foo.ts", "src/bar.ts"],
+    });
   });
 
   it("returns success result when Claude succeeds and tests pass", async () => {
@@ -113,6 +131,9 @@ describe("executePhase", () => {
     expect(result.phaseName).toBe("Phase One");
     expect(result.commitHash).toBe("abc12345");
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.status).toBe("success");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
   });
 
   it("returns failure result when Claude call fails", async () => {
@@ -124,6 +145,9 @@ describe("executePhase", () => {
     expect(result.phaseName).toBe("Phase One");
     expect(result.error).toContain("Phase implementation failed");
     expect(result.errorCategory).toBe("TS_ERROR");
+    expect(result.status).toBe("failure");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([expect.stringContaining("Phase implementation failed")]);
   });
 
   it("returns failure when tests fail", async () => {
@@ -562,7 +586,14 @@ describe("executePhase", () => {
 
     const ctx = makeCtx({
       gitConfig: {
-        commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}"
+        commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}",
+        defaultBaseBranch: "main",
+        branchTemplate: "aqm-{{issueNumber}}-{{slug}}",
+        remoteAlias: "origin",
+        allowedRepos: [],
+        gitPath: "git",
+        fetchDepth: 50,
+        signCommits: false,
       }
     });
 
@@ -570,6 +601,9 @@ describe("executePhase", () => {
 
     expect(result.success).toBe(true);
     expect(result.commitHash).toBe("deadbeef");
+    expect(result.status).toBe("success");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
 
     // Verify that git add and git commit were NOT called (auto-commit was skipped)
     const cliCalls = mockRunCli.mock.calls;
@@ -592,7 +626,14 @@ describe("executePhase", () => {
 
     const ctx = makeCtx({
       gitConfig: {
-        commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}"
+        commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}",
+        defaultBaseBranch: "main",
+        branchTemplate: "aqm-{{issueNumber}}-{{slug}}",
+        remoteAlias: "origin",
+        allowedRepos: [],
+        gitPath: "git",
+        fetchDepth: 50,
+        signCommits: false,
       }
     });
 
@@ -600,6 +641,9 @@ describe("executePhase", () => {
 
     expect(result.success).toBe(true);
     expect(result.commitHash).toBe("abcdef12");
+    expect(result.status).toBe("success");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
 
     // Verify that auto-commit was performed
     const cliCalls = mockRunCli.mock.calls;

--- a/tests/pipeline/phase-retry.test.ts
+++ b/tests/pipeline/phase-retry.test.ts
@@ -28,6 +28,9 @@ vi.mock("../../src/utils/logger.js", () => ({
 vi.mock("../../src/safety/rollback-manager.js", () => ({
   ensureCleanState: vi.fn(),
 }));
+vi.mock("../../src/git/diff-collector.js", () => ({
+  collectDiff: vi.fn(),
+}));
 
 import { retryPhase, type PhaseRetryContext } from "../../src/pipeline/phase-retry.js";
 import { renderTemplate, loadTemplate } from "../../src/prompt/template-renderer.js";
@@ -37,6 +40,7 @@ import { runShell } from "../../src/utils/cli-runner.js";
 import { classifyError } from "../../src/pipeline/error-classifier.js";
 import { autoCommitIfDirty, getHeadHash } from "../../src/git/commit-helper.js";
 import { ensureCleanState } from "../../src/safety/rollback-manager.js";
+import { collectDiff } from "../../src/git/diff-collector.js";
 import type { Plan, Phase, ErrorHistoryEntry } from "../../src/types/pipeline.js";
 import type { GitHubIssue } from "../../src/github/issue-fetcher.js";
 
@@ -49,6 +53,7 @@ const mockClassifyError = vi.mocked(classifyError);
 const mockAutoCommitIfDirty = vi.mocked(autoCommitIfDirty);
 const mockGetHeadHash = vi.mocked(getHeadHash);
 const mockEnsureCleanState = vi.mocked(ensureCleanState);
+const mockCollectDiff = vi.mocked(collectDiff);
 
 function makeIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -155,6 +160,12 @@ describe("retryPhase", () => {
     mockEnsureCleanState.mockResolvedValue({
       path: "/tmp/project",
       branch: "test-branch",
+    });
+    mockCollectDiff.mockResolvedValue({
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      changedFiles: [],
     });
   });
 
@@ -474,6 +485,306 @@ describe("retryPhase", () => {
       expect(mockJobLogger.log).toHaveBeenCalledWith("[INFO] Something else");
       expect(mockJobLogger.log).not.toHaveBeenCalledWith("Regular stderr line");
       expect(mockJobLogger.setProgress).toHaveBeenCalled();
+    });
+  });
+
+  describe("partial success retry scenarios", () => {
+    it("should target only failed files when isPartialRetry is true", async () => {
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts", "src/utils.ts"],
+          failedFiles: ["src/broken.ts", "src/failing.ts"],
+        },
+        phase: {
+          index: 0,
+          name: "TestPhase",
+          description: "Phase TestPhase description",
+          targetFiles: ["src/component.ts", "src/utils.ts", "src/broken.ts", "src/failing.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: ["TestPhase criteria"],
+          dependsOn: [],
+        },
+      });
+
+      await retryPhase(ctx);
+
+      expect(mockRenderTemplate).toHaveBeenCalledWith("Template content", expect.objectContaining({
+        phase: expect.objectContaining({
+          files: ["src/broken.ts", "src/failing.ts"], // Only failed files
+        }),
+        retry: expect.objectContaining({
+          isPartialRetry: true,
+          succeededFiles: ["src/component.ts", "src/utils.ts"],
+          failedFiles: ["src/broken.ts", "src/failing.ts"],
+        }),
+      }));
+    });
+
+    it("should target all files when isPartialRetry is false", async () => {
+      const ctx = makeContext({
+        isPartialRetry: false,
+        phase: {
+          index: 0,
+          name: "TestPhase",
+          description: "Phase TestPhase description",
+          targetFiles: ["src/component.ts", "src/utils.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: ["TestPhase criteria"],
+          dependsOn: [],
+        },
+      });
+
+      await retryPhase(ctx);
+
+      expect(mockRenderTemplate).toHaveBeenCalledWith("Template content", expect.objectContaining({
+        phase: expect.objectContaining({
+          files: ["src/component.ts", "src/utils.ts"], // All target files
+        }),
+        retry: expect.objectContaining({
+          isPartialRetry: false,
+          succeededFiles: [],
+          failedFiles: [],
+        }),
+      }));
+    });
+
+    it("should return partial success when partial retry succeeds with Claude but tests fail", async () => {
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 2,
+        changedFiles: ["src/fixed.ts"],
+      });
+      mockRunShell.mockResolvedValue({
+        exitCode: 1,
+        stdout: "1 test failed",
+        stderr: "",
+      });
+      mockClassifyError.mockReturnValue("VERIFICATION_FAILED");
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("partial");
+      expect(result.error).toContain("Tests failed after retry");
+      expect(result.partial).toEqual({
+        succeededFiles: ["src/fixed.ts"],
+        failedFiles: [],
+      });
+    });
+
+    it("should return complete success when partial retry succeeds and tests pass", async () => {
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 2,
+        insertions: 10,
+        deletions: 3,
+        changedFiles: ["src/fixed1.ts", "src/fixed2.ts"],
+      });
+      mockRunShell.mockResolvedValue({
+        exitCode: 0,
+        stdout: "All tests pass",
+        stderr: "",
+      });
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken1.ts", "src/broken2.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe("success");
+      expect(result.partial).toBeUndefined();
+      expect(result.warnings).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("should handle collectDiff error gracefully during partial retry", async () => {
+      mockCollectDiff.mockRejectedValue(new Error("Git diff failed"));
+      mockRunShell.mockResolvedValue({
+        exitCode: 1,
+        stdout: "Test failed",
+        stderr: "",
+      });
+      mockClassifyError.mockReturnValue("VERIFICATION_FAILED");
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("failure");
+      expect(result.error).toContain("Tests failed after retry");
+      expect(result.partial).toBeUndefined();
+    });
+  });
+
+  describe("partial success retry scenarios", () => {
+    it("should target only failed files when isPartialRetry is true", async () => {
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts", "src/utils.ts"],
+          failedFiles: ["src/broken.ts", "src/failing.ts"],
+        },
+        phase: {
+          index: 0,
+          name: "TestPhase",
+          description: "Phase TestPhase description",
+          targetFiles: ["src/component.ts", "src/utils.ts", "src/broken.ts", "src/failing.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: ["TestPhase criteria"],
+          dependsOn: [],
+        },
+      });
+
+      await retryPhase(ctx);
+
+      expect(mockRenderTemplate).toHaveBeenCalledWith("Template content", expect.objectContaining({
+        phase: expect.objectContaining({
+          files: ["src/broken.ts", "src/failing.ts"], // Only failed files
+        }),
+        retry: expect.objectContaining({
+          isPartialRetry: true,
+          succeededFiles: ["src/component.ts", "src/utils.ts"],
+          failedFiles: ["src/broken.ts", "src/failing.ts"],
+        }),
+      }));
+    });
+
+    it("should target all files when isPartialRetry is false", async () => {
+      const ctx = makeContext({
+        isPartialRetry: false,
+        phase: {
+          index: 0,
+          name: "TestPhase",
+          description: "Phase TestPhase description",
+          targetFiles: ["src/component.ts", "src/utils.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: ["TestPhase criteria"],
+          dependsOn: [],
+        },
+      });
+
+      await retryPhase(ctx);
+
+      expect(mockRenderTemplate).toHaveBeenCalledWith("Template content", expect.objectContaining({
+        phase: expect.objectContaining({
+          files: ["src/component.ts", "src/utils.ts"], // All target files
+        }),
+        retry: expect.objectContaining({
+          isPartialRetry: false,
+          succeededFiles: [],
+          failedFiles: [],
+        }),
+      }));
+    });
+
+    it("should return partial success when partial retry succeeds with Claude but tests fail", async () => {
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 1,
+        insertions: 5,
+        deletions: 2,
+        changedFiles: ["src/fixed.ts"],
+      });
+      mockRunShell.mockResolvedValue({
+        exitCode: 1,
+        stdout: "1 test failed",
+        stderr: "",
+      });
+      mockClassifyError.mockReturnValue("VERIFICATION_FAILED");
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("partial");
+      expect(result.error).toContain("Tests failed after retry");
+      expect(result.partial).toEqual({
+        succeededFiles: ["src/fixed.ts"],
+        failedFiles: [],
+      });
+    });
+
+    it("should return complete success when partial retry succeeds and tests pass", async () => {
+      mockCollectDiff.mockResolvedValue({
+        filesChanged: 2,
+        insertions: 10,
+        deletions: 3,
+        changedFiles: ["src/fixed1.ts", "src/fixed2.ts"],
+      });
+      mockRunShell.mockResolvedValue({
+        exitCode: 0,
+        stdout: "All tests pass",
+        stderr: "",
+      });
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken1.ts", "src/broken2.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe("success");
+      expect(result.partial).toBeUndefined();
+      expect(result.warnings).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("should handle collectDiff error gracefully during partial retry", async () => {
+      mockCollectDiff.mockRejectedValue(new Error("Git diff failed"));
+      mockRunShell.mockResolvedValue({
+        exitCode: 1,
+        stdout: "Test failed",
+        stderr: "",
+      });
+      mockClassifyError.mockReturnValue("VERIFICATION_FAILED");
+
+      const ctx = makeContext({
+        isPartialRetry: true,
+        partialResult: {
+          succeededFiles: ["src/component.ts"],
+          failedFiles: ["src/broken.ts"],
+        },
+      });
+
+      const result = await retryPhase(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe("failure");
+      expect(result.error).toContain("Tests failed after retry");
+      expect(result.partial).toBeUndefined();
     });
   });
 

--- a/tests/pipeline/phase-retry.test.ts
+++ b/tests/pipeline/phase-retry.test.ts
@@ -183,6 +183,9 @@ describe("retryPhase", () => {
           errorMessage: "Previous error message",
           errorHistory: undefined,
           lastOutput: "",
+          isPartialRetry: false,
+          succeededFiles: [],
+          failedFiles: [],
         },
         config: {
           testCommand: "npm test",
@@ -303,9 +306,13 @@ describe("retryPhase", () => {
         phaseIndex: 0,
         phaseName: "TestPhase",
         success: true,
+        status: "success",
         commitHash: "abc12345",
         durationMs: expect.any(Number),
         costUsd: undefined,
+        usage: undefined,
+        warnings: [],
+        errors: [],
       });
     });
 
@@ -346,11 +353,15 @@ describe("retryPhase", () => {
         phaseIndex: 0,
         phaseName: "TestPhase",
         success: false,
+        status: "failure",
         error: "Phase retry failed: Claude failed",
         errorCategory: "CLI_CRASH",
         lastOutput: "Phase retry failed: Claude failed",
         durationMs: expect.any(Number),
         costUsd: undefined,
+        usage: undefined,
+        warnings: [],
+        errors: ["Phase retry failed: Claude failed"],
       });
     });
 
@@ -370,11 +381,15 @@ describe("retryPhase", () => {
         phaseIndex: 0,
         phaseName: "TestPhase",
         success: false,
+        status: "failure",
         error: "Tests failed after retry:\nTest output\nTest failed",
         errorCategory: "VERIFICATION_FAILED",
         lastOutput: expect.stringMatching(/Tests failed after retry/),
         durationMs: expect.any(Number),
         costUsd: undefined,
+        usage: undefined,
+        warnings: [],
+        errors: ["Tests failed after retry:\nTest output\nTest failed"],
       });
     });
 


### PR DESCRIPTION
## Summary

Resolves #265 — refactor: Result Type — Phase 부분 성공 지원

현재 PhaseResult는 success: boolean으로 이진 판정만 지원하여 부분 성공(일부 파일 성공, 일부 실패) 상황을 처리할 수 없다. 이로 인해 부분적으로 성공한 변경사항도 전체 롤백되고, 재시도 시 전체를 다시 실행해야 한다. PhaseResult를 Discriminated Union으로 확장하고 부분 성공 감지 및 선택적 재시도를 구현해야 한다.

## Requirements

- PhaseResult 타입을 Discriminated Union으로 확장 (SuccessPhaseResult, FailurePhaseResult, PartialPhaseResult)
- warnings, errors, partial 필드를 PhaseResult에 추가
- phase-executor에서 부분 성공 상태 감지 로직 구현
- phase-retry에서 실패 부분만 재시도하는 선택적 재시도 로직 구현
- 기존 코드와의 하위 호환성 유지

## Implementation Phases

- Phase 0: PhaseResult 타입 확장 — SUCCESS (be7d7ef1)
- Phase 1: phase-executor 부분 성공 감지 — SUCCESS (db5ee8d2)
- Phase 2: phase-retry 선택적 재시도 — SUCCESS (48b6ca6f)
- Phase 3: 테스트 작성 및 검증 — SUCCESS (3fefb463)

## Risks

- 기존 PhaseResult를 사용하는 코드에서 타입 에러 발생 가능
- 부분 성공 판정 기준이 모호할 경우 예상치 못한 동작 발생
- 선택적 재시도 로직이 복잡해질 경우 디버깅 어려움

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/265-refactor-result-type-phase` → `develop`
- **Tokens**: 1456 input, 36785 output{{#stats.cacheCreationTokens}}, 271839 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3635323 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #265