### PR TITLE
[AQ-#349] feat: safety rule-engine 신규 생성 — glob 패턴 매칭 규칙 엔진

### DIFF
--- a/src/safety/rule-engine.ts
+++ b/src/safety/rule-engine.ts
@@ -1,0 +1,77 @@
+import { minimatch } from "minimatch";
+import { SafetyViolationError } from "../types/errors.js";
+
+export interface RuleSet {
+  allow: string[];
+  deny: string[];
+  /** "allow-first": allow 매칭 시 통과, 이후 deny 검사. "deny-first": deny 매칭 시 즉시 차단. default: "deny-first" */
+  strategy?: "allow-first" | "deny-first";
+}
+
+/**
+ * Checks a file path against allow/deny glob rules.
+ *
+ * deny-first (default): deny 패턴 매칭 → 차단. allow 패턴으로 예외 허용 없음.
+ * allow-first: allow 패턴 매칭 → 통과. allow에 없으면 deny 패턴 검사.
+ *
+ * Throws SafetyViolationError if the path is denied.
+ */
+export function checkPathAgainstRules(path: string, rules: RuleSet): void {
+  const strategy = rules.strategy ?? "deny-first";
+  const opts = { dot: true };
+
+  if (strategy === "allow-first") {
+    const allowed = rules.allow.some((pattern) => minimatch(path, pattern, opts));
+    if (allowed) return;
+
+    const denied = rules.deny.some((pattern) => minimatch(path, pattern, opts));
+    if (denied) {
+      throw new SafetyViolationError(
+        "RuleEngine",
+        `Path "${path}" is denied by rule (strategy: allow-first)`,
+        { path, matchedDenyPattern: rules.deny.find((p) => minimatch(path, p, opts)) }
+      );
+    }
+  } else {
+    // deny-first
+    const matchedDeny = rules.deny.find((pattern) => minimatch(path, pattern, opts));
+    if (matchedDeny) {
+      const allowOverride = rules.allow.some((pattern) => minimatch(path, pattern, opts));
+      if (!allowOverride) {
+        throw new SafetyViolationError(
+          "RuleEngine",
+          `Path "${path}" is denied by rule "${matchedDeny}" (strategy: deny-first)`,
+          { path, matchedDenyPattern: matchedDeny }
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Checks multiple file paths against allow/deny glob rules.
+ * Collects all violations and throws a single SafetyViolationError.
+ */
+export function checkPathsAgainstRules(paths: string[], rules: RuleSet): void {
+  const violations: string[] = [];
+
+  for (const path of paths) {
+    try {
+      checkPathAgainstRules(path, rules);
+    } catch (err: unknown) {
+      if (err instanceof SafetyViolationError) {
+        violations.push(err.message);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new SafetyViolationError(
+      "RuleEngine",
+      `Rule violations detected:\n${violations.join("\n")}`,
+      { violations }
+    );
+  }
+}

--- a/tests/safety/rule-engine.test.ts
+++ b/tests/safety/rule-engine.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { checkPathAgainstRules, checkPathsAgainstRules } from "../../src/safety/rule-engine.js";
+import { SafetyViolationError } from "../../src/types/errors.js";
+import type { RuleSet } from "../../src/safety/rule-engine.js";
+
+describe("checkPathAgainstRules", () => {
+  describe("deny-first (default)", () => {
+    const rules: RuleSet = {
+      allow: [],
+      deny: ["**/.env*", "**/secrets/**"],
+    };
+
+    it("should pass for non-matching path", () => {
+      expect(() => checkPathAgainstRules("src/app.ts", rules)).not.toThrow();
+    });
+
+    it("should throw for denied path", () => {
+      expect(() => checkPathAgainstRules(".env.local", rules)).toThrow(SafetyViolationError);
+    });
+
+    it("should throw for denied nested path", () => {
+      expect(() => checkPathAgainstRules("config/secrets/key.json", rules)).toThrow(SafetyViolationError);
+    });
+
+    it("should allow override: allow pattern exempts denied path", () => {
+      const overrideRules: RuleSet = {
+        allow: ["config/secrets/allowed.json"],
+        deny: ["**/secrets/**"],
+      };
+      expect(() => checkPathAgainstRules("config/secrets/allowed.json", overrideRules)).not.toThrow();
+    });
+
+    it("error details contain path and matchedDenyPattern", () => {
+      try {
+        checkPathAgainstRules(".env", rules);
+        expect.fail("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(SafetyViolationError);
+        if (err instanceof SafetyViolationError) {
+          expect(err.details?.path).toBe(".env");
+          expect(err.details?.matchedDenyPattern).toBe("**/.env*");
+        }
+      }
+    });
+  });
+
+  describe("allow-first strategy", () => {
+    const rules: RuleSet = {
+      allow: ["src/**"],
+      deny: ["**/*.secret.ts"],
+      strategy: "allow-first",
+    };
+
+    it("should pass for allowed path even if deny pattern could match", () => {
+      // src/** matches → allowed regardless of deny
+      expect(() => checkPathAgainstRules("src/utils.ts", rules)).not.toThrow();
+    });
+
+    it("should pass for path not in allow and not in deny", () => {
+      expect(() => checkPathAgainstRules("README.md", rules)).not.toThrow();
+    });
+
+    it("should throw for path not in allow but in deny", () => {
+      expect(() => checkPathAgainstRules("config/db.secret.ts", rules)).toThrow(SafetyViolationError);
+    });
+
+    it("should pass for empty allow/deny", () => {
+      const emptyRules: RuleSet = { allow: [], deny: [], strategy: "allow-first" };
+      expect(() => checkPathAgainstRules("anything.ts", emptyRules)).not.toThrow();
+    });
+  });
+});
+
+describe("checkPathsAgainstRules", () => {
+  const rules: RuleSet = {
+    allow: [],
+    deny: ["**/.env*", "**/secrets/**"],
+  };
+
+  it("should pass when no paths violate rules", () => {
+    expect(() => checkPathsAgainstRules(["src/app.ts", "tests/app.test.ts"], rules)).not.toThrow();
+  });
+
+  it("should throw when one path violates", () => {
+    expect(() => checkPathsAgainstRules(["src/app.ts", ".env.local"], rules)).toThrow(SafetyViolationError);
+  });
+
+  it("should collect all violations in single error", () => {
+    try {
+      checkPathsAgainstRules([".env", "config/secrets/key.json", "src/ok.ts"], rules);
+      expect.fail("should have thrown");
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(SafetyViolationError);
+      if (err instanceof SafetyViolationError) {
+        const violations = err.details?.violations as string[];
+        expect(violations).toHaveLength(2);
+      }
+    }
+  });
+
+  it("should pass on empty paths array", () => {
+    expect(() => checkPathsAgainstRules([], rules)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #349 — feat: safety rule-engine 신규 생성 — glob 패턴 매칭 규칙 엔진

현재 safety 모듈에는 하드코딩된 sensitivePaths 검증만 존재하며, 사용자가 allow/deny 규칙을 유연하게 정의할 방법이 없습니다. glob 패턴 기반의 규칙 엔진을 도입하여 파일 경로 검증을 구성 가능하게 만들어야 합니다.

## Requirements

- src/safety/rule-engine.ts 신규 생성
- allow/deny glob 패턴 목록으로 파일 경로 검증 함수 구현
- minimatch 기반 매칭 (프로젝트 기존 패턴 활용)
- 테스트 추가 (tests/safety/rule-engine.test.ts)
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: Rule Engine 구현 — SUCCESS (d33b8ee7)
- Phase 1: 테스트 작성 — SUCCESS (d33b8ee7)

## Risks

- config safety.rules 필드가 별도 이슈로 처리되므로, 인터페이스 설계 시 향후 통합 고려 필요
- glob 패턴 복잡도에 따른 성능 이슈 가능성

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/349-feat-safety-rule-engine-glob` → `develop`
- **Tokens**: 86 input, 9199 output{{#stats.cacheCreationTokens}}, 107076 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 767399 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #349