### PR TITLE
[AQ-#358] feat: job-queue 프로젝트별 슬롯 분리 — 프로젝트 간 큐 격리

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,16 @@ import { PatternStore } from "./learning/pattern-store.js";
 import { SelfUpdater } from "./update/self-updater.js";
 import { ConfigWatcher } from "./config/config-watcher.js";
 
+function buildProjectConcurrency(projects: Array<{ repo: string; concurrency?: number }>): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const p of projects) {
+    if (p.concurrency !== undefined) {
+      result[p.repo] = p.concurrency;
+    }
+  }
+  return result;
+}
+
 interface CliArgs {
   command?: string;
   issue?: number;
@@ -214,6 +224,7 @@ async function startCommand(args: CliArgs): Promise<void> {
 
   const dataDir = resolve(aqRoot, "data");
   const store = new JobStore(dataDir);
+  const projectConcurrency = buildProjectConcurrency(effectiveConfig.projects ?? []);
   const queue = new JobQueue(store, effectiveConfig.general.concurrency, async (job) => {
     const jl = new JobLogger(store, job.id);
     try {
@@ -257,7 +268,7 @@ async function startCommand(args: CliArgs): Promise<void> {
       });
       return { error: errorMsg };
     }
-  }, effectiveConfig.general.stuckTimeoutMs);
+  }, effectiveConfig.general.stuckTimeoutMs, Object.keys(projectConcurrency).length > 0 ? projectConcurrency : undefined);
 
   // Recover jobs from previous session
   queue.recover();
@@ -506,7 +517,8 @@ async function planCommand(args: CliArgs): Promise<void> {
     const { JobStore } = await import("./queue/job-store.js");
     const { JobQueue } = await import("./queue/job-queue.js");
     const store = new JobStore(dataDir);
-    const queue = new JobQueue(store, config.general.concurrency, async () => ({ error: "직접 실행 모드에서는 큐만 등록됩니다" }), config.general.stuckTimeoutMs);
+    const planProjectConcurrency = buildProjectConcurrency(config.projects ?? []);
+    const queue = new JobQueue(store, config.general.concurrency, async () => ({ error: "직접 실행 모드에서는 큐만 등록됩니다" }), config.general.stuckTimeoutMs, Object.keys(planProjectConcurrency).length > 0 ? planProjectConcurrency : undefined);
 
     let enqueued = 0;
     for (const batch of plan.executionOrder) {

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -414,6 +414,27 @@ export class JobQueue {
   }
 
   /**
+   * Sets the per-project concurrency limit for the given repo at runtime.
+   * Pass null to remove the project-specific limit.
+   */
+  setProjectConcurrency(repo: string, limit: number | null): void {
+    if (limit !== null && (limit <= 0 || !Number.isInteger(limit))) {
+      throw new Error("Project concurrency limit must be a positive integer");
+    }
+
+    if (limit === null) {
+      this.projectConcurrency.delete(repo);
+      logger.info(`Project concurrency limit removed for ${repo}`);
+    } else {
+      this.projectConcurrency.set(repo, limit);
+      logger.info(`Project concurrency limit for ${repo} set to ${limit}`);
+    }
+
+    // Trigger immediate processing in case capacity increased
+    this.processNext();
+  }
+
+  /**
    * Returns queue status.
    */
   getStatus(): { pending: number; running: number; concurrency: number } {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -300,6 +300,26 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
     setGlobalLogLevel(newConfig.general.logLevel);
     logger.info(`Log level updated: ${oldConfig.general.logLevel} → ${newConfig.general.logLevel}`);
   }
+
+  // Update per-project concurrency limits
+  const oldProjects = new Map((oldConfig.projects ?? []).map(p => [p.repo, p.concurrency ?? null]));
+  const newProjects = new Map((newConfig.projects ?? []).map(p => [p.repo, p.concurrency ?? null]));
+
+  for (const [repo, newLimit] of newProjects) {
+    const oldLimit = oldProjects.get(repo) ?? null;
+    if (newLimit !== oldLimit) {
+      queue.setProjectConcurrency(repo, newLimit);
+      logger.info(`Project concurrency updated for ${repo}: ${oldLimit ?? "unlimited"} → ${newLimit ?? "unlimited"}`);
+    }
+  }
+
+  // Remove limits for projects that were removed from config
+  for (const [repo] of oldProjects) {
+    if (!newProjects.has(repo)) {
+      queue.setProjectConcurrency(repo, null);
+      logger.info(`Project concurrency limit removed for ${repo} (project removed from config)`);
+    }
+  }
 }
 
 /**

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1402,4 +1402,174 @@ describe("JobQueue", () => {
       expect(queue.isProjectPaused("test/repo")).toBe(false);
     });
   });
+
+  describe("setProjectConcurrency", () => {
+    it("should set per-project concurrency limit at runtime", async () => {
+      const handler: JobHandler = vi.fn().mockImplementation(async () => {
+        await new Promise(r => setTimeout(r, 100));
+        return { prUrl: "https://test-pr" };
+      });
+
+      const queue = new JobQueue(store, 5, handler);
+
+      // Set project limit to 1
+      queue.setProjectConcurrency("test/repo", 1);
+
+      // Enqueue 3 jobs for same repo
+      queue.enqueue(1, "test/repo");
+      queue.enqueue(2, "test/repo");
+      queue.enqueue(3, "test/repo");
+
+      // Only 1 should run at a time
+      await new Promise(r => setTimeout(r, 50));
+      expect(queue.getStatus().running).toBe(1);
+      expect(queue.getStatus().pending).toBe(2);
+
+      // Wait for all to complete
+      await new Promise(r => setTimeout(r, 400));
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it("should remove per-project limit when null is passed", async () => {
+      let maxRunning = 0;
+      let currentRunning = 0;
+
+      const handler: JobHandler = vi.fn().mockImplementation(async () => {
+        currentRunning++;
+        maxRunning = Math.max(maxRunning, currentRunning);
+        await new Promise(r => setTimeout(r, 100));
+        currentRunning--;
+        return { prUrl: "https://test-pr" };
+      });
+
+      // Start with limit of 1
+      const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+
+      // Remove the limit at runtime
+      queue.setProjectConcurrency("test/repo", null);
+
+      // Now all jobs should be able to run simultaneously (up to global limit 5)
+      queue.enqueue(1, "test/repo");
+      queue.enqueue(2, "test/repo");
+      queue.enqueue(3, "test/repo");
+
+      await new Promise(r => setTimeout(r, 50));
+      expect(maxRunning).toBeGreaterThanOrEqual(2); // more than 1 can run now
+
+      await new Promise(r => setTimeout(r, 200));
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it("should validate limit value", () => {
+      const handler: JobHandler = vi.fn();
+      const queue = new JobQueue(store, 1, handler);
+
+      expect(() => queue.setProjectConcurrency("test/repo", 0)).toThrow("Project concurrency limit must be a positive integer");
+      expect(() => queue.setProjectConcurrency("test/repo", -1)).toThrow("Project concurrency limit must be a positive integer");
+      expect(() => queue.setProjectConcurrency("test/repo", 1.5)).toThrow("Project concurrency limit must be a positive integer");
+
+      // null should be valid (removes limit)
+      expect(() => queue.setProjectConcurrency("test/repo", null)).not.toThrow();
+
+      // positive integers should be valid
+      expect(() => queue.setProjectConcurrency("test/repo", 1)).not.toThrow();
+      expect(() => queue.setProjectConcurrency("test/repo", 3)).not.toThrow();
+    });
+
+    it("should trigger immediate processing when limit is increased at runtime", async () => {
+      const handler: JobHandler = vi.fn().mockImplementation(async () => {
+        await new Promise(r => setTimeout(r, 100));
+        return { prUrl: "https://test-pr" };
+      });
+
+      // Start with project limit of 1
+      const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+
+      queue.enqueue(1, "test/repo");
+      queue.enqueue(2, "test/repo");
+      queue.enqueue(3, "test/repo");
+
+      // Wait for first to start
+      await new Promise(r => setTimeout(r, 30));
+      expect(queue.getStatus().running).toBe(1);
+      expect(queue.getStatus().pending).toBe(2);
+
+      // Increase to 2 — should immediately start another pending job
+      queue.setProjectConcurrency("test/repo", 2);
+      await new Promise(r => setTimeout(r, 30));
+      expect(queue.getStatus().running).toBe(2);
+      expect(queue.getStatus().pending).toBe(1);
+
+      // Wait for all to complete
+      await new Promise(r => setTimeout(r, 300));
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it("should initialize project concurrency via constructor and apply limits correctly", async () => {
+      const runningByRepo: Record<string, number> = {};
+      const maxByRepo: Record<string, number> = {};
+
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        const repo = job.repo;
+        runningByRepo[repo] = (runningByRepo[repo] || 0) + 1;
+        maxByRepo[repo] = Math.max(maxByRepo[repo] || 0, runningByRepo[repo]);
+
+        await new Promise(r => setTimeout(r, 100));
+
+        runningByRepo[repo]--;
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      // Pass projectConcurrency via constructor (CLI 연동 시나리오)
+      const queue = new JobQueue(store, 10, handler, 600000, {
+        "org/repo-a": 1,
+        "org/repo-b": 2,
+      });
+
+      // Enqueue multiple jobs for each repo
+      queue.enqueue(1, "org/repo-a");
+      queue.enqueue(2, "org/repo-a");
+      queue.enqueue(3, "org/repo-b");
+      queue.enqueue(4, "org/repo-b");
+      queue.enqueue(5, "org/repo-b");
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // repo-a limited to 1
+      expect(maxByRepo["org/repo-a"] || 0).toBeLessThanOrEqual(1);
+      // repo-b limited to 2
+      expect(maxByRepo["org/repo-b"] || 0).toBeLessThanOrEqual(2);
+
+      await new Promise(r => setTimeout(r, 400));
+      expect(handler).toHaveBeenCalledTimes(5);
+    });
+
+    it("should apply runtime limit change independently per repo", async () => {
+      const handler: JobHandler = vi.fn().mockImplementation(async () => {
+        await new Promise(r => setTimeout(r, 100));
+        return { prUrl: "https://test-pr" };
+      });
+
+      const queue = new JobQueue(store, 5, handler);
+
+      // Set different limits for two repos
+      queue.setProjectConcurrency("org/repo-x", 1);
+      queue.setProjectConcurrency("org/repo-y", 2);
+
+      queue.enqueue(1, "org/repo-x");
+      queue.enqueue(2, "org/repo-x");
+      queue.enqueue(3, "org/repo-y");
+      queue.enqueue(4, "org/repo-y");
+      queue.enqueue(5, "org/repo-y");
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // repo-x: 1 running, 1 pending; repo-y: 2 running, 1 pending
+      expect(queue.getStatus().running).toBe(3);
+      expect(queue.getStatus().pending).toBe(2);
+
+      await new Promise(r => setTimeout(r, 400));
+      expect(handler).toHaveBeenCalledTimes(5);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #358 — feat: job-queue 프로젝트별 슬롯 분리 — 프로젝트 간 큐 격리

현재 JobQueue에 프로젝트별 concurrency 제한 기능이 구현되어 있지만, CLI에서 config.projects[].concurrency 값을 JobQueue에 전달하지 않아 실제로 동작하지 않습니다. 이로 인해 한 프로젝트의 잡들이 전체 슬롯을 점유할 수 있어 multi-repo 환경에서 프로젝트 간 격리가 되지 않습니다.

## Requirements

- CLI에서 config.projects[].concurrency 값을 추출하여 JobQueue 생성 시 전달
- JobQueue에 setProjectConcurrency 메서드 추가 (런타임 변경 지원)
- dashboard-api에서 프로젝트별 concurrency 변경 시 queue에 반영
- 프로젝트별 슬롯 격리 테스트 추가

## Implementation Phases

- Phase 0: JobQueue setProjectConcurrency 메서드 추가 — SUCCESS (9fb7d412)
- Phase 1: CLI에서 projectConcurrency 전달 — SUCCESS (95f847d0)
- Phase 2: dashboard-api 런타임 업데이트 연동 — SUCCESS (95f847d0)
- Phase 3: 테스트 추가 — SUCCESS (fba2dfd5)

## Risks

- 기존 projectConcurrency 로직 변경 시 이미 존재하는 테스트 실패 가능
- config 로딩 실패 시 기본값 처리 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/358-feat-job-queue` → `develop`
- **Tokens**: 177 input, 16239 output{{#stats.cacheCreationTokens}}, 236340 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2161360 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #358