### PR TITLE
[AQ-#348] feat: config safety.rules 필드 추가 — allow/deny 패턴 선언

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -152,6 +152,10 @@ export const DEFAULT_CONFIG: AQConfig = {
       ],
     },
     strict: true,
+    rules: {
+      allow: [],
+      deny: [],
+    },
   },
   features: {
     parallelPhases: false,  // 안정성을 위해 기본값은 false

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -261,6 +261,11 @@ const timeoutsConfigSchema = z.object({
   prCreation: z.number().positive(),
 });
 
+const safetyRulesSchema = z.object({
+  allow: z.array(z.string()),
+  deny: z.array(z.string()),
+});
+
 const safetyConfigSchema = z.object({
   sensitivePaths: z.array(z.string()),
   maxPhases: z.number().int().min(1).max(20),
@@ -276,6 +281,7 @@ const safetyConfigSchema = z.object({
   allowedLabels: z.array(z.string()),
   rollbackStrategy: z.enum(["none", "all", "failed-only"]),
   strict: z.boolean().default(true),
+  rules: safetyRulesSchema.default({ allow: [], deny: [] }),
 });
 
 const featuresConfigSchema = z.object({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -140,6 +140,11 @@ export interface FeasibilityCheckConfig {
   skipReasons: string[];
 }
 
+export interface SafetyRules {
+  allow: string[];
+  deny: string[];
+}
+
 export interface SafetyConfig {
   sensitivePaths: string[];
   maxPhases: number;
@@ -156,6 +161,7 @@ export interface SafetyConfig {
   rollbackStrategy: "none" | "all" | "failed-only";
   feasibilityCheck: FeasibilityCheckConfig;
   strict: boolean;
+  rules: SafetyRules;
 }
 
 export interface FeaturesConfig {

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -116,6 +116,10 @@ describe("validateConfig", () => {
       allowedLabels: ["bug", "feature"],
       rollbackStrategy: "none",
       strict: false,
+      rules: {
+        allow: [],
+        deny: [],
+      },
     },
     features: {
       parallelPhases: false,


### PR DESCRIPTION
## Summary

Resolves #348 — feat: config safety.rules 필드 추가 — allow/deny 패턴 선언

현재 SafetyConfig에는 sensitivePaths로 민감 경로만 정의할 수 있으나, 사용자가 allow/deny glob 패턴을 선언적으로 설정하여 더 유연한 파일 접근 제어가 필요하다. safety.rules 필드를 추가하여 allow와 deny 패턴 배열을 지원해야 한다.

## Requirements

- src/types/config.ts에 SafetyRules 인터페이스 및 safety.rules 타입 추가 (allow/deny glob 패턴 배열)
- src/config/defaults.ts에 safety.rules 기본값 추가 (빈 배열)
- src/config/validator.ts에 safetyRulesSchema Zod 검증 추가 및 safetyConfigSchema에 통합

## Implementation Phases

- Phase 0: safety.rules 타입, 기본값, 검증 추가 — SUCCESS (7dcdd33c)

## Risks

- 3곳 중 하나라도 누락 시 타입 에러 또는 런타임 검증 실패
- Zod 스키마와 TypeScript 타입 불일치 가능성

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/348-feat-config-safety-rules-allow-deny` → `develop`
- **Tokens**: 25 input, 2080 output{{#stats.cacheCreationTokens}}, 46551 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 77686 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #348