### PR TITLE
[AQ-#347] feat: Repositories 뷰 UI — 프로젝트별 카드 그리드 + 스토리지 관리

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -488,14 +488,93 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     </div>
   </div>
 
-  <!-- ============ Coming Soon Views ============ -->
+  <!-- ============ Repositories View ============ -->
   <div id="view-repositories" class="view-panel">
-    <div class="flex flex-col items-center justify-center py-32 text-center">
-      <span class="material-symbols-outlined text-6xl text-outline/20 mb-4">inventory_2</span>
-      <h2 class="text-lg font-headline font-bold text-on-surface mb-2" data-i18n="repositories">Repositories</h2>
-      <p class="text-sm text-outline" data-i18n="comingSoon">Coming Soon</p>
+
+    <!-- Section Header -->
+    <div class="flex items-end justify-between mb-8">
+      <div>
+        <h2 class="text-sm font-headline font-bold text-on-surface uppercase tracking-widest flex items-center gap-2 mb-2">
+          <span class="w-1 h-4 bg-primary-container rounded-full"></span>
+          <span data-i18n="repositories">Repositories</span>
+        </h2>
+        <p class="text-outline font-body text-sm" data-i18n="repositories.subtitle">등록된 레포지토리와 스토리지 사용량을 관리합니다.</p>
+      </div>
+      <!-- Storage Stats -->
+      <div class="flex gap-3">
+        <div class="bg-surface-container p-4 rounded-xl flex items-center gap-3 ring-1 ring-outline-variant/10">
+          <span class="material-symbols-outlined text-primary-container">database</span>
+          <div>
+            <p class="text-[10px] font-headline uppercase tracking-widest text-outline" data-i18n="repositories.totalDbSize">Total DB Size</p>
+            <p id="repo-stat-db-size" class="text-base font-mono font-medium text-on-surface">—</p>
+          </div>
+        </div>
+        <div class="bg-surface-container p-4 rounded-xl flex items-center gap-3 ring-1 ring-outline-variant/10">
+          <span class="material-symbols-outlined text-tertiary">description</span>
+          <div>
+            <p class="text-[10px] font-headline uppercase tracking-widest text-outline" data-i18n="repositories.logVolume">Log Volume</p>
+            <p id="repo-stat-log-size" class="text-base font-mono font-medium text-on-surface">—</p>
+          </div>
+        </div>
+      </div>
     </div>
+
+    <!-- Repository Card Grid -->
+    <div id="repo-card-grid" class="grid grid-cols-1 xl:grid-cols-2 gap-6 mb-8">
+
+      <!-- Add Repository Card (static) -->
+      <div class="group h-full min-h-[300px] rounded-xl border-2 border-dashed border-outline-variant flex flex-col items-center justify-center hover:border-primary-container hover:bg-primary-container/5 transition-all cursor-pointer" onclick="showAddRepositoryDialog()">
+        <div class="w-14 h-14 rounded-full bg-surface-container flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
+          <span class="material-symbols-outlined text-2xl text-outline group-hover:text-primary-container">add</span>
+        </div>
+        <span class="font-headline font-bold text-sm tracking-widest text-outline group-hover:text-on-surface" data-i18n="repositories.addRepo">ADD REPOSITORY</span>
+        <p class="text-xs text-outline/50 mt-2 font-body" data-i18n="repositories.addRepoDesc">새 Git 레포지토리를 연결합니다</p>
+      </div>
+
+      <!-- Dynamic repository cards will be injected here by render.js -->
+      <!-- Placeholder shown while loading -->
+      <div id="repo-loading-placeholder" class="bg-surface-container rounded-xl p-6 flex flex-col items-center justify-center min-h-[300px] ring-1 ring-outline-variant/10">
+        <span class="material-symbols-outlined text-4xl text-outline/20 mb-3 animate-pulse">inventory_2</span>
+        <p class="text-sm text-outline font-body" data-i18n="repositories.loading">로딩 중...</p>
+      </div>
+
+    </div>
+
+    <!-- Storage Management Section -->
+    <div class="relative overflow-hidden rounded-xl bg-surface-container ring-1 ring-outline-variant/10 p-6 flex flex-col md:flex-row items-center justify-between gap-6">
+      <!-- Left: description -->
+      <div class="flex-1 space-y-3">
+        <div class="flex items-center gap-3">
+          <div class="p-2 bg-primary/10 rounded-lg">
+            <span class="material-symbols-outlined text-primary">auto_delete</span>
+          </div>
+          <h3 class="text-base font-headline font-bold" data-i18n="repositories.storageMgmt">스토리지 관리</h3>
+        </div>
+        <p class="text-outline text-sm leading-relaxed max-w-xl font-body" data-i18n="repositories.storageDesc">
+          AQM은 기본적으로 텔레메트리 데이터를 30일간 보관합니다. 오래된 데이터를 정리하여 디스크 공간을 확보할 수 있습니다.
+        </p>
+      </div>
+      <!-- Right: retention bar + action -->
+      <div class="flex items-center gap-8">
+        <div>
+          <p class="text-[10px] font-headline uppercase tracking-widest text-outline mb-2" data-i18n="repositories.retention">데이터 보관율</p>
+          <div class="h-2 w-48 bg-surface-container-highest rounded-full overflow-hidden">
+            <div id="repo-retention-bar" class="h-full bg-gradient-to-r from-primary to-primary-container rounded-full transition-all duration-500" style="width: 0%;"></div>
+          </div>
+          <p id="repo-retention-label" class="text-xs font-mono mt-2 text-primary-container">—</p>
+        </div>
+        <button onclick="cleanOldData()" class="flex items-center gap-2 px-5 py-2.5 bg-surface-container-highest border border-outline-variant/20 text-on-surface font-headline font-bold text-xs tracking-widest uppercase rounded-lg hover:bg-surface-bright hover:border-primary/30 active:scale-95 transition-all">
+          <span class="material-symbols-outlined text-sm">cleaning_services</span>
+          <span data-i18n="repositories.cleanData">오래된 데이터 정리</span>
+        </button>
+      </div>
+      <!-- Decorative bottom line -->
+      <div class="absolute bottom-0 left-0 w-full h-[2px] bg-gradient-to-r from-transparent via-primary/20 to-transparent"></div>
+    </div>
+
   </div>
+
+  <!-- ============ Coming Soon Views ============ -->
   <div id="view-automations" class="view-panel">
     <div class="flex flex-col items-center justify-center py-32 text-center">
       <span class="material-symbols-outlined text-6xl text-outline/20 mb-4">precision_manufacturing</span>

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -42,6 +42,11 @@ function navigateTo(view) {
   if (view === 'settings') {
     loadSettings();
   }
+
+  // If navigating to repositories view, render it
+  if (view === 'repositories') {
+    renderRepositoriesView(MOCK_REPOS, MOCK_STORAGE);
+  }
 }
 
 // Bind navigation clicks

--- a/src/server/public/js/i18n.js
+++ b/src/server/public/js/i18n.js
@@ -7,7 +7,19 @@ var i18n = {
   ko: {
     dashboard: "대시보드",
     logs: "로그",
-    repositories: "저장소",
+    repositories: {
+      _: "저장소",
+      subtitle: "등록된 레포지토리와 스토리지 사용량을 관리합니다.",
+      totalDbSize: "전체 DB 크기",
+      logVolume: "로그 볼륨",
+      addRepo: "저장소 추가",
+      addRepoDesc: "새 Git 레포지토리를 연결합니다",
+      loading: "로딩 중...",
+      storageMgmt: "스토리지 관리",
+      storageDesc: "AQM은 기본적으로 텔레메트리 데이터를 30일간 보관합니다. 오래된 데이터를 정리하여 디스크 공간을 확보할 수 있습니다.",
+      retention: "데이터 보관율",
+      cleanData: "오래된 데이터 정리"
+    },
     automations: "자동화",
     settings: { _: "설정", general: "일반", safety: "안전", review: "리뷰" },
     totalJobs: "전체 작업",
@@ -66,7 +78,19 @@ var i18n = {
   en: {
     dashboard: "Dashboard",
     logs: "Logs",
-    repositories: "Repositories",
+    repositories: {
+      _: "Repositories",
+      subtitle: "Manage registered repositories and storage usage.",
+      totalDbSize: "Total DB Size",
+      logVolume: "Log Volume",
+      addRepo: "Add Repository",
+      addRepoDesc: "Connect a new Git repository",
+      loading: "Loading...",
+      storageMgmt: "Storage Management",
+      storageDesc: "AQM retains telemetry data for 30 days by default. Clean up old data to free disk space.",
+      retention: "Data Retention",
+      cleanData: "Clean Old Data"
+    },
     automations: "Automations",
     settings: { _: "Settings", general: "General", safety: "Safety", review: "Review" },
     totalJobs: "Total Jobs",

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -709,6 +709,209 @@ function renderObjectInput(fieldId, value, configPath, isReadonly) {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   Repositories View
+   ══════════════════════════════════════════════════════════════ */
+
+var MOCK_REPOS = [
+  {
+    repo: 'myorg/api-service',
+    path: '/home/user/workspace/api-service',
+    baseBranch: 'main',
+    totalJobs: 23,
+    successRate: 87,
+    totalCostUsd: 4.32,
+    worktreeCount: 2,
+    lastActiveAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    isActive: true,
+    health: 'stable'
+  },
+  {
+    repo: 'myorg/frontend',
+    path: '/home/user/workspace/frontend',
+    baseBranch: 'develop',
+    totalJobs: 8,
+    successRate: 100,
+    totalCostUsd: 1.20,
+    worktreeCount: 1,
+    lastActiveAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    isActive: false,
+    health: 'local-missing'
+  }
+];
+
+var MOCK_STORAGE = {
+  dbSizeBytes: 1288490188,
+  logSizeBytes: 471859200,
+  retentionPct: 65
+};
+
+function fmtBytes(bytes) {
+  if (bytes === null || bytes === undefined) return '—';
+  if (bytes >= 1073741824) return (bytes / 1073741824).toFixed(1) + ' GB';
+  if (bytes >= 1048576) return (bytes / 1048576).toFixed(0) + ' MB';
+  if (bytes >= 1024) return (bytes / 1024).toFixed(0) + ' KB';
+  return bytes + ' B';
+}
+
+function renderRepoCard(repo) {
+  var isActive = repo.isActive;
+  var health = repo.health || 'stable';
+
+  var statusBadge = isActive
+    ? '<div class="flex items-center gap-2 px-3 py-1 bg-surface-container-lowest rounded-full">' +
+        '<span class="w-2 h-2 rounded-full bg-[#3fb950] animate-pulse"></span>' +
+        '<span class="text-[10px] font-headline font-bold uppercase tracking-tighter">Active</span>' +
+      '</div>'
+    : '<div class="flex items-center gap-2 px-3 py-1 bg-surface-container-lowest rounded-full">' +
+        '<span class="w-2 h-2 rounded-full bg-outline"></span>' +
+        '<span class="text-[10px] font-headline font-bold uppercase tracking-tighter text-outline">Inactive</span>' +
+      '</div>';
+
+  var healthHtml = (health === 'local-missing')
+    ? '<div class="flex gap-1 items-center">' +
+        '<span class="w-1.5 h-1.5 rounded-full bg-[#3fb950]"></span>' +
+        '<span class="w-1.5 h-1.5 rounded-full bg-error"></span>' +
+        '<span class="text-[10px] text-error font-bold ml-1">LOCAL MISSING</span>' +
+      '</div>'
+    : '<div class="flex gap-1 items-center">' +
+        '<span class="w-1.5 h-1.5 rounded-full bg-[#3fb950]"></span>' +
+        '<span class="w-1.5 h-1.5 rounded-full bg-[#3fb950]"></span>' +
+        '<span class="text-[10px] text-outline ml-1">STABLE</span>' +
+      '</div>';
+
+  var statsClass = isActive ? '' : ' grayscale opacity-60';
+  var successRate = (repo.successRate !== null && repo.successRate !== undefined) ? repo.successRate : null;
+  var successColor = (successRate !== null && successRate >= 90) ? 'text-[#3fb950]' : 'text-tertiary';
+  var successText = successRate !== null ? successRate + '%' : '—';
+  var costText = (repo.totalCostUsd !== null && repo.totalCostUsd !== undefined)
+    ? '$' + Number(repo.totalCostUsd).toFixed(2) : '$0.00';
+  var lastActiveText = repo.lastActiveAt ? relativeTime(repo.lastActiveAt) : '—';
+
+  var footerButtons = (health === 'local-missing')
+    ? '<div class="flex gap-2">' +
+        '<button class="px-3 py-1 bg-primary text-on-primary text-[10px] font-headline font-bold uppercase tracking-widest rounded hover:bg-primary-container transition-colors">RE-LINK</button>' +
+        '<button class="p-1.5 hover:text-error transition-colors"><span class="material-symbols-outlined text-sm">delete</span></button>' +
+      '</div>'
+    : '<div class="flex gap-2">' +
+        '<button class="p-1.5 hover:text-primary transition-colors"><span class="material-symbols-outlined text-sm">terminal</span></button>' +
+        '<button class="p-1.5 hover:text-primary transition-colors"><span class="material-symbols-outlined text-sm">sync</span></button>' +
+        '<button class="p-1.5 hover:text-error transition-colors"><span class="material-symbols-outlined text-sm">delete</span></button>' +
+      '</div>';
+
+  return '<div class="repo-card-dynamic bg-surface-container-high rounded-xl overflow-hidden flex flex-col transition-all hover:-translate-y-1 hover:shadow-2xl hover:shadow-black/40">' +
+    '<div class="p-6 flex-1">' +
+      '<div class="flex justify-between items-start mb-4">' +
+        '<div>' +
+          '<div class="flex items-center gap-2 mb-1">' +
+            '<h3 class="text-lg font-headline font-bold text-primary">' + esc(repo.repo) + '</h3>' +
+            '<span class="material-symbols-outlined text-sm text-outline">open_in_new</span>' +
+          '</div>' +
+          '<p class="text-xs font-mono text-outline">' + esc(repo.path || '') + '</p>' +
+        '</div>' +
+        statusBadge +
+      '</div>' +
+      '<div class="grid grid-cols-3 gap-4 mb-6">' +
+        '<div class="space-y-1">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline">Branch</p>' +
+          '<div class="flex items-center gap-1.5">' +
+            '<span class="material-symbols-outlined text-xs text-primary">account_tree</span>' +
+            '<span class="font-mono text-sm">' + esc(repo.baseBranch || 'main') + '</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="space-y-1">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline">Worktrees</p>' +
+          '<div class="flex items-center gap-1.5">' +
+            '<span class="material-symbols-outlined text-xs text-tertiary">layers</span>' +
+            '<span class="font-mono text-sm">' + (repo.worktreeCount || 0) + ' active</span>' +
+          '</div>' +
+        '</div>' +
+        '<div class="space-y-1">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline">Health</p>' +
+          healthHtml +
+        '</div>' +
+      '</div>' +
+      '<div class="bg-surface-container-low rounded-lg p-4 grid grid-cols-3 divide-x divide-outline-variant/20' + statsClass + '">' +
+        '<div class="px-2 text-center">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline mb-1">Jobs</p>' +
+          '<p class="text-xl font-headline font-bold">' + (repo.totalJobs || 0) + '</p>' +
+        '</div>' +
+        '<div class="px-2 text-center">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline mb-1">Success</p>' +
+          '<p class="text-xl font-headline font-bold ' + successColor + '">' + successText + '</p>' +
+        '</div>' +
+        '<div class="px-2 text-center">' +
+          '<p class="text-[10px] font-headline uppercase tracking-widest text-outline mb-1">Cost</p>' +
+          '<p class="text-xl font-headline font-bold text-tertiary">' + costText + '</p>' +
+        '</div>' +
+      '</div>' +
+    '</div>' +
+    '<div class="px-6 py-3 bg-surface-container-highest flex justify-between items-center border-t border-white/5">' +
+      '<span class="text-[10px] text-outline font-body flex items-center gap-1">' +
+        '<span class="material-symbols-outlined text-xs">schedule</span>' +
+        lastActiveText +
+      '</span>' +
+      footerButtons +
+    '</div>' +
+  '</div>';
+}
+
+function renderStorageSection(storageData) {
+  var data = storageData || {};
+  var dbSizeEl = document.getElementById('repo-stat-db-size');
+  var logSizeEl = document.getElementById('repo-stat-log-size');
+  var retentionBarEl = document.getElementById('repo-retention-bar');
+  var retentionLabelEl = document.getElementById('repo-retention-label');
+
+  if (dbSizeEl) dbSizeEl.textContent = fmtBytes(data.dbSizeBytes);
+  if (logSizeEl) logSizeEl.textContent = fmtBytes(data.logSizeBytes);
+  var pct = data.retentionPct || 0;
+  if (retentionBarEl) retentionBarEl.style.width = pct + '%';
+  if (retentionLabelEl) retentionLabelEl.textContent = pct + '% Capacity Reached';
+}
+
+function renderRepositoriesView(repos, storageData) {
+  var grid = document.getElementById('repo-card-grid');
+  if (!grid) return;
+
+  // Remove loading placeholder
+  var placeholder = document.getElementById('repo-loading-placeholder');
+  if (placeholder) placeholder.remove();
+
+  // Remove previously injected cards
+  grid.querySelectorAll('.repo-card-dynamic').forEach(function(el) { el.remove(); });
+
+  // Inject repo cards
+  var repoList = Array.isArray(repos) ? repos : [];
+  if (repoList.length === 0) {
+    grid.insertAdjacentHTML('beforeend',
+      '<div class="repo-card-dynamic bg-surface-container rounded-xl p-6 flex flex-col items-center justify-center min-h-[200px] ring-1 ring-outline-variant/10">' +
+        '<span class="material-symbols-outlined text-4xl text-outline/20 mb-3">inventory_2</span>' +
+        '<p class="text-sm text-outline font-body">등록된 레포지토리가 없습니다.</p>' +
+      '</div>'
+    );
+  } else {
+    repoList.forEach(function(repo) {
+      grid.insertAdjacentHTML('beforeend', renderRepoCard(repo));
+    });
+  }
+
+  renderStorageSection(storageData);
+}
+
+// Hook into navigateTo for repositories view (mock data until API is connected)
+document.addEventListener('DOMContentLoaded', function() {
+  var orig = window.navigateTo;
+  if (typeof orig === 'function') {
+    window.navigateTo = function(view) {
+      orig(view);
+      if (view === 'repositories') {
+        renderRepositoriesView(MOCK_REPOS, MOCK_STORAGE);
+      }
+    };
+  }
+});
+
+/* ══════════════════════════════════════════════════════════════
    Responsive Activity Log Handler
    ══════════════════════════════════════════════════════════════ */
 window.addEventListener('resize', function() {


### PR DESCRIPTION
## Summary

Resolves #347 — feat: Repositories 뷰 UI — 프로젝트별 카드 그리드 + 스토리지 관리

대시보드에 Repositories 메뉴가 존재하지만 해당 뷰가 구현되어 있지 않다. 사용자가 등록된 레포지토리들을 카드 형태로 확인하고, 시스템의 DB/로그 스토리지 사용량을 모니터링할 수 있는 UI가 필요하다.

## Requirements

- src/server/public/index.html에 Repositories 뷰 패널(view-repositories) 추가
- 레포 카드 그리드 UI 구현 (Add Repository 카드 + 레포 상태 카드)
- 하단 스토리지 관리 섹션 (DB 크기, 로그 크기 표시, 정리 버튼)
- src/server/public/js/render.js에 renderRepositoriesView() 함수 추가
- 디자인 파일(docs/design/repositories-stitch.html) 기반 구현
- npx tsc --noEmit 및 npx vitest run 통과

## Implementation Phases

- Phase 0: Repositories 뷰 HTML 구조 추가 — SUCCESS (6f7e23f1)
- Phase 1: 레포 카드 렌더링 함수 구현 — SUCCESS (e27388dc)
- Phase 2: i18n 키 및 뷰 전환 통합 — SUCCESS (f60edfe7)

## Risks

- Repositories API 엔드포인트가 아직 구현되지 않았을 수 있음 — 목업 데이터로 UI 먼저 구현
- 기존 view-panel 전환 로직과의 통합 필요
- i18n 키 추가 필요 (js/i18n.js)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/347-feat-repositories-ui` → `develop`
- **Tokens**: 166 input, 30701 output{{#stats.cacheCreationTokens}}, 245887 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2186993 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #347