### PR TITLE
[AQ-#359] feat: worktree 경로에 repo slug 포함 — 동일 이슈번호 충돌 방지

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -28,7 +28,7 @@ export const DEFAULT_CONFIG: AQConfig = {
     cleanupOnSuccess: true,
     cleanupOnFailure: false,
     maxAge: "24h",
-    dirTemplate: "{{issueNumber}}-{{slug}}",
+    dirTemplate: "{{repoSlug}}-{{issueNumber}}-{{slug}}",
   },
   commands: {
     claudeCli: {

--- a/src/git/worktree-manager.ts
+++ b/src/git/worktree-manager.ts
@@ -58,7 +58,13 @@ export async function createWorktree(
     ...(repoSlug && { repoSlug }),
   };
 
-  const dirName = renderTemplate(worktreeConfig.dirTemplate, templateVars);
+  // Backward compatibility: if repoSlug is not provided, remove the {{repoSlug}}- prefix
+  // from the template to avoid literal "{{repoSlug}}-" appearing in the directory name.
+  const effectiveTemplate = repoSlug
+    ? worktreeConfig.dirTemplate
+    : worktreeConfig.dirTemplate.replace(/\{\{\s*repoSlug\s*\}\}-/g, "");
+
+  const dirName = renderTemplate(effectiveTemplate, templateVars);
 
   // Resolve rootPath relative to cwd if not absolute
   const rootPath = resolve(options.cwd, worktreeConfig.rootPath);

--- a/src/safety/rollback-manager.ts
+++ b/src/safety/rollback-manager.ts
@@ -82,6 +82,7 @@ export interface EnsureCleanStateOptions {
   issueNumber: number;
   slug: string;
   worktreePath: string;
+  repoSlug?: string;
 }
 
 /**
@@ -125,7 +126,7 @@ export async function ensureCleanState(
         options.issueNumber,
         options.slug,
         { cwd: options.cwd },
-        undefined  // repoSlug not available in rollback context
+        options.repoSlug
       );
 
       logger.info(`Clean state restored via worktree recreation at ${newWorktreeInfo.path}`);

--- a/tests/git/worktree-manager.test.ts
+++ b/tests/git/worktree-manager.test.ts
@@ -50,6 +50,30 @@ describe("createWorktree", () => {
     expect(info.branch).toBe("ax/42-fix-bug");
   });
 
+  it("should strip {{repoSlug}}- prefix when repoSlug is not provided (double-brace template)", async () => {
+    const configWithDoublebraceTemplate = {
+      ...worktreeConfig,
+      dirTemplate: "{{repoSlug}}-{{issueNumber}}-{{slug}}",
+    };
+    mockRunCli.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+    // repoSlug 미전달 → {{repoSlug}}- 자동 제거되어 42-fix-bug 형태가 되어야 함
+    const info = await createWorktree(gitConfig, configWithDoublebraceTemplate, "ax/42-fix-bug", 42, "fix-bug", { cwd: "/repo" });
+    expect(info.path).toContain("42-fix-bug");
+    expect(info.path).not.toContain("repoSlug");
+    expect(info.branch).toBe("ax/42-fix-bug");
+  });
+
+  it("should include repoSlug when provided with double-brace dirTemplate", async () => {
+    const configWithDoublebraceTemplate = {
+      ...worktreeConfig,
+      dirTemplate: "{{repoSlug}}-{{issueNumber}}-{{slug}}",
+    };
+    mockRunCli.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
+    const info = await createWorktree(gitConfig, configWithDoublebraceTemplate, "ax/42-fix-bug", 42, "fix-bug", { cwd: "/repo" }, "myorg-myrepo");
+    expect(info.path).toContain("myorg-myrepo-42-fix-bug");
+    expect(info.branch).toBe("ax/42-fix-bug");
+  });
+
   it("should set AI-Quartermaster as git author in worktree", async () => {
     mockRunCli.mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 });
     await createWorktree(gitConfig, worktreeConfig, "ax/42-fix-bug", 42, "fix-bug", { cwd: "/repo" });


### PR DESCRIPTION
## Summary

Resolves #359 — feat: worktree 경로에 repo slug 포함 — 동일 이슈번호 충돌 방지

multi-repo 환경에서 동일한 이슈 번호가 서로 다른 저장소에 존재할 경우, 현재 dirTemplate(`{{issueNumber}}-{{slug}}`)으로는 worktree 경로가 충돌할 수 있다. 예: repo-A#42와 repo-B#42가 동일한 `42-fix-bug` 디렉토리를 사용하게 됨. repoSlug를 경로에 포함하여 충돌을 방지해야 한다.

## Requirements

- worktree dirTemplate 기본값에 repoSlug 포함 ({{repoSlug}}-{{issueNumber}}-{{slug}})
- repoSlug 없을 때 하위 호환 유지 (기존 {{issueNumber}}-{{slug}} 패턴으로 fallback)
- rollback-manager의 ensureCleanState에서 repoSlug 전달 지원
- 기존 테스트 통과 + 하위 호환성 테스트 추가

## Implementation Phases

- Phase 0: 기본값 변경 및 하위 호환 로직 — SUCCESS (fc1052ec)
- Phase 1: rollback-manager repoSlug 지원 — SUCCESS (1b153a42)
- Phase 2: 테스트 보강 — SUCCESS (1b153a42)

## Risks

- 기존 worktree 경로와의 하위 호환성 — repoSlug 미제공 시 기존 패턴 유지 필요
- config.yml에 기존 dirTemplate 사용 중인 사용자 — 기본값 변경은 새 설치에만 영향

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/359-feat-worktree-repo-slug` → `develop`
- **Tokens**: 139 input, 14324 output{{#stats.cacheCreationTokens}}, 152512 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1341963 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #359