### PR TITLE
[AQ-#350] refactor: safety-checker 규칙 엔진 위임 — 기존 guard 로직 전환

### DIFF
--- a/src/safety/rule-engine.ts
+++ b/src/safety/rule-engine.ts
@@ -1,0 +1,71 @@
+import { SafetyViolationError } from "../types/errors.js";
+import { getLogger } from "../utils/logger.js";
+import type {
+  Rule,
+  RuleContext,
+  RuleCheckpoint,
+  RuleResult,
+  IssueRuleContext,
+  PlanRuleContext,
+  PushRuleContext,
+} from "../types/safety.js";
+
+interface StoredRule {
+  id: string;
+  checkpoint: RuleCheckpoint;
+  warnOnly: boolean;
+  // Runtime safety is guaranteed: we only call this after filtering by checkpoint
+  check: (ctx: RuleContext) => RuleResult | Promise<RuleResult>;
+}
+
+/**
+ * 규칙 엔진 — guard 로직을 플러그인 방식으로 등록하고 시점별로 실행한다.
+ *
+ * - blocking 규칙: 실패 시 SafetyViolationError를 throw한다.
+ * - warn-only 규칙: 실패 시 경고 로그만 남기고 계속 진행한다.
+ */
+export class RuleEngine {
+  private readonly rules: StoredRule[] = [];
+  private readonly logger = getLogger();
+
+  /**
+   * 규칙을 엔진에 등록한다.
+   *
+   * @param rule      등록할 규칙 객체
+   * @param options   { warnOnly: true } 이면 실패 시 경고만 남기고 진행
+   */
+  register<C extends RuleContext>(
+    rule: Rule<C>,
+    options?: { warnOnly?: boolean }
+  ): this {
+    this.rules.push({
+      id: rule.id,
+      checkpoint: rule.checkpoint,
+      warnOnly: options?.warnOnly ?? false,
+      // Checkpoint matching before invocation guarantees runtime type safety
+      check: rule.check.bind(rule) as StoredRule["check"],
+    });
+    return this;
+  }
+
+  async run(checkpoint: "issue", ctx: IssueRuleContext): Promise<void>;
+  async run(checkpoint: "plan", ctx: PlanRuleContext): Promise<void>;
+  async run(checkpoint: "push", ctx: PushRuleContext): Promise<void>;
+  async run(checkpoint: RuleCheckpoint, ctx: RuleContext): Promise<void> {
+    const relevant = this.rules.filter((r) => r.checkpoint === checkpoint);
+
+    for (const { id, warnOnly, check } of relevant) {
+      const result = await check(ctx);
+
+      if (!result.passed) {
+        if (warnOnly) {
+          this.logger.warn(
+            `[${id}] ${result.message} — 경고만 남기고 계속 진행합니다`
+          );
+        } else {
+          throw new SafetyViolationError(id, result.message, result.details);
+        }
+      }
+    }
+  }
+}

--- a/src/safety/rules/base-branch-rule.ts
+++ b/src/safety/rules/base-branch-rule.ts
@@ -1,0 +1,22 @@
+import type { PushRule, PushRuleContext, RuleResult } from "../../types/safety.js";
+import { assertNotOnBaseBranch } from "../base-branch-guard.js";
+import { SafetyViolationError } from "../../types/errors.js";
+
+export const baseBranchRule: PushRule = {
+  id: "base-branch",
+  checkpoint: "push",
+  async check(ctx: PushRuleContext): Promise<RuleResult> {
+    try {
+      await assertNotOnBaseBranch(ctx.baseBranch, {
+        cwd: ctx.cwd,
+        gitPath: ctx.gitConfig.gitPath,
+      });
+      return { passed: true };
+    } catch (err: unknown) {
+      if (err instanceof SafetyViolationError) {
+        return { passed: false, message: err.message, details: err.details };
+      }
+      throw err;
+    }
+  },
+};

--- a/src/safety/rules/change-limit-rule.ts
+++ b/src/safety/rules/change-limit-rule.ts
@@ -1,0 +1,32 @@
+import type { PushRule, PushRuleContext, RuleResult } from "../../types/safety.js";
+import { checkChangeLimits } from "../change-limit-guard.js";
+import { collectDiff } from "../../git/diff-collector.js";
+import { SafetyViolationError } from "../../types/errors.js";
+
+export const changeLimitRule: PushRule = {
+  id: "change-limit",
+  checkpoint: "push",
+  async check(ctx: PushRuleContext): Promise<RuleResult> {
+    try {
+      const diffStats = await collectDiff(ctx.gitConfig, ctx.baseBranch, { cwd: ctx.cwd });
+      checkChangeLimits(
+        {
+          filesChanged: diffStats.filesChanged,
+          insertions: diffStats.insertions,
+          deletions: diffStats.deletions,
+        },
+        {
+          maxFileChanges: ctx.safetyConfig.maxFileChanges,
+          maxInsertions: ctx.safetyConfig.maxInsertions,
+          maxDeletions: ctx.safetyConfig.maxDeletions,
+        }
+      );
+      return { passed: true };
+    } catch (err: unknown) {
+      if (err instanceof SafetyViolationError) {
+        return { passed: false, message: err.message, details: err.details };
+      }
+      throw err;
+    }
+  },
+};

--- a/src/safety/rules/index.ts
+++ b/src/safety/rules/index.ts
@@ -1,0 +1,5 @@
+export { labelRule } from "./label-rule.js";
+export { phaseLimitRule } from "./phase-limit-rule.js";
+export { baseBranchRule } from "./base-branch-rule.js";
+export { sensitivePathRule } from "./sensitive-path-rule.js";
+export { changeLimitRule } from "./change-limit-rule.js";

--- a/src/safety/rules/label-rule.ts
+++ b/src/safety/rules/label-rule.ts
@@ -1,0 +1,15 @@
+import type { IssueRule, IssueRuleContext, RuleResult } from "../../types/safety.js";
+import { isAllowedLabel } from "../label-filter.js";
+
+export const labelRule: IssueRule = {
+  id: "label-filter",
+  checkpoint: "issue",
+  check(ctx: IssueRuleContext): RuleResult {
+    const passed = isAllowedLabel(ctx.issue.labels, ctx.safetyConfig.allowedLabels);
+    if (passed) return { passed: true };
+    return {
+      passed: false,
+      message: `Issue labels [${ctx.issue.labels.join(", ")}] do not match allowed labels [${ctx.safetyConfig.allowedLabels.join(", ")}]`,
+    };
+  },
+};

--- a/src/safety/rules/phase-limit-rule.ts
+++ b/src/safety/rules/phase-limit-rule.ts
@@ -1,0 +1,19 @@
+import type { PlanRule, PlanRuleContext, RuleResult } from "../../types/safety.js";
+import { checkPhaseLimit } from "../phase-limit-guard.js";
+import { SafetyViolationError } from "../../types/errors.js";
+
+export const phaseLimitRule: PlanRule = {
+  id: "phase-limit",
+  checkpoint: "plan",
+  check(ctx: PlanRuleContext): RuleResult {
+    try {
+      checkPhaseLimit(ctx.plan.phases.length, ctx.safetyConfig.maxPhases);
+      return { passed: true };
+    } catch (err: unknown) {
+      if (err instanceof SafetyViolationError) {
+        return { passed: false, message: err.message, details: err.details };
+      }
+      throw err;
+    }
+  },
+};

--- a/src/safety/rules/sensitive-path-rule.ts
+++ b/src/safety/rules/sensitive-path-rule.ts
@@ -1,0 +1,21 @@
+import type { PushRule, PushRuleContext, RuleResult } from "../../types/safety.js";
+import { checkSensitivePaths } from "../sensitive-path-guard.js";
+import { collectDiff } from "../../git/diff-collector.js";
+import { SafetyViolationError } from "../../types/errors.js";
+
+export const sensitivePathRule: PushRule = {
+  id: "sensitive-path",
+  checkpoint: "push",
+  async check(ctx: PushRuleContext): Promise<RuleResult> {
+    try {
+      const diffStats = await collectDiff(ctx.gitConfig, ctx.baseBranch, { cwd: ctx.cwd });
+      checkSensitivePaths(diffStats.changedFiles, ctx.safetyConfig.sensitivePaths);
+      return { passed: true };
+    } catch (err: unknown) {
+      if (err instanceof SafetyViolationError) {
+        return { passed: false, message: err.message, details: err.details };
+      }
+      throw err;
+    }
+  },
+};

--- a/src/safety/safety-checker.ts
+++ b/src/safety/safety-checker.ts
@@ -1,14 +1,17 @@
-import { checkSensitivePaths } from "./sensitive-path-guard.js";
-import { checkChangeLimits } from "./change-limit-guard.js";
-import { assertNotOnBaseBranch } from "./base-branch-guard.js";
-import { checkPhaseLimit } from "./phase-limit-guard.js";
-import { isAllowedLabel } from "./label-filter.js";
-import { collectDiff } from "../git/diff-collector.js";
+import { RuleEngine } from "./rule-engine.js";
+import {
+  labelRule,
+  phaseLimitRule,
+  baseBranchRule,
+  sensitivePathRule,
+  changeLimitRule,
+} from "./rules/index.js";
 import { getLogger } from "../utils/logger.js";
 import type { SafetyConfig, GitConfig } from "../types/config.js";
 import type { Plan } from "../types/pipeline.js";
 import type { GitHubIssue } from "../github/issue-fetcher.js";
 import { SafetyViolationError } from "../types/errors.js";
+import type { RuleResult } from "../types/safety.js";
 
 const logger = getLogger();
 
@@ -26,11 +29,9 @@ export function validateIssue(
   issue: GitHubIssue,
   safetyConfig: SafetyConfig
 ): void {
-  if (!isAllowedLabel(issue.labels, safetyConfig.allowedLabels)) {
-    throw new SafetyViolationError(
-      "LabelFilter",
-      `Issue labels [${issue.labels.join(", ")}] do not match allowed labels [${safetyConfig.allowedLabels.join(", ")}]`
-    );
+  const result = labelRule.check({ checkpoint: "issue", issue, safetyConfig }) as RuleResult;
+  if (!result.passed) {
+    throw new SafetyViolationError("LabelFilter", result.message, result.details);
   }
 }
 
@@ -41,47 +42,29 @@ export function validatePlan(
   plan: Plan,
   safetyConfig: SafetyConfig
 ): void {
-  checkPhaseLimit(plan.phases.length, safetyConfig.maxPhases);
+  const result = phaseLimitRule.check({ checkpoint: "plan", plan, safetyConfig }) as RuleResult;
+  if (!result.passed) {
+    throw new SafetyViolationError(phaseLimitRule.id, result.message, result.details);
+  }
 }
 
 /**
  * Pre-push validation: check branch, sensitive paths, and change limits.
  */
 export async function validateBeforePush(ctx: SafetyContext): Promise<void> {
-  // Ensure not on base branch
-  await assertNotOnBaseBranch(ctx.baseBranch, {
+  const engine = new RuleEngine();
+  engine
+    .register(baseBranchRule)
+    .register(sensitivePathRule)
+    .register(changeLimitRule, { warnOnly: true });
+
+  await engine.run("push", {
+    checkpoint: "push",
+    safetyConfig: ctx.safetyConfig,
+    gitConfig: ctx.gitConfig,
     cwd: ctx.cwd,
-    gitPath: ctx.gitConfig.gitPath,
+    baseBranch: ctx.baseBranch,
   });
-
-  // Collect diff stats
-  const diffStats = await collectDiff(ctx.gitConfig, ctx.baseBranch, { cwd: ctx.cwd });
-
-  // Check sensitive paths
-  checkSensitivePaths(diffStats.changedFiles, ctx.safetyConfig.sensitivePaths);
-
-  // Check change limits — warn only, do not block (draft PR can be discarded)
-  try {
-    checkChangeLimits(
-      {
-        filesChanged: diffStats.filesChanged,
-        insertions: diffStats.insertions,
-        deletions: diffStats.deletions,
-      },
-      {
-        maxFileChanges: ctx.safetyConfig.maxFileChanges,
-        maxInsertions: ctx.safetyConfig.maxInsertions,
-        maxDeletions: ctx.safetyConfig.maxDeletions,
-      }
-    );
-  } catch (err: unknown) {
-    if (err instanceof SafetyViolationError) {
-      logger.warn(`[ChangeLimitGuard] ${err.message} — 경고만 남기고 계속 진행합니다`);
-    } else {
-      throw err;
-    }
-  }
 
   logger.info("Safety checks passed");
 }
-

--- a/src/types/safety.ts
+++ b/src/types/safety.ts
@@ -1,0 +1,70 @@
+import type { SafetyConfig, GitConfig } from "./config.js";
+import type { Plan } from "./pipeline.js";
+import type { GitHubIssue } from "../github/issue-fetcher.js";
+
+/**
+ * 규칙이 실행되는 검증 시점
+ */
+export type RuleCheckpoint = "issue" | "plan" | "push";
+
+/**
+ * 규칙 검사 결과
+ */
+export type RuleResult =
+  | { passed: true }
+  | { passed: false; message: string; details?: Record<string, unknown> };
+
+/**
+ * 이슈 검증 시점 컨텍스트 (파이프라인 시작 전)
+ */
+export interface IssueRuleContext {
+  checkpoint: "issue";
+  issue: GitHubIssue;
+  safetyConfig: SafetyConfig;
+}
+
+/**
+ * Plan 검증 시점 컨텍스트 (Plan 생성 후)
+ */
+export interface PlanRuleContext {
+  checkpoint: "plan";
+  plan: Plan;
+  safetyConfig: SafetyConfig;
+}
+
+/**
+ * Push 직전 검증 시점 컨텍스트 (diff 수준)
+ */
+export interface PushRuleContext {
+  checkpoint: "push";
+  safetyConfig: SafetyConfig;
+  gitConfig: GitConfig;
+  cwd: string;
+  baseBranch: string;
+}
+
+/**
+ * 모든 검증 시점 컨텍스트의 판별 유니온
+ */
+export type RuleContext = IssueRuleContext | PlanRuleContext | PushRuleContext;
+
+/**
+ * 규칙 인터페이스 — 규칙 엔진에 등록되는 단위 규칙
+ */
+export interface Rule<C extends RuleContext = RuleContext> {
+  /** 규칙 고유 식별자 (예: "label-filter", "phase-limit") */
+  readonly id: string;
+  /** 이 규칙이 실행되는 검증 시점 */
+  readonly checkpoint: C["checkpoint"];
+  /** 규칙 검사 실행 — 동기/비동기 모두 지원 */
+  check(ctx: C): RuleResult | Promise<RuleResult>;
+}
+
+/** 이슈 검증 규칙 */
+export type IssueRule = Rule<IssueRuleContext>;
+
+/** Plan 검증 규칙 */
+export type PlanRule = Rule<PlanRuleContext>;
+
+/** Push 직전 검증 규칙 */
+export type PushRule = Rule<PushRuleContext>;

--- a/tests/safety/rule-engine.test.ts
+++ b/tests/safety/rule-engine.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RuleEngine } from "../../src/safety/rule-engine.js";
+import { SafetyViolationError } from "../../src/types/errors.js";
+import type { IssueRule, PlanRule, PushRule } from "../../src/types/safety.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+import { getLogger } from "../../src/utils/logger.js";
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+const baseIssueCtx = {
+  checkpoint: "issue" as const,
+  issue: {
+    number: 1,
+    title: "Test issue",
+    body: "body",
+    labels: ["bug"],
+    assignee: null,
+    state: "open" as const,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  safetyConfig: {
+    allowedLabels: ["bug"],
+    sensitivePaths: [],
+    maxPhases: 5,
+    maxFileChanges: 100,
+    maxInsertions: 1000,
+    maxDeletions: 500,
+    stopConditions: [],
+    timeoutMs: 300000,
+  },
+};
+
+const basePlanCtx = {
+  checkpoint: "plan" as const,
+  plan: {
+    title: "Test plan",
+    description: "desc",
+    phases: [{ description: "p1", commands: [] }],
+  },
+  safetyConfig: baseIssueCtx.safetyConfig,
+};
+
+describe("RuleEngine", () => {
+  let engine: RuleEngine;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getLogger).mockReturnValue(mockLogger as ReturnType<typeof getLogger>);
+    engine = new RuleEngine();
+  });
+
+  describe("register", () => {
+    it("returns this for method chaining", () => {
+      const rule: IssueRule = {
+        id: "test-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: true }),
+      };
+      const result = engine.register(rule);
+      expect(result).toBe(engine);
+    });
+
+    it("supports chaining multiple registers", () => {
+      const ruleA: IssueRule = { id: "a", checkpoint: "issue", check: () => ({ passed: true }) };
+      const ruleB: IssueRule = { id: "b", checkpoint: "issue", check: () => ({ passed: true }) };
+      expect(() => engine.register(ruleA).register(ruleB)).not.toThrow();
+    });
+  });
+
+  describe("run — checkpoint filtering", () => {
+    it("only runs rules matching the given checkpoint", async () => {
+      const issueCheck = vi.fn(() => ({ passed: true as const }));
+      const planCheck = vi.fn(() => ({ passed: true as const }));
+
+      const issueRule: IssueRule = { id: "issue-rule", checkpoint: "issue", check: issueCheck };
+      const planRule: PlanRule = { id: "plan-rule", checkpoint: "plan", check: planCheck };
+
+      engine.register(issueRule).register(planRule);
+
+      await engine.run("issue", baseIssueCtx);
+
+      expect(issueCheck).toHaveBeenCalledOnce();
+      expect(planCheck).not.toHaveBeenCalled();
+    });
+
+    it("runs no rules when none match checkpoint", async () => {
+      const planCheck = vi.fn(() => ({ passed: true as const }));
+      const planRule: PlanRule = { id: "plan-rule", checkpoint: "plan", check: planCheck };
+
+      engine.register(planRule);
+
+      await engine.run("issue", baseIssueCtx);
+
+      expect(planCheck).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("run — blocking rule", () => {
+    it("does not throw when blocking rule passes", async () => {
+      const rule: IssueRule = {
+        id: "pass-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: true }),
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).resolves.toBeUndefined();
+    });
+
+    it("throws SafetyViolationError when blocking rule fails", async () => {
+      const rule: IssueRule = {
+        id: "fail-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "rule failed" }),
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).rejects.toThrow(SafetyViolationError);
+    });
+
+    it("sets correct guard id and message on thrown error", async () => {
+      const rule: IssueRule = {
+        id: "my-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "something went wrong" }),
+      };
+      engine.register(rule);
+
+      const err = await engine.run("issue", baseIssueCtx).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(SafetyViolationError);
+      const violation = err as SafetyViolationError;
+      expect(violation.guard).toBe("my-rule");
+      expect(violation.message).toContain("something went wrong");
+    });
+
+    it("includes details in thrown error when provided", async () => {
+      const rule: IssueRule = {
+        id: "detail-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "err", details: { count: 3 } }),
+      };
+      engine.register(rule);
+
+      const err = await engine.run("issue", baseIssueCtx).catch((e: unknown) => e);
+      const violation = err as SafetyViolationError;
+      expect(violation.details).toEqual({ count: 3 });
+    });
+
+    it("stops executing after first blocking failure", async () => {
+      const secondCheck = vi.fn(() => ({ passed: true as const }));
+      const firstRule: IssueRule = {
+        id: "first",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "first fails" }),
+      };
+      const secondRule: IssueRule = { id: "second", checkpoint: "issue", check: secondCheck };
+
+      engine.register(firstRule).register(secondRule);
+
+      await expect(engine.run("issue", baseIssueCtx)).rejects.toThrow(SafetyViolationError);
+      expect(secondCheck).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("run — warn-only rule", () => {
+    it("does not throw when warn-only rule fails", async () => {
+      const rule: IssueRule = {
+        id: "warn-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "just a warning" }),
+      };
+      engine.register(rule, { warnOnly: true });
+
+      await expect(engine.run("issue", baseIssueCtx)).resolves.toBeUndefined();
+    });
+
+    it("logs warning when warn-only rule fails", async () => {
+      const rule: IssueRule = {
+        id: "warn-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "just a warning" }),
+      };
+      engine.register(rule, { warnOnly: true });
+
+      await engine.run("issue", baseIssueCtx);
+
+      expect(mockLogger.warn).toHaveBeenCalledOnce();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("warn-rule")
+      );
+    });
+
+    it("continues running subsequent rules after warn-only failure", async () => {
+      const thirdCheck = vi.fn(() => ({ passed: true as const }));
+      const warnRule: IssueRule = {
+        id: "warn-rule",
+        checkpoint: "issue",
+        check: () => ({ passed: false, message: "warn" }),
+      };
+      const thirdRule: IssueRule = { id: "third", checkpoint: "issue", check: thirdCheck };
+
+      engine.register(warnRule, { warnOnly: true }).register(thirdRule);
+
+      await engine.run("issue", baseIssueCtx);
+
+      expect(thirdCheck).toHaveBeenCalledOnce();
+    });
+
+    it("does not log warning when warn-only rule passes", async () => {
+      const rule: IssueRule = {
+        id: "warn-pass",
+        checkpoint: "issue",
+        check: () => ({ passed: true }),
+      };
+      engine.register(rule, { warnOnly: true });
+
+      await engine.run("issue", baseIssueCtx);
+
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("run — async rules", () => {
+    it("supports async check returning passed", async () => {
+      const rule: IssueRule = {
+        id: "async-pass",
+        checkpoint: "issue",
+        check: async () => ({ passed: true }),
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).resolves.toBeUndefined();
+    });
+
+    it("supports async check returning failed", async () => {
+      const rule: IssueRule = {
+        id: "async-fail",
+        checkpoint: "issue",
+        check: async () => ({ passed: false, message: "async fail" }),
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).rejects.toThrow(SafetyViolationError);
+    });
+  });
+
+  describe("run — unexpected errors", () => {
+    it("propagates non-SafetyViolationError thrown from check", async () => {
+      const rule: IssueRule = {
+        id: "error-rule",
+        checkpoint: "issue",
+        check: () => { throw new Error("unexpected"); },
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).rejects.toThrow("unexpected");
+    });
+
+    it("propagates rejected promise from async check", async () => {
+      const rule: IssueRule = {
+        id: "async-error",
+        checkpoint: "issue",
+        check: async () => { throw new Error("async unexpected"); },
+      };
+      engine.register(rule);
+
+      await expect(engine.run("issue", baseIssueCtx)).rejects.toThrow("async unexpected");
+    });
+  });
+
+  describe("run — plan checkpoint", () => {
+    it("passes plan context to check", async () => {
+      const planCheck = vi.fn(() => ({ passed: true as const }));
+      const rule: PlanRule = { id: "plan-check", checkpoint: "plan", check: planCheck };
+
+      engine.register(rule);
+      await engine.run("plan", basePlanCtx);
+
+      expect(planCheck).toHaveBeenCalledWith(basePlanCtx);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #350 — refactor: safety-checker 규칙 엔진 위임 — 기존 guard 로직 전환

현재 safety-checker.ts는 각 guard 함수를 직접 import하여 호출하는 하드코딩 방식으로 구현되어 있다. validateIssue는 label-filter, validatePlan은 phase-limit-guard, validateBeforePush는 base-branch-guard, sensitive-path-guard, change-limit-guard를 직접 호출한다. 이 구조는 새로운 guard 추가 시 safety-checker.ts를 수정해야 하며, 규칙의 동적 활성화/비활성화가 불가능하다. 규칙 엔진을 도입하여 guard 로직을 플러그인 방식으로 전환하면 확장성과 유지보수성이 향상된다.

## Requirements

- src/safety/safety-checker.ts의 기존 하드코딩된 guard 호출을 rule-engine으로 위임
- 기존 동작 100% 유지 (validateIssue, validatePlan, validateBeforePush)
- 기존 guard 파일들(label-filter, phase-limit-guard 등)은 그대로 유지하고 rule adapter로 래핑
- SafetyViolationError throw 동작 유지
- change-limit-guard의 warn-only 동작 유지
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: 규칙 엔진 타입 정의 — SUCCESS (cbceeb1e)
- Phase 1: 규칙 엔진 코어 구현 — SUCCESS (4ef79fdf)
- Phase 2: 기존 guard를 Rule로 래핑 — SUCCESS (4ef79fdf)
- Phase 3: safety-checker를 rule-engine으로 전환 — SUCCESS (e6667a7b)
- Phase 4: 규칙 엔진 테스트 추가 — SUCCESS (38f3d62f)

## Risks

- 기존 guard 동작이 미묘하게 변경될 위험 (특히 change-limit-guard의 warn-only 로직)
- 규칙 실행 순서 변경으로 인한 에러 메시지 차이
- SafetyContext 타입 확장 시 기존 호출부 영향

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/350-refactor-safety-checker-guard` → `develop`
- **Tokens**: 275 input, 51103 output{{#stats.cacheCreationTokens}}, 313980 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3127825 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #350