### PR TITLE
[AQ-#343] refactor: PhaseResult 타입 확장 — warnings, errors, partial 필드 추가

### DIFF
--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -98,6 +98,9 @@ export interface PhaseResult {
   durationMs: number;
   costUsd?: number;
   usage?: UsageInfo;
+  warnings?: string[];
+  errors?: string[];
+  partial?: boolean;
 }
 
 export interface PipelineResult {

--- a/tests/types/pipeline.test.ts
+++ b/tests/types/pipeline.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import type { PhaseResult } from "../../src/types/pipeline.js";
+
+describe("PhaseResult", () => {
+  it("최소 필수 필드만으로 성공 결과를 생성할 수 있다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 0,
+      phaseName: "구현",
+      success: true,
+      durationMs: 1000,
+    };
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeUndefined();
+    expect(result.errors).toBeUndefined();
+    expect(result.partial).toBeUndefined();
+  });
+
+  it("warnings 필드에 경고 메시지 목록을 담을 수 있다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 0,
+      phaseName: "구현",
+      success: true,
+      durationMs: 500,
+      warnings: ["미사용 변수 발견", "타입 단언 사용됨"],
+    };
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings?.[0]).toBe("미사용 변수 발견");
+  });
+
+  it("errors 필드에 에러 메시지 목록을 담을 수 있다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 1,
+      phaseName: "검증",
+      success: false,
+      durationMs: 300,
+      error: "검증 실패",
+      errors: ["테스트 실패: foo.test.ts", "타입 에러: bar.ts:10"],
+    };
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors?.[1]).toBe("타입 에러: bar.ts:10");
+  });
+
+  it("partial 필드로 부분 성공 상태를 표현할 수 있다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 2,
+      phaseName: "테스트",
+      success: false,
+      durationMs: 800,
+      partial: true,
+      warnings: ["일부 테스트 스킵됨"],
+      errors: ["테스트 3개 실패"],
+    };
+    expect(result.partial).toBe(true);
+    expect(result.success).toBe(false);
+  });
+
+  it("warnings, errors, partial 모두 optional이다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 0,
+      phaseName: "구현",
+      success: true,
+      durationMs: 100,
+    };
+    // TypeScript 컴파일이 통과하면 optional 확인됨
+    expect(result).not.toHaveProperty("warnings");
+    expect(result).not.toHaveProperty("errors");
+    expect(result).not.toHaveProperty("partial");
+  });
+
+  it("빈 배열도 유효한 warnings/errors 값이다", () => {
+    const result: PhaseResult = {
+      phaseIndex: 0,
+      phaseName: "구현",
+      success: true,
+      durationMs: 200,
+      warnings: [],
+      errors: [],
+    };
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #343 — refactor: PhaseResult 타입 확장 — warnings, errors, partial 필드 추가

PhaseResult 타입에 Phase 실행 결과의 세부 정보를 담을 수 있는 필드가 부족하다. 경고(warnings), 에러 목록(errors), 부분 성공(partial) 상태를 표현할 수 있도록 타입을 확장해야 한다.

## Requirements

- PhaseResult 인터페이스에 warnings?: string[] 필드 추가
- PhaseResult 인터페이스에 errors?: string[] 필드 추가
- PhaseResult 인터페이스에 partial?: boolean 필드 추가
- 기존 사용처 타입 에러 방지를 위해 모든 필드는 optional로 추가
- 새 필드를 검증하는 단위 테스트 작성

## Implementation Phases

- Phase 0: PhaseResult 타입 확장 및 테스트 — SUCCESS (646601dc)

## Risks

- 기존 PhaseResult 사용처에서 새 필드 접근 시 undefined 처리 필요 (optional이므로 타입 에러는 없음)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/343-refactor-phaseresult-warnings-errors-partial` → `develop`
- **Tokens**: 63 input, 5256 output{{#stats.cacheCreationTokens}}, 84804 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 461004 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #343