### PR TITLE
[AQ-#272] feat: 파이프라인 타임라인 뷰 — Phase별 Gantt 차트

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -611,6 +611,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 <script src="js/state.js"></script>
 <script src="js/modal.js"></script>
 <script src="js/render.js"></script>
+<script src="js/timeline.js"></script>
 <script src="js/app.js"></script>
 
 <!-- Confirm Modal -->
@@ -630,5 +631,8 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     <div class="absolute bottom-0 left-0 w-full h-[2px] bg-gradient-to-r from-transparent via-[#f85149]/40 to-transparent"></div>
   </div>
 </div>
+
+<!-- Timeline Modal -->
+<div id="timeline-modal-root"></div>
 </body>
 </html>

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -76,6 +76,9 @@ function renderJobDetail(job) {
 
   // Action buttons
   html += '<div class="flex gap-3">';
+  if (job.phaseResults && job.phaseResults.length > 0) {
+    html += '<button onclick="openTimelineModal(currentJobs.find(function(j){return j.id===\'' + esc(job.id) + '\'})||{})" class="px-4 py-2 bg-surface-container-high text-primary text-sm font-bold rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">timeline</span> 타임라인</button>';
+  }
   if (isActive) {
     html += '<button onclick="cancelJob(\'' + esc(job.id) + '\')" class="px-4 py-2 bg-surface-container-high text-[#f85149] text-sm font-bold rounded-lg border border-[#f85149]/30 hover:bg-[#f85149]/10 transition-colors">' + t('cancel') + '</button>';
   }

--- a/src/server/public/js/timeline.js
+++ b/src/server/public/js/timeline.js
@@ -1,0 +1,225 @@
+'use strict';
+
+/* ══════════════════════════════════════════════════════════════
+   Timeline Modal — Gantt Chart
+   ══════════════════════════════════════════════════════════════ */
+
+function openTimelineModal(job) {
+  var existing = document.getElementById('timeline-modal');
+  if (existing) existing.remove();
+  document.body.insertAdjacentHTML('beforeend', renderTimelineModal(job));
+}
+
+function closeTimelineModal() {
+  var modal = document.getElementById('timeline-modal');
+  if (modal) modal.remove();
+}
+
+function renderTimelineModal(job) {
+  var phases = job.phaseResults || [];
+
+  // Calculate total duration: prefer job wall-clock time, fall back to sum of phase durations
+  var totalDurationMs = 0;
+  if (job.startedAt) {
+    var end = job.completedAt ? new Date(job.completedAt) : new Date();
+    totalDurationMs = end - new Date(job.startedAt);
+  }
+  if (totalDurationMs <= 0) {
+    phases.forEach(function(p) { totalDurationMs += (p.durationMs || 0); });
+  }
+
+  var dur = fmtDuration(job);
+  var costHtml = fmtCost(job.totalCostUsd);
+
+  var metaHtml = '';
+  if (dur) {
+    metaHtml += '<div class="flex flex-col"><span class="text-[10px] uppercase text-outline tracking-widest font-bold">Duration</span>' +
+      '<span class="text-lg font-mono text-on-surface">' + esc(dur) + '</span></div>';
+  }
+  if (costHtml) {
+    metaHtml += '<div class="w-px h-8 bg-outline-variant/30"></div>' +
+      '<div class="flex flex-col"><span class="text-[10px] uppercase text-outline tracking-widest font-bold">Total Cost</span>' +
+      '<span class="text-lg font-mono text-tertiary">' + esc(costHtml) + '</span></div>';
+  }
+
+  return '<div id="timeline-modal" class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4" onclick="closeTimelineModal()">' +
+    '<div class="bg-surface-container-lowest rounded-xl border border-outline-variant/20 w-full max-w-4xl max-h-[90vh] overflow-y-auto custom-scrollbar" onclick="event.stopPropagation()">' +
+
+    // Header
+    '<div class="flex justify-between items-start p-6 border-b border-outline-variant/10">' +
+      '<div>' +
+        '<h2 class="font-headline text-xl font-bold flex items-center gap-2">' +
+          '<span class="material-symbols-outlined text-primary">analytics</span>' +
+          'Pipeline Timeline' +
+        '</h2>' +
+        '<p class="text-sm text-outline mt-1">#' + esc(String(job.issueNumber)) + ' — ' + esc(job.repo) + '</p>' +
+        (metaHtml ? '<div class="flex items-center gap-6 mt-3">' + metaHtml + '</div>' : '') +
+      '</div>' +
+      '<button onclick="closeTimelineModal()" class="text-outline hover:text-on-surface transition-colors mt-1">' +
+        '<span class="material-symbols-outlined">close</span>' +
+      '</button>' +
+    '</div>' +
+
+    // Gantt body
+    '<div class="p-6">' +
+      renderGanttChart(phases, totalDurationMs) +
+    '</div>' +
+
+    '</div>' +
+  '</div>';
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Gantt Chart
+   ══════════════════════════════════════════════════════════════ */
+
+function renderGanttChart(phases, totalDurationMs) {
+  if (!phases || phases.length === 0) {
+    return '<div class="flex items-center justify-center py-16 text-outline text-sm">' +
+      '<span class="material-symbols-outlined text-lg mr-2">hourglass_empty</span>No phase data available</div>';
+  }
+
+  // Legend
+  var html = '<div class="flex gap-4 text-[10px] font-mono text-outline mb-6">' +
+    '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#3fb950]"></span> SUCCESS</span>' +
+    '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#f85149]"></span> FAILED</span>' +
+    '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#58a6ff]"></span> RUNNING</span>' +
+    '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full" style="background:#31353c"></span> PENDING</span>' +
+    '</div>';
+
+  // X-axis labels
+  html += buildXAxis(totalDurationMs);
+
+  // Phase rows with grid overlay
+  html += '<div class="relative">';
+  // Vertical grid lines (inline style to avoid CSS class dependency)
+  html += '<div class="absolute top-0 bottom-0 right-0 pointer-events-none opacity-20" style="left:12rem;' +
+    'background-image:linear-gradient(to right,rgba(65,71,82,0.4) 1px,transparent 1px);background-size:16.66% 100%"></div>';
+
+  html += '<div class="space-y-4">';
+  var cumulativeMs = 0;
+  phases.forEach(function(phase) {
+    html += renderGanttPhaseRow(phase, cumulativeMs, totalDurationMs);
+    cumulativeMs += (phase.durationMs || 0);
+  });
+  html += '</div>';
+  html += '</div>';
+
+  return html;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   X-Axis
+   ══════════════════════════════════════════════════════════════ */
+
+function buildXAxis(totalDurationMs) {
+  var TICKS = 6;
+  var labels = [];
+  for (var i = 0; i < TICKS; i++) {
+    var ms = totalDurationMs > 0 ? Math.round((totalDurationMs * i) / (TICKS - 1)) : 0;
+    labels.push(fmtDurationMs(ms));
+  }
+
+  var html = '<div class="flex justify-between text-[10px] font-mono text-outline-variant pb-2 border-b border-outline-variant/10 mb-4" style="margin-left:12rem">';
+  labels.forEach(function(label, i) {
+    var cls = i === labels.length - 1 ? ' class="text-primary"' : '';
+    html += '<span' + cls + '>' + esc(label) + '</span>';
+  });
+  html += '</div>';
+  return html;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Phase Row
+   ══════════════════════════════════════════════════════════════ */
+
+function renderGanttPhaseRow(phase, startMs, totalDurationMs) {
+  var phaseName = phase.name || 'Phase';
+  var isSuccess = phase.success === true;
+  var isFailed = phase.success === false;
+  var durationMs = phase.durationMs || 0;
+  var hasDuration = durationMs > 0;
+  var dur = fmtDurationMs(durationMs);
+  var cost = fmtCost(phase.costUsd);
+
+  // Bar position (percentage of total)
+  var leftPct = (totalDurationMs > 0 && startMs > 0) ? (startMs / totalDurationMs * 100) : 0;
+  var widthPct = (totalDurationMs > 0 && hasDuration) ? (durationMs / totalDurationMs * 100) : 0;
+
+  // Clamp: always show at least 0.5% width for visible phases
+  leftPct = Math.min(Math.max(leftPct, 0), 100);
+  if (widthPct > 0) widthPct = Math.max(widthPct, 0.5);
+  widthPct = Math.min(widthPct, 100 - leftPct);
+
+  var labelClass;
+  if (isSuccess) labelClass = 'text-on-surface-variant';
+  else if (isFailed) labelClass = 'text-[#f85149]';
+  else if (hasDuration) labelClass = 'text-primary';
+  else labelClass = 'text-on-surface-variant opacity-40';
+
+  var html = '<div class="flex items-center group">';
+
+  // Phase label (fixed 12rem width)
+  html += '<div class="pr-4 text-sm font-medium ' + labelClass + ' group-hover:text-on-surface transition-colors truncate" style="width:12rem;flex-shrink:0">' +
+    esc(phaseName) + '</div>';
+
+  if (isSuccess || isFailed || hasDuration) {
+    // Bar track
+    html += '<div class="flex-1 h-10 rounded-md relative overflow-visible" style="background:#1c2026">';
+
+    var barColor = isSuccess ? '#3fb950' : isFailed ? '#f85149' : '#58a6ff';
+    var textColor = isSuccess ? '#0d1117' : '#ffffff';
+
+    var barStyle = [
+      'position:absolute',
+      'left:' + leftPct.toFixed(2) + '%',
+      'top:0',
+      'height:100%',
+      'width:' + widthPct.toFixed(2) + '%',
+      'background:' + barColor,
+      'display:flex',
+      'align-items:center',
+      'padding:0 8px',
+      'justify-content:space-between',
+      'border-radius:4px',
+      'overflow:hidden',
+      'min-width:4px'
+    ].join(';');
+
+    html += '<div style="' + barStyle + '" class="relative group/bar cursor-default">';
+
+    // Duration label inside bar
+    html += '<span class="text-[10px] font-bold font-mono truncate" style="color:' + textColor + '">' + esc(dur) + '</span>';
+    if (cost) {
+      html += '<span class="text-[10px] font-bold font-mono" style="color:' + textColor + '">' + esc(cost) + '</span>';
+    }
+
+    // Error tooltip (visible on hover)
+    if (isFailed && phase.error) {
+      var errMsg = String(phase.error).substring(0, 80);
+      html += '<div class="absolute bottom-full left-1/2 mb-2 pointer-events-none opacity-0 group-hover/bar:opacity-100 transition-opacity z-20" ' +
+        'style="transform:translateX(-50%);white-space:nowrap">' +
+        '<div class="px-3 py-1.5 rounded text-[10px] font-bold shadow-xl" style="background:#f85149;color:#fff">' +
+          '<span class="material-symbols-outlined mr-1" style="font-size:12px;vertical-align:middle">error</span>' +
+          esc(errMsg) +
+        '</div>' +
+      '</div>';
+    }
+
+    html += '</div>'; // bar
+    html += '</div>'; // track
+  } else {
+    // Pending: dashed placeholder
+    html += '<div class="flex-1 h-10 rounded-md border border-dashed flex items-center justify-center" ' +
+      'style="background:rgba(28,32,38,0.3);border-color:rgba(65,71,82,0.2)">' +
+      '<span class="text-[10px] font-mono uppercase tracking-widest" style="color:rgba(139,145,157,0.5)">Awaiting preceding tasks</span>' +
+      '</div>';
+  }
+
+  html += '</div>'; // row
+  return html;
+}
+
+// Expose globals for HTML onclick handlers
+window.openTimelineModal = openTimelineModal;
+window.closeTimelineModal = closeTimelineModal;


### PR DESCRIPTION
## Summary

Resolves #272 — feat: 파이프라인 타임라인 뷰 — Phase별 Gantt 차트

현재 대시보드에서 Job 상세 정보는 Phase 목록 형태로만 표시되며, 각 Phase의 시작/종료 시점과 전체 파이프라인 대비 소요 시간 비율을 시각적으로 파악하기 어렵다. 이슈 #272는 Job 카드 클릭 시 Gantt 스타일 수평 바 차트로 Phase별 타임라인을 시각화하여 파이프라인 실행 흐름과 병목 구간을 직관적으로 확인할 수 있게 한다.

## Requirements

- Job 카드 클릭 시 Phase별 타임라인 상세 보기 모달 표시 (Gantt 스타일 수평 바)
- 각 Phase 바에 소요시간(duration), 비용(cost), 성공/실패 상태 표시
- X축 타임라인 눈금과 그리드 라인 표시
- 실패한 Phase에 에러 툴팁 표시
- timeline-stitch.html 디자인 시스템 준수
- src/server/public/js/timeline.js 신규 생성
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: timeline.js 생성 — Gantt 차트 렌더링 모듈 — SUCCESS (2051cd98)
- Phase 1: index.html 수정 — timeline.js 로드 및 모달 마크업 — SUCCESS (7a12bb06)
- Phase 2: render.js 통합 — 타임라인 버튼 및 모달 호출 — SUCCESS (3e1cc384)
- Phase 3: 검증 — tsc 및 vitest 통과 확인 — SUCCESS (3e1cc384)

## Risks

- 기존 render.js의 renderJobDetail 함수와 타임라인 뷰 간 상태 동기화 이슈
- Phase 실행 시간이 0인 경우 바 너비 계산 오류 가능
- 모바일/태블릿 반응형 대응 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/272-feat-phase-gantt` → `develop`
- **Tokens**: 174 input, 23511 output{{#stats.cacheCreationTokens}}, 268677 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2057110 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #272