### PR TITLE
[AQ-#261] feat: 통계/분석 쿼리 API — 프로젝트별/기간별/비용별 집계

### DIFF
--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -89,6 +89,10 @@ export class JobStore extends EventEmitter {
     }
   }
 
+  getAqDb(): AQDatabase {
+    return this.db;
+  }
+
   /**
    * 캐시에서 job 제거
    */

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -10,7 +10,8 @@ import { maskSensitiveConfig } from "../utils/config-masker.js";
 import type { ProjectConfig, AQConfig } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, type HealthCheckResponse } from "../types/api.js";
+import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, type HealthCheckResponse } from "../types/api.js";
+import { getJobStats, getCostStats } from "../store/queries.js";
 import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
 import { runCli } from "../utils/cli-runner.js";
@@ -350,6 +351,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     api.use("/api/jobs", bearerAuth);
     api.use("/api/jobs/*", bearerAuth);
     api.use("/api/stats", bearerAuth);
+    api.use("/api/stats/costs", bearerAuth);
     api.use("/api/config", bearerAuth);
     api.use("/api/projects", bearerAuth);
     api.use("/api/projects/*", bearerAuth);
@@ -745,7 +747,6 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Aggregate stats
   api.get("/api/stats", (c) => {
     try {
-      // Parse query parameters using Zod schema
       const queryParams = {
         project: c.req.query("project"),
         timeRange: c.req.query("timeRange") || "7d",
@@ -759,71 +760,34 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
         }, 400);
       }
 
-      const { project, timeRange } = parseResult.data;
-
-      // Get base job list
-      let jobs = store.list();
-
-      // Apply project filter
-      if (project) {
-        jobs = jobs.filter(j => j.repo === project);
-      }
-
-      // Apply time range filter
-      if (timeRange !== "all") {
-        const now = new Date();
-        let cutoffTime: Date;
-
-        switch (timeRange) {
-          case "24h":
-            cutoffTime = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-            break;
-          case "7d":
-            cutoffTime = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-            break;
-          case "30d":
-            cutoffTime = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-            break;
-          default:
-            cutoffTime = new Date(0); // No filter
-        }
-
-        jobs = jobs.filter(j => {
-          const createdAt = new Date(j.createdAt);
-          return createdAt >= cutoffTime;
-        });
-      }
-
-      const total = jobs.length;
-      const successCount = jobs.filter(j => j.status === "success").length;
-      const failureCount = jobs.filter(j => j.status === "failure").length;
-      const runningCount = jobs.filter(j => j.status === "running").length;
-      const queuedCount = jobs.filter(j => j.status === "queued").length;
-      const cancelledCount = jobs.filter(j => j.status === "cancelled").length;
-
-      const completed = jobs.filter(j => j.completedAt && j.startedAt);
-      const avgDurationMs = completed.length > 0
-        ? Math.round(completed.reduce((sum, j) => {
-            return sum + (new Date(j.completedAt!).getTime() - new Date(j.startedAt!).getTime());
-          }, 0) / completed.length)
-        : 0;
-
-      const successRate = total > 0 ? Math.round((successCount / total) * 100) : 0;
-
-      return c.json({
-        total,
-        successCount,
-        failureCount,
-        runningCount,
-        queuedCount,
-        cancelledCount,
-        avgDurationMs,
-        successRate,
-        project: project || null,
-        timeRange,
-      });
+      const stats = getJobStats(store.getAqDb(), parseResult.data);
+      return c.json(stats);
     } catch (error: unknown) {
       return c.json({ error: `Failed to fetch stats: ${getErrorMessage(error)}` }, 500);
+    }
+  });
+
+  // Cost stats
+  api.get("/api/stats/costs", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "30d",
+        groupBy: c.req.query("groupBy") || "project",
+      };
+
+      const parseResult = GetCostsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: parseResult.error
+        }, 400);
+      }
+
+      const costs = getCostStats(store.getAqDb(), parseResult.data);
+      return c.json(costs);
+    } catch (error: unknown) {
+      return c.json({ error: `Failed to fetch cost stats: ${getErrorMessage(error)}` }, 500);
     }
   });
 

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -443,4 +443,9 @@ export class AQDatabase {
   transaction<T>(fn: () => T): T {
     return this.db.transaction(fn)();
   }
+
+  // Raw SQLite 접근 (queries.ts 전용)
+  getDb(): SQLite.Database {
+    return this.db;
+  }
 }

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -1,0 +1,224 @@
+import type { AQDatabase } from "./database.js";
+import type { StatsResponse, GetStatsQuery, CostsResponse, GetCostsQuery, CostEntry } from "../types/api.js";
+
+// SQLite row types for query results
+interface StatsRow {
+  total: number;
+  success_count: number;
+  failure_count: number;
+  running_count: number;
+  queued_count: number;
+  cancelled_count: number;
+  avg_duration_ms: number | null;
+}
+
+interface CostGroupRow {
+  label: string;
+  total_cost_usd: number;
+  job_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cache_read_tokens: number;
+}
+
+interface CostSummaryRow {
+  total_cost_usd: number;
+  job_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cache_read_tokens: number;
+}
+
+interface ProjectSummaryRow {
+  repo: string;
+  total: number;
+  success_count: number;
+  failure_count: number;
+  total_cost_usd: number;
+  last_activity: string | null;
+}
+
+export interface ProjectSummary {
+  repo: string;
+  total: number;
+  successCount: number;
+  failureCount: number;
+  totalCostUsd: number;
+  successRate: number;
+  lastActivity: string | null;
+}
+
+function getTimeRangeCutoff(timeRange: string): string | null {
+  if (timeRange === "all") return null;
+  const now = new Date();
+  switch (timeRange) {
+    case "24h": return new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    case "7d": return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    case "30d": return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    default: return null;
+  }
+}
+
+function buildWhereClause(project: string | undefined, cutoff: string | null): {
+  sql: string;
+  params: (string | null)[];
+} {
+  const conditions: string[] = [];
+  const params: (string | null)[] = [];
+
+  if (project) {
+    conditions.push("repo = ?");
+    params.push(project);
+  }
+  if (cutoff) {
+    conditions.push("created_at >= ?");
+    params.push(cutoff);
+  }
+
+  return {
+    sql: conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "",
+    params,
+  };
+}
+
+export function getJobStats(aqDb: AQDatabase, query: GetStatsQuery): StatsResponse {
+  const { project, timeRange } = query;
+  const cutoff = getTimeRangeCutoff(timeRange);
+  const { sql: whereClause, params } = buildWhereClause(project, cutoff);
+
+  const db = aqDb.getDb();
+
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) as total,
+      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
+      SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) as failure_count,
+      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) as running_count,
+      SUM(CASE WHEN status = 'queued' THEN 1 ELSE 0 END) as queued_count,
+      SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count,
+      AVG(CASE
+        WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
+        THEN (julianday(completed_at) - julianday(started_at)) * 86400000.0
+        ELSE NULL
+      END) as avg_duration_ms
+    FROM jobs
+    ${whereClause}
+  `).get(...params) as StatsRow;
+
+  const total = row.total ?? 0;
+  const successCount = row.success_count ?? 0;
+
+  return {
+    total,
+    successCount,
+    failureCount: row.failure_count ?? 0,
+    runningCount: row.running_count ?? 0,
+    queuedCount: row.queued_count ?? 0,
+    cancelledCount: row.cancelled_count ?? 0,
+    avgDurationMs: row.avg_duration_ms != null ? Math.round(row.avg_duration_ms) : 0,
+    successRate: total > 0 ? Math.round((successCount / total) * 100) : 0,
+    project: project ?? null,
+    timeRange,
+  };
+}
+
+export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsResponse {
+  const { project, timeRange, groupBy } = query;
+  const cutoff = getTimeRangeCutoff(timeRange);
+  const { sql: whereClause, params } = buildWhereClause(project, cutoff);
+
+  const db = aqDb.getDb();
+
+  let groupExpr: string;
+  switch (groupBy) {
+    case "day":   groupExpr = "date(created_at)"; break;
+    case "week":  groupExpr = "strftime('%Y-W%W', created_at)"; break;
+    case "month": groupExpr = "strftime('%Y-%m', created_at)"; break;
+    default:      groupExpr = "repo"; // project
+  }
+
+  const breakdownRows = db.prepare(`
+    SELECT
+      ${groupExpr} as label,
+      COALESCE(SUM(total_cost_usd), 0) as total_cost_usd,
+      COUNT(*) as job_count,
+      COALESCE(SUM(total_input_tokens), 0) as total_input_tokens,
+      COALESCE(SUM(total_output_tokens), 0) as total_output_tokens,
+      COALESCE(SUM(total_cache_creation_input_tokens), 0) as total_cache_creation_tokens,
+      COALESCE(SUM(total_cache_read_input_tokens), 0) as total_cache_read_tokens
+    FROM jobs
+    ${whereClause}
+    GROUP BY ${groupExpr}
+    ORDER BY ${groupExpr}
+  `).all(...params) as CostGroupRow[];
+
+  const summaryRow = db.prepare(`
+    SELECT
+      COALESCE(SUM(total_cost_usd), 0) as total_cost_usd,
+      COUNT(*) as job_count,
+      COALESCE(SUM(total_input_tokens), 0) as total_input_tokens,
+      COALESCE(SUM(total_output_tokens), 0) as total_output_tokens,
+      COALESCE(SUM(total_cache_creation_input_tokens), 0) as total_cache_creation_tokens,
+      COALESCE(SUM(total_cache_read_input_tokens), 0) as total_cache_read_tokens
+    FROM jobs
+    ${whereClause}
+  `).get(...params) as CostSummaryRow;
+
+  const breakdown: CostEntry[] = breakdownRows.map(row => ({
+    label: row.label,
+    totalCostUsd: row.total_cost_usd,
+    jobCount: row.job_count,
+    avgCostUsd: row.job_count > 0 ? row.total_cost_usd / row.job_count : 0,
+    totalInputTokens: row.total_input_tokens,
+    totalOutputTokens: row.total_output_tokens,
+    totalCacheCreationTokens: row.total_cache_creation_tokens,
+    totalCacheReadTokens: row.total_cache_read_tokens,
+  }));
+
+  const totalJobCount = summaryRow.job_count;
+
+  return {
+    project: project ?? null,
+    timeRange,
+    groupBy,
+    summary: {
+      totalCostUsd: summaryRow.total_cost_usd,
+      jobCount: totalJobCount,
+      avgCostUsd: totalJobCount > 0 ? summaryRow.total_cost_usd / totalJobCount : 0,
+      totalInputTokens: summaryRow.total_input_tokens,
+      totalOutputTokens: summaryRow.total_output_tokens,
+      totalCacheCreationTokens: summaryRow.total_cache_creation_tokens,
+      totalCacheReadTokens: summaryRow.total_cache_read_tokens,
+    },
+    breakdown,
+  };
+}
+
+export function getProjectSummary(aqDb: AQDatabase): ProjectSummary[] {
+  const db = aqDb.getDb();
+
+  const rows = db.prepare(`
+    SELECT
+      repo,
+      COUNT(*) as total,
+      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
+      SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) as failure_count,
+      COALESCE(SUM(total_cost_usd), 0) as total_cost_usd,
+      MAX(created_at) as last_activity
+    FROM jobs
+    GROUP BY repo
+    ORDER BY last_activity DESC
+  `).all() as ProjectSummaryRow[];
+
+  return rows.map(row => ({
+    repo: row.repo,
+    total: row.total,
+    successCount: row.success_count,
+    failureCount: row.failure_count,
+    totalCostUsd: row.total_cost_usd,
+    successRate: row.total > 0 ? Math.round((row.success_count / row.total) * 100) : 0,
+    lastActivity: row.last_activity ?? null,
+  }));
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -186,6 +186,63 @@ export const GetStatsQuerySchema = z.object({
 
 export type GetStatsQuery = z.infer<typeof GetStatsQuerySchema>;
 
+// StatsResponse 응답 타입 (GET /api/stats)
+export const StatsResponseSchema = z.object({
+  total: z.number().int().nonnegative(),
+  successCount: z.number().int().nonnegative(),
+  failureCount: z.number().int().nonnegative(),
+  runningCount: z.number().int().nonnegative(),
+  queuedCount: z.number().int().nonnegative(),
+  cancelledCount: z.number().int().nonnegative(),
+  avgDurationMs: z.number().nonnegative(),
+  successRate: z.number().min(0).max(100),
+  project: z.string().nullable(),
+  timeRange: z.enum(["24h", "7d", "30d", "all"]),
+});
+
+export type StatsResponse = z.infer<typeof StatsResponseSchema>;
+
+// GetCosts 쿼리 스키마 (GET /api/costs)
+export const GetCostsQuerySchema = z.object({
+  project: z.string().optional(),
+  timeRange: z.enum(["24h", "7d", "30d", "all"]).default("30d"),
+  groupBy: z.enum(["project", "day", "week", "month"]).default("project"),
+}).strict();
+
+export type GetCostsQuery = z.infer<typeof GetCostsQuerySchema>;
+
+// CostsResponse 응답 타입 (GET /api/costs)
+export const CostEntrySchema = z.object({
+  label: z.string(),
+  totalCostUsd: z.number().nonnegative(),
+  jobCount: z.number().int().nonnegative(),
+  avgCostUsd: z.number().nonnegative(),
+  totalInputTokens: z.number().int().nonnegative(),
+  totalOutputTokens: z.number().int().nonnegative(),
+  totalCacheCreationTokens: z.number().int().nonnegative(),
+  totalCacheReadTokens: z.number().int().nonnegative(),
+});
+
+export type CostEntry = z.infer<typeof CostEntrySchema>;
+
+export const CostsResponseSchema = z.object({
+  project: z.string().nullable(),
+  timeRange: z.enum(["24h", "7d", "30d", "all"]),
+  groupBy: z.enum(["project", "day", "week", "month"]),
+  summary: z.object({
+    totalCostUsd: z.number().nonnegative(),
+    jobCount: z.number().int().nonnegative(),
+    avgCostUsd: z.number().nonnegative(),
+    totalInputTokens: z.number().int().nonnegative(),
+    totalOutputTokens: z.number().int().nonnegative(),
+    totalCacheCreationTokens: z.number().int().nonnegative(),
+    totalCacheReadTokens: z.number().int().nonnegative(),
+  }),
+  breakdown: z.array(CostEntrySchema),
+});
+
+export type CostsResponse = z.infer<typeof CostsResponseSchema>;
+
 // HealthCheck 응답 스키마 (GET /api/health)
 export const HealthCheckResponseSchema = z.object({
   project: z.string(),

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -26,6 +26,37 @@ vi.mock("../../src/update/self-updater.js", () => ({
   SelfUpdater: vi.fn(),
 }));
 
+vi.mock("../../src/store/queries.js", () => ({
+  getJobStats: vi.fn().mockReturnValue({
+    total: 3,
+    successCount: 1,
+    failureCount: 1,
+    runningCount: 1,
+    queuedCount: 0,
+    cancelledCount: 0,
+    avgDurationMs: 0,
+    successRate: 33,
+    project: null,
+    timeRange: "7d",
+  }),
+  getCostStats: vi.fn().mockReturnValue({
+    project: null,
+    timeRange: "30d",
+    groupBy: "project",
+    summary: {
+      totalCostUsd: 0,
+      jobCount: 0,
+      avgCostUsd: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+    },
+    breakdown: [],
+  }),
+  getProjectSummary: vi.fn().mockReturnValue([]),
+}));
+
 vi.mock("fs", () => ({
   readFileSync: vi.fn(),
 }));
@@ -50,6 +81,7 @@ const mockJobStore: JobStore = {
   remove: vi.fn(),
   on: globalEmitter.on.bind(globalEmitter),
   emit: globalEmitter.emit.bind(globalEmitter),
+  getAqDb: vi.fn().mockReturnValue({}),
 } as any;
 
 const mockJobQueue: JobQueue = {

--- a/tests/store/queries.test.ts
+++ b/tests/store/queries.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { AQDatabase, type DatabaseJob } from "../../src/store/database.js";
+import { getJobStats, getCostStats, getProjectSummary } from "../../src/store/queries.js";
+import { rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Helper: create a minimal job object
+function makeJob(overrides: Partial<DatabaseJob> & { id: string }): DatabaseJob {
+  return {
+    issueNumber: 1,
+    repo: "org/repo",
+    status: "success",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// Helper: ISO string N days ago
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("queries", () => {
+  let dataDir: string;
+  let dbPath: string;
+  let db: AQDatabase;
+
+  beforeEach(() => {
+    dataDir = join(tmpdir(), `aq-queries-test-${Date.now()}`);
+    dbPath = join(dataDir, "test.db");
+    db = new AQDatabase(dbPath);
+  });
+
+  afterEach(() => {
+    db?.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // getJobStats
+  // ────────────────────────────────────────────────────────────
+  describe("getJobStats", () => {
+    it("returns all-zero stats for empty db", () => {
+      const result = getJobStats(db, { timeRange: "all" });
+      expect(result.total).toBe(0);
+      expect(result.successCount).toBe(0);
+      expect(result.failureCount).toBe(0);
+      expect(result.runningCount).toBe(0);
+      expect(result.queuedCount).toBe(0);
+      expect(result.cancelledCount).toBe(0);
+      expect(result.avgDurationMs).toBe(0);
+      expect(result.successRate).toBe(0);
+      expect(result.project).toBeNull();
+      expect(result.timeRange).toBe("all");
+    });
+
+    it("counts jobs by status correctly", () => {
+      db.createJob(makeJob({ id: "j1", status: "success" }));
+      db.createJob(makeJob({ id: "j2", status: "success" }));
+      db.createJob(makeJob({ id: "j3", status: "failure" }));
+      db.createJob(makeJob({ id: "j4", status: "running" }));
+      db.createJob(makeJob({ id: "j5", status: "queued" }));
+      db.createJob(makeJob({ id: "j6", status: "cancelled" }));
+
+      const result = getJobStats(db, { timeRange: "all" });
+      expect(result.total).toBe(6);
+      expect(result.successCount).toBe(2);
+      expect(result.failureCount).toBe(1);
+      expect(result.runningCount).toBe(1);
+      expect(result.queuedCount).toBe(1);
+      expect(result.cancelledCount).toBe(1);
+    });
+
+    it("calculates successRate correctly", () => {
+      db.createJob(makeJob({ id: "j1", status: "success" }));
+      db.createJob(makeJob({ id: "j2", status: "success" }));
+      db.createJob(makeJob({ id: "j3", status: "failure" }));
+      db.createJob(makeJob({ id: "j4", status: "failure" }));
+
+      const result = getJobStats(db, { timeRange: "all" });
+      expect(result.successRate).toBe(50);
+    });
+
+    it("calculates avgDurationMs for completed jobs", () => {
+      const startedAt = new Date("2024-01-01T10:00:00.000Z").toISOString();
+      const completedAt = new Date("2024-01-01T10:00:02.000Z").toISOString(); // +2000ms
+      db.createJob(makeJob({ id: "j1", status: "success", startedAt, completedAt }));
+
+      const result = getJobStats(db, { timeRange: "all" });
+      expect(result.avgDurationMs).toBeCloseTo(2000, -1);
+    });
+
+    it("ignores jobs without completedAt in avgDurationMs", () => {
+      const startedAt = new Date().toISOString();
+      db.createJob(makeJob({ id: "j1", status: "running", startedAt })); // no completedAt
+
+      const result = getJobStats(db, { timeRange: "all" });
+      expect(result.avgDurationMs).toBe(0);
+    });
+
+    describe("project filter", () => {
+      beforeEach(() => {
+        db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success" }));
+        db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "failure" }));
+        db.createJob(makeJob({ id: "j3", repo: "org/beta", status: "success" }));
+      });
+
+      it("returns stats for all projects when project is undefined", () => {
+        const result = getJobStats(db, { timeRange: "all" });
+        expect(result.total).toBe(3);
+        expect(result.project).toBeNull();
+      });
+
+      it("filters by project", () => {
+        const result = getJobStats(db, { project: "org/alpha", timeRange: "all" });
+        expect(result.total).toBe(2);
+        expect(result.successCount).toBe(1);
+        expect(result.failureCount).toBe(1);
+        expect(result.project).toBe("org/alpha");
+      });
+
+      it("returns zero total for unknown project", () => {
+        const result = getJobStats(db, { project: "org/unknown", timeRange: "all" });
+        expect(result.total).toBe(0);
+      });
+    });
+
+    describe("timeRange filter", () => {
+      beforeEach(() => {
+        db.createJob(makeJob({ id: "j-12h", status: "success", createdAt: daysAgo(0.5) }));
+        db.createJob(makeJob({ id: "j-3d", status: "success", createdAt: daysAgo(3) }));
+        db.createJob(makeJob({ id: "j-10d", status: "success", createdAt: daysAgo(10) }));
+        db.createJob(makeJob({ id: "j-35d", status: "failure", createdAt: daysAgo(35) }));
+      });
+
+      it("timeRange=24h returns only recent jobs", () => {
+        const result = getJobStats(db, { timeRange: "24h" });
+        expect(result.total).toBe(1);
+      });
+
+      it("timeRange=7d returns jobs within 7 days", () => {
+        const result = getJobStats(db, { timeRange: "7d" });
+        expect(result.total).toBe(2);
+      });
+
+      it("timeRange=30d returns jobs within 30 days", () => {
+        const result = getJobStats(db, { timeRange: "30d" });
+        expect(result.total).toBe(3);
+      });
+
+      it("timeRange=all returns all jobs", () => {
+        const result = getJobStats(db, { timeRange: "all" });
+        expect(result.total).toBe(4);
+      });
+    });
+
+    it("combines project and timeRange filters", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", createdAt: daysAgo(1) }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "success", createdAt: daysAgo(10) }));
+      db.createJob(makeJob({ id: "j3", repo: "org/beta", status: "success", createdAt: daysAgo(1) }));
+
+      const result = getJobStats(db, { project: "org/alpha", timeRange: "7d" });
+      expect(result.total).toBe(1);
+      expect(result.project).toBe("org/alpha");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // getCostStats
+  // ────────────────────────────────────────────────────────────
+  describe("getCostStats", () => {
+    it("returns zero summary for empty db", () => {
+      const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+      expect(result.summary.totalCostUsd).toBe(0);
+      expect(result.summary.jobCount).toBe(0);
+      expect(result.summary.avgCostUsd).toBe(0);
+      expect(result.breakdown).toHaveLength(0);
+      expect(result.project).toBeNull();
+    });
+
+    it("aggregates cost across all jobs", () => {
+      db.createJob(makeJob({
+        id: "j1", status: "success",
+        totalCostUsd: 1.0,
+        totalUsage: { input_tokens: 100, output_tokens: 50 },
+      }));
+      db.createJob(makeJob({
+        id: "j2", status: "success",
+        totalCostUsd: 2.0,
+        totalUsage: { input_tokens: 200, output_tokens: 100 },
+      }));
+
+      const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+      expect(result.summary.totalCostUsd).toBeCloseTo(3.0);
+      expect(result.summary.jobCount).toBe(2);
+      expect(result.summary.avgCostUsd).toBeCloseTo(1.5);
+      expect(result.summary.totalInputTokens).toBe(300);
+      expect(result.summary.totalOutputTokens).toBe(150);
+    });
+
+    it("handles jobs with null cost (treats as 0)", () => {
+      db.createJob(makeJob({ id: "j1", status: "success" })); // no cost fields
+      const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+      expect(result.summary.totalCostUsd).toBe(0);
+      expect(result.summary.jobCount).toBe(1);
+    });
+
+    describe("groupBy=project", () => {
+      beforeEach(() => {
+        db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", totalCostUsd: 1.0 }));
+        db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "success", totalCostUsd: 2.0 }));
+        db.createJob(makeJob({ id: "j3", repo: "org/beta", status: "success", totalCostUsd: 5.0 }));
+      });
+
+      it("produces one breakdown entry per repo", () => {
+        const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+        expect(result.breakdown).toHaveLength(2);
+      });
+
+      it("sums cost per repo correctly", () => {
+        const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+        const alpha = result.breakdown.find(e => e.label === "org/alpha");
+        const beta = result.breakdown.find(e => e.label === "org/beta");
+
+        expect(alpha).toBeDefined();
+        expect(alpha?.totalCostUsd).toBeCloseTo(3.0);
+        expect(alpha?.jobCount).toBe(2);
+        expect(alpha?.avgCostUsd).toBeCloseTo(1.5);
+
+        expect(beta).toBeDefined();
+        expect(beta?.totalCostUsd).toBeCloseTo(5.0);
+        expect(beta?.jobCount).toBe(1);
+      });
+    });
+
+    describe("groupBy=day", () => {
+      it("groups jobs by date", () => {
+        db.createJob(makeJob({ id: "j1", status: "success", totalCostUsd: 1.0, createdAt: "2024-01-10T10:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j2", status: "success", totalCostUsd: 2.0, createdAt: "2024-01-10T20:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j3", status: "success", totalCostUsd: 3.0, createdAt: "2024-01-11T10:00:00.000Z" }));
+
+        const result = getCostStats(db, { timeRange: "all", groupBy: "day" });
+        expect(result.breakdown).toHaveLength(2);
+
+        const jan10 = result.breakdown.find(e => e.label === "2024-01-10");
+        expect(jan10?.totalCostUsd).toBeCloseTo(3.0);
+        expect(jan10?.jobCount).toBe(2);
+      });
+    });
+
+    describe("groupBy=week", () => {
+      it("groups jobs by ISO week", () => {
+        db.createJob(makeJob({ id: "j1", status: "success", totalCostUsd: 1.0, createdAt: "2024-01-08T10:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j2", status: "success", totalCostUsd: 2.0, createdAt: "2024-01-08T20:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j3", status: "success", totalCostUsd: 3.0, createdAt: "2024-01-15T10:00:00.000Z" }));
+
+        const result = getCostStats(db, { timeRange: "all", groupBy: "week" });
+        expect(result.breakdown).toHaveLength(2);
+      });
+    });
+
+    describe("groupBy=month", () => {
+      it("groups jobs by year-month", () => {
+        db.createJob(makeJob({ id: "j1", status: "success", totalCostUsd: 1.0, createdAt: "2024-01-10T10:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j2", status: "success", totalCostUsd: 2.0, createdAt: "2024-01-20T10:00:00.000Z" }));
+        db.createJob(makeJob({ id: "j3", status: "success", totalCostUsd: 3.0, createdAt: "2024-02-05T10:00:00.000Z" }));
+
+        const result = getCostStats(db, { timeRange: "all", groupBy: "month" });
+        expect(result.breakdown).toHaveLength(2);
+
+        const jan = result.breakdown.find(e => e.label === "2024-01");
+        expect(jan?.totalCostUsd).toBeCloseTo(3.0);
+        expect(jan?.jobCount).toBe(2);
+      });
+    });
+
+    describe("project filter", () => {
+      it("filters breakdown and summary by project", () => {
+        db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", totalCostUsd: 1.0 }));
+        db.createJob(makeJob({ id: "j2", repo: "org/beta", status: "success", totalCostUsd: 9.0 }));
+
+        const result = getCostStats(db, { project: "org/alpha", timeRange: "all", groupBy: "project" });
+        expect(result.summary.totalCostUsd).toBeCloseTo(1.0);
+        expect(result.summary.jobCount).toBe(1);
+        expect(result.breakdown).toHaveLength(1);
+        expect(result.breakdown[0].label).toBe("org/alpha");
+        expect(result.project).toBe("org/alpha");
+      });
+    });
+
+    describe("timeRange filter", () => {
+      it("filters by 7d time range", () => {
+        db.createJob(makeJob({ id: "j1", status: "success", totalCostUsd: 1.0, createdAt: daysAgo(3) }));
+        db.createJob(makeJob({ id: "j2", status: "success", totalCostUsd: 2.0, createdAt: daysAgo(10) }));
+
+        const result = getCostStats(db, { timeRange: "7d", groupBy: "project" });
+        expect(result.summary.jobCount).toBe(1);
+        expect(result.summary.totalCostUsd).toBeCloseTo(1.0);
+      });
+    });
+
+    it("includes cache token fields in breakdown", () => {
+      db.createJob(makeJob({
+        id: "j1", status: "success",
+        totalCostUsd: 1.0,
+        totalUsage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 20,
+          cache_read_input_tokens: 30,
+        },
+      }));
+
+      const result = getCostStats(db, { timeRange: "all", groupBy: "project" });
+      expect(result.summary.totalCacheCreationTokens).toBe(20);
+      expect(result.summary.totalCacheReadTokens).toBe(30);
+      expect(result.breakdown[0].totalCacheCreationTokens).toBe(20);
+      expect(result.breakdown[0].totalCacheReadTokens).toBe(30);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // getProjectSummary
+  // ────────────────────────────────────────────────────────────
+  describe("getProjectSummary", () => {
+    it("returns empty array for empty db", () => {
+      const result = getProjectSummary(db);
+      expect(result).toHaveLength(0);
+    });
+
+    it("groups jobs by repo", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success" }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "failure" }));
+      db.createJob(makeJob({ id: "j3", repo: "org/beta", status: "success" }));
+
+      const result = getProjectSummary(db);
+      expect(result).toHaveLength(2);
+    });
+
+    it("calculates successCount, failureCount per repo", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success" }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "success" }));
+      db.createJob(makeJob({ id: "j3", repo: "org/alpha", status: "failure" }));
+
+      const result = getProjectSummary(db);
+      const alpha = result.find(r => r.repo === "org/alpha");
+      expect(alpha?.total).toBe(3);
+      expect(alpha?.successCount).toBe(2);
+      expect(alpha?.failureCount).toBe(1);
+    });
+
+    it("calculates successRate per repo", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success" }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "failure" }));
+      db.createJob(makeJob({ id: "j3", repo: "org/alpha", status: "failure" }));
+      db.createJob(makeJob({ id: "j4", repo: "org/alpha", status: "failure" }));
+
+      const result = getProjectSummary(db);
+      const alpha = result.find(r => r.repo === "org/alpha");
+      expect(alpha?.successRate).toBe(25);
+    });
+
+    it("aggregates totalCostUsd per repo", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", totalCostUsd: 1.5 }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "success", totalCostUsd: 2.5 }));
+      db.createJob(makeJob({ id: "j3", repo: "org/beta", status: "success", totalCostUsd: 10.0 }));
+
+      const result = getProjectSummary(db);
+      const alpha = result.find(r => r.repo === "org/alpha");
+      expect(alpha?.totalCostUsd).toBeCloseTo(4.0);
+    });
+
+    it("orders repos by last_activity DESC", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", createdAt: daysAgo(5) }));
+      db.createJob(makeJob({ id: "j2", repo: "org/beta", status: "success", createdAt: daysAgo(1) }));
+      db.createJob(makeJob({ id: "j3", repo: "org/gamma", status: "success", createdAt: daysAgo(3) }));
+
+      const result = getProjectSummary(db);
+      expect(result[0].repo).toBe("org/beta");
+      expect(result[1].repo).toBe("org/gamma");
+      expect(result[2].repo).toBe("org/alpha");
+    });
+
+    it("sets lastActivity to max createdAt within a repo", () => {
+      const older = daysAgo(5);
+      const newer = daysAgo(1);
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success", createdAt: older }));
+      db.createJob(makeJob({ id: "j2", repo: "org/alpha", status: "success", createdAt: newer }));
+
+      const result = getProjectSummary(db);
+      const alpha = result.find(r => r.repo === "org/alpha");
+      expect(alpha?.lastActivity).toBe(newer);
+    });
+
+    it("treats jobs with no cost as 0 in totalCostUsd", () => {
+      db.createJob(makeJob({ id: "j1", repo: "org/alpha", status: "success" })); // no totalCostUsd
+
+      const result = getProjectSummary(db);
+      expect(result[0].totalCostUsd).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #261 — feat: 통계/분석 쿼리 API — 프로젝트별/기간별/비용별 집계

현재 /api/stats 엔드포인트는 store.list()로 전체 Job을 메모리에 로드한 후 JavaScript로 필터링/집계하는 비효율적인 방식입니다. SQLite에 이미 cost_usd, total_cost_usd, 토큰 사용량 등의 필드가 있으므로, 효율적인 SQL 쿼리 기반 집계로 전환하고 비용 분석 API를 추가해야 합니다.

## Requirements

- GET /api/stats 강화 — SQLite 쿼리 기반 프로젝트별/기간별 집계
- GET /api/stats/costs 신규 — 이슈당/프로젝트당 비용 분석 API
- src/store/queries.ts 신규 — 통계 쿼리 함수 모음 (getJobStats, getCostStats 등)
- 기존 GetStatsQuerySchema 활용 및 GetCostsQuerySchema 추가
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: 타입 정의 확장 — SUCCESS (5b23ec34)
- Phase 1: queries.ts 통계 쿼리 모듈 생성 — SUCCESS (92b4a0ba)
- Phase 2: dashboard-api.ts stats API 확장 — SUCCESS (bfa0042c)
- Phase 3: 테스트 작성 — SUCCESS (bfa0042c)

## Risks

- SQLite 쿼리 성능 — 대용량 데이터 시 인덱스 활용 필수
- 기존 /api/stats 응답 형식 변경 시 프론트엔드 호환성
- AQDatabase 클래스에 raw SQL 쿼리 메서드 추가 필요 여부

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/261-feat-api` → `develop`
- **Tokens**: 232 input, 31665 output{{#stats.cacheCreationTokens}}, 199873 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3257681 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #261