### PR TITLE
[AQ-#344] feat: phase-executor 부분 성공 감지 — 일부 파일 성공/실패 구분

### DIFF
--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -7,6 +7,7 @@ import { getErrorMessage } from "../utils/error-utils.js";
 import type { ClaudeCliConfig } from "../types/config.js";
 import type { Plan, Phase, PhaseResult } from "../types/pipeline.js";
 import { classifyError } from "./error-classifier.js";
+import { parseTscOutput, parseVitestOutput } from "./verification-parser.js";
 import type { GitHubIssue } from "../github/issue-fetcher.js";
 import { getLogger } from "../utils/logger.js";
 import type { JobLogger } from "../queue/job-logger.js";
@@ -168,6 +169,57 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       logger.info(`Running verification for phase ${ctx.phase.index}: ${ctx.phase.name}`);
       const testResult = await runShell(ctx.testCommand, { cwd: ctx.cwd, timeout: 120000 });
       if (testResult.exitCode !== 0) {
+        const output = [testResult.stdout, testResult.stderr].filter(Boolean).join("\n");
+
+        // Detect partial vitest success: some files passed, some failed
+        const vitestResult = parseVitestOutput(output);
+        if (vitestResult.totalFiles > 0 && vitestResult.passedFiles.length > 0 && vitestResult.failedFiles.length > 0) {
+          logger.warn(
+            `Phase ${ctx.phase.index} partial success: ` +
+            `${vitestResult.passedFiles.length} passed, ${vitestResult.failedFiles.length} failed`
+          );
+          const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
+          const errors = vitestResult.failedFiles.map(f => `FAIL: ${f}`);
+          const warnings = vitestResult.failedTests.length > 0
+            ? vitestResult.failedTests.map(t => `Test failed: ${t}`)
+            : undefined;
+          return {
+            phaseIndex: ctx.phase.index,
+            phaseName: ctx.phase.name,
+            success: true,
+            partial: true,
+            errors,
+            warnings,
+            commitHash,
+            durationMs: Date.now() - startTime,
+            costUsd: claudeResult?.costUsd,
+            usage: claudeResult?.usage,
+          };
+        }
+
+        // Detect partial tsc success: errors only in specific files
+        const tscResult = parseTscOutput(output);
+        if (tscResult.hasErrors && Object.keys(tscResult.errorsByFile).length > 0 && vitestResult.totalFiles === 0) {
+          logger.warn(
+            `Phase ${ctx.phase.index} partial success: tsc errors in ${Object.keys(tscResult.errorsByFile).length} file(s)`
+          );
+          const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
+          const errors = Object.entries(tscResult.errorsByFile).flatMap(([file, msgs]) =>
+            msgs.map(msg => `${file}: ${msg}`)
+          );
+          return {
+            phaseIndex: ctx.phase.index,
+            phaseName: ctx.phase.name,
+            success: true,
+            partial: true,
+            errors,
+            commitHash,
+            durationMs: Date.now() - startTime,
+            costUsd: claudeResult?.costUsd,
+            usage: claudeResult?.usage,
+          };
+        }
+
         throw new Error(`Tests failed:\n${testResult.stdout}\n${testResult.stderr}`);
       }
     }

--- a/src/pipeline/verification-parser.ts
+++ b/src/pipeline/verification-parser.ts
@@ -1,0 +1,85 @@
+/**
+ * Parses tsc and vitest output to identify per-file success/failure.
+ */
+
+export interface TscParseResult {
+  /** Per-file error messages */
+  errorsByFile: Record<string, string[]>;
+  totalErrors: number;
+  hasErrors: boolean;
+}
+
+export interface VitestParseResult {
+  failedFiles: string[];
+  passedFiles: string[];
+  failedTests: string[];
+  totalFiles: number;
+  hasFailures: boolean;
+}
+
+// Matches: src/foo.ts(10,5): error TS2345: message
+const TSC_ERROR_LINE_RE = /^(.+\.tsx?)\(\d+,\d+\):\s+error\s+(TS\d+:.+)$/;
+
+export function parseTscOutput(output: string): TscParseResult {
+  const errorsByFile: Record<string, string[]> = {};
+  let totalErrors = 0;
+
+  for (const raw of output.split("\n")) {
+    const line = raw.trim();
+    const match = line.match(TSC_ERROR_LINE_RE);
+    if (!match) continue;
+    const file = match[1];
+    const msg = match[2];
+    if (!errorsByFile[file]) errorsByFile[file] = [];
+    errorsByFile[file].push(msg);
+    totalErrors++;
+  }
+
+  return { errorsByFile, totalErrors, hasErrors: totalErrors > 0 };
+}
+
+// File-level FAIL/PASS — match before the `>` test separator to distinguish files
+// Examples:
+//   " × tests/foo.test.ts (3 tests | 1 failed) 200ms"
+//   " ✓ tests/foo.test.ts (5 tests) 100ms"
+//   " FAIL  tests/foo.test.ts"
+//   " PASS  tests/foo.test.ts"
+const VITEST_FAIL_FILE_RE = /^\s*(?:FAIL|[×✗])\s+([\w./@-][\w./@/-]*\.test\.[jt]sx?)(?:\s|$)/;
+const VITEST_PASS_FILE_RE = /^\s*(?:PASS|[✓✅])\s+([\w./@-][\w./@/-]*\.test\.[jt]sx?)(?:\s|$)/;
+
+// Individual failing test inside a describe block — starts with indented ×/✗ and contains no file extension
+// Example: "     × should return error on failure"
+const VITEST_FAIL_TEST_RE = /^\s{2,}[×✗]\s+(.+)$/;
+
+export function parseVitestOutput(output: string): VitestParseResult {
+  const failedFiles = new Set<string>();
+  const passedFiles = new Set<string>();
+  const failedTests: string[] = [];
+
+  for (const line of output.split("\n")) {
+    const failFile = line.match(VITEST_FAIL_FILE_RE);
+    if (failFile) {
+      failedFiles.add(failFile[1]);
+      continue;
+    }
+
+    const passFile = line.match(VITEST_PASS_FILE_RE);
+    if (passFile) {
+      passedFiles.add(passFile[1]);
+      continue;
+    }
+
+    const failTest = line.match(VITEST_FAIL_TEST_RE);
+    if (failTest) {
+      failedTests.push(failTest[1].trim());
+    }
+  }
+
+  return {
+    failedFiles: [...failedFiles],
+    passedFiles: [...passedFiles],
+    failedTests,
+    totalFiles: failedFiles.size + passedFiles.size,
+    hasFailures: failedFiles.size > 0,
+  };
+}

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,6 +91,9 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
+  partial?: boolean;
+  warnings?: string[];
+  errors?: string[];
   commitHash?: string;
   error?: string;
   errorCategory?: ErrorCategory;

--- a/tests/pipeline/phase-executor.test.ts
+++ b/tests/pipeline/phase-executor.test.ts
@@ -612,4 +612,107 @@ describe("executePhase", () => {
     const commitCall = gitCommitCalls[0];
     expect(commitCall[1]).toContain("[#42] Phase 1: Phase One");
   });
+
+  // Partial success scenarios
+  it("returns partial success when some vitest test files fail and some pass", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log (getHeadHash in partial path)
+    const partialOutput = [
+      " ✓ tests/pipeline/orchestrator.test.ts (5 tests) 100ms",
+      " × tests/pipeline/phase-executor.test.ts (3 tests | 1 failed) 200ms",
+      "     × should handle error correctly",
+    ].join("\n");
+    mockRunShell.mockResolvedValue({ stdout: partialOutput, stderr: "", exitCode: 1 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.errors).toEqual(["FAIL: tests/pipeline/phase-executor.test.ts"]);
+    expect(result.warnings).toContain("Test failed: should handle error correctly");
+    expect(result.commitHash).toBe("abc12345");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns partial success without warnings when no individual failing test names captured", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "deadbeef", stderr: "", exitCode: 0 }); // git log
+    const partialOutput = [
+      " ✓ tests/a.test.ts (3 tests) 50ms",
+      " FAIL  tests/b.test.ts",
+    ].join("\n");
+    mockRunShell.mockResolvedValue({ stdout: partialOutput, stderr: "", exitCode: 1 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.errors).toEqual(["FAIL: tests/b.test.ts"]);
+    expect(result.warnings).toBeUndefined();
+    expect(result.commitHash).toBe("deadbeef");
+  });
+
+  it("returns partial success when tsc has errors in specific files", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "cafebabe", stderr: "", exitCode: 0 }); // git log
+    const tscOutput = "src/pipeline/phase-executor.ts(39,3): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.";
+    mockRunShell.mockResolvedValue({ stdout: tscOutput, stderr: "", exitCode: 1 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors![0]).toContain("src/pipeline/phase-executor.ts");
+    expect(result.errors![0]).toContain("TS2345");
+    expect(result.commitHash).toBe("cafebabe");
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("returns partial success with errors from multiple tsc-errored files", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "beefdead", stderr: "", exitCode: 0 }); // git log
+    const tscOutput = [
+      "src/foo.ts(10,5): error TS2345: Type mismatch.",
+      "src/bar.ts(5,1): error TS1005: ';' expected.",
+      "src/bar.ts(20,3): error TS2304: Cannot find name 'x'.",
+    ].join("\n");
+    mockRunShell.mockResolvedValue({ stdout: tscOutput, stderr: "", exitCode: 1 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(result.partial).toBe(true);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors!.some(e => e.startsWith("src/foo.ts:"))).toBe(true);
+    expect(result.errors!.filter(e => e.startsWith("src/bar.ts:")).length).toBe(2);
+  });
+
+  it("falls through to full failure when vitest output has no passed files", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+    // All files failed — no passed files, so not partial
+    const allFailedOutput = [
+      " × tests/a.test.ts (3 tests | 3 failed) 100ms",
+      " × tests/b.test.ts (2 tests | 2 failed) 200ms",
+      "     × test one",
+    ].join("\n");
+    mockRunShell.mockResolvedValue({ stdout: allFailedOutput, stderr: "", exitCode: 1 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.partial).toBeUndefined();
+    expect(result.errorCategory).toBe("VERIFICATION_FAILED");
+  });
 });

--- a/tests/pipeline/verification-parser.test.ts
+++ b/tests/pipeline/verification-parser.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { parseTscOutput, parseVitestOutput } from "../../src/pipeline/verification-parser.js";
+
+describe("parseTscOutput", () => {
+  it("returns empty result for clean output", () => {
+    const result = parseTscOutput("");
+    expect(result.hasErrors).toBe(false);
+    expect(result.totalErrors).toBe(0);
+    expect(result.errorsByFile).toEqual({});
+  });
+
+  it("parses single file error", () => {
+    const output = "src/foo.ts(10,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.";
+    const result = parseTscOutput(output);
+    expect(result.hasErrors).toBe(true);
+    expect(result.totalErrors).toBe(1);
+    expect(result.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    expect(result.errorsByFile["src/foo.ts"][0]).toContain("TS2345");
+  });
+
+  it("groups multiple errors from the same file", () => {
+    const output = [
+      "src/foo.ts(10,5): error TS2345: First error.",
+      "src/foo.ts(20,3): error TS2304: Cannot find name 'bar'.",
+    ].join("\n");
+    const result = parseTscOutput(output);
+    expect(result.totalErrors).toBe(2);
+    expect(result.errorsByFile["src/foo.ts"]).toHaveLength(2);
+  });
+
+  it("separates errors from different files", () => {
+    const output = [
+      "src/foo.ts(10,5): error TS2345: Error in foo.",
+      "src/bar.ts(5,1): error TS1005: ';' expected.",
+    ].join("\n");
+    const result = parseTscOutput(output);
+    expect(result.totalErrors).toBe(2);
+    expect(Object.keys(result.errorsByFile)).toHaveLength(2);
+    expect(result.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    expect(result.errorsByFile["src/bar.ts"]).toHaveLength(1);
+  });
+
+  it("ignores non-error lines", () => {
+    const output = [
+      "src/foo.ts(10,5): error TS2345: Real error.",
+      "Found 1 error.",
+      "",
+      "src/foo.ts(10,5): warning TS1234: Just a warning.",
+    ].join("\n");
+    const result = parseTscOutput(output);
+    expect(result.totalErrors).toBe(1);
+  });
+
+  it("handles nested path separators", () => {
+    const output = "src/pipeline/phase-executor.ts(39,3): error TS2345: Type mismatch.";
+    const result = parseTscOutput(output);
+    expect(result.errorsByFile["src/pipeline/phase-executor.ts"]).toHaveLength(1);
+  });
+});
+
+describe("parseVitestOutput", () => {
+  it("returns empty result for empty output", () => {
+    const result = parseVitestOutput("");
+    expect(result.hasFailures).toBe(false);
+    expect(result.failedFiles).toHaveLength(0);
+    expect(result.passedFiles).toHaveLength(0);
+    expect(result.failedTests).toHaveLength(0);
+    expect(result.totalFiles).toBe(0);
+  });
+
+  it("detects FAIL prefix for failed file", () => {
+    const output = " FAIL  tests/pipeline/phase-executor.test.ts";
+    const result = parseVitestOutput(output);
+    expect(result.hasFailures).toBe(true);
+    expect(result.failedFiles).toContain("tests/pipeline/phase-executor.test.ts");
+  });
+
+  it("detects × prefix for failed file", () => {
+    const output = " × tests/pipeline/phase-executor.test.ts (3 tests | 1 failed) 200ms";
+    const result = parseVitestOutput(output);
+    expect(result.hasFailures).toBe(true);
+    expect(result.failedFiles).toContain("tests/pipeline/phase-executor.test.ts");
+  });
+
+  it("detects PASS prefix for passed file", () => {
+    const output = " PASS  tests/pipeline/orchestrator.test.ts";
+    const result = parseVitestOutput(output);
+    expect(result.hasFailures).toBe(false);
+    expect(result.passedFiles).toContain("tests/pipeline/orchestrator.test.ts");
+  });
+
+  it("detects ✓ prefix for passed file", () => {
+    const output = " ✓ tests/pipeline/orchestrator.test.ts (5 tests) 350ms";
+    const result = parseVitestOutput(output);
+    expect(result.passedFiles).toContain("tests/pipeline/orchestrator.test.ts");
+  });
+
+  it("separates failed and passed files in mixed output", () => {
+    const output = [
+      " ✓ tests/pipeline/orchestrator.test.ts (5 tests) 100ms",
+      " × tests/pipeline/phase-executor.test.ts (3 tests | 1 failed) 200ms",
+      " ✓ tests/pipeline/error-classifier.test.ts (8 tests) 50ms",
+    ].join("\n");
+    const result = parseVitestOutput(output);
+    expect(result.failedFiles).toHaveLength(1);
+    expect(result.passedFiles).toHaveLength(2);
+    expect(result.totalFiles).toBe(3);
+    expect(result.hasFailures).toBe(true);
+  });
+
+  it("does not double-count the same file", () => {
+    const output = [
+      " FAIL  tests/pipeline/phase-executor.test.ts",
+      " × tests/pipeline/phase-executor.test.ts (3 tests | 1 failed) 200ms",
+    ].join("\n");
+    const result = parseVitestOutput(output);
+    expect(result.failedFiles).toHaveLength(1);
+  });
+
+  it("extracts individual failing test names", () => {
+    const output = [
+      " × tests/pipeline/phase-executor.test.ts (2 tests | 1 failed) 200ms",
+      "     × should return error on failure",
+    ].join("\n");
+    const result = parseVitestOutput(output);
+    expect(result.failedTests).toContain("should return error on failure");
+  });
+
+  it("returns hasFailures false when all files pass", () => {
+    const output = [
+      " ✓ tests/a.test.ts (3 tests) 100ms",
+      " ✓ tests/b.test.ts (5 tests) 200ms",
+    ].join("\n");
+    const result = parseVitestOutput(output);
+    expect(result.hasFailures).toBe(false);
+    expect(result.totalFiles).toBe(2);
+  });
+});

--- a/tests/pipeline/verification-parser.test.ts
+++ b/tests/pipeline/verification-parser.test.ts
@@ -82,6 +82,13 @@ describe("parseVitestOutput", () => {
     expect(result.failedFiles).toContain("tests/pipeline/phase-executor.test.ts");
   });
 
+  it("detects ✗ prefix for failed file", () => {
+    const output = " ✗ tests/pipeline/phase-executor.test.ts (3 tests | 1 failed) 200ms";
+    const result = parseVitestOutput(output);
+    expect(result.hasFailures).toBe(true);
+    expect(result.failedFiles).toContain("tests/pipeline/phase-executor.test.ts");
+  });
+
   it("detects PASS prefix for passed file", () => {
     const output = " PASS  tests/pipeline/orchestrator.test.ts";
     const result = parseVitestOutput(output);
@@ -91,6 +98,12 @@ describe("parseVitestOutput", () => {
 
   it("detects ✓ prefix for passed file", () => {
     const output = " ✓ tests/pipeline/orchestrator.test.ts (5 tests) 350ms";
+    const result = parseVitestOutput(output);
+    expect(result.passedFiles).toContain("tests/pipeline/orchestrator.test.ts");
+  });
+
+  it("detects ✅ prefix for passed file", () => {
+    const output = " ✅ tests/pipeline/orchestrator.test.ts (5 tests) 350ms";
     const result = parseVitestOutput(output);
     expect(result.passedFiles).toContain("tests/pipeline/orchestrator.test.ts");
   });


### PR DESCRIPTION
## Summary

Resolves #344 — feat: phase-executor 부분 성공 감지 — 일부 파일 성공/실패 구분

현재 phase-executor는 tsc/vitest 실행 결과를 전체 성공/실패로만 판단한다. 일부 파일만 실패한 경우에도 전체 실패로 처리되어, 부분적으로 성공한 작업의 정보가 유실된다. 부분 성공을 감지하고 PhaseResult에 partial=true, warnings, errors 필드를 채워 리턴해야 한다.

## Requirements

- tsc 결과에서 성공 파일과 실패 파일을 분리하는 파서 구현
- vitest 결과에서 성공 테스트와 실패 테스트를 분리하는 파서 구현
- PhaseResult에 partial, warnings, errors 필드 추가 (depends: #343)
- phase-executor.ts에서 부분 성공 감지 로직 추가
- 부분 성공 시 partial=true와 함께 warnings/errors 배열 채워서 리턴

## Implementation Phases

- Phase 0: PhaseResult 타입 확장 — SUCCESS (5695f797)
- Phase 1: verification-parser 모듈 구현 — SUCCESS (0fb53f0b)
- Phase 2: phase-executor 부분 성공 로직 — SUCCESS (30f45b67)
- Phase 3: 테스트 작성 — SUCCESS (4cd38d90)

## Risks

- #343 (PhaseResult 타입 확장)이 먼저 완료되어야 함
- tsc/vitest 출력 포맷이 버전에 따라 다를 수 있음
- 부분 성공 판단 기준이 모호할 수 있음 (예: 몇 개 실패까지 부분 성공인가)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/344-feat-phase-executor` → `develop`
- **Tokens**: 186 input, 28238 output{{#stats.cacheCreationTokens}}, 242188 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2184505 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #344