### PR TITLE
[AQ-#360] feat: 프로젝트별 concurrency 설정 — 글로벌 + 프로젝트별 오버라이드

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -257,7 +257,7 @@ async function startCommand(args: CliArgs): Promise<void> {
       });
       return { error: errorMsg };
     }
-  }, effectiveConfig.general.stuckTimeoutMs);
+  }, effectiveConfig.general.stuckTimeoutMs, Object.fromEntries((effectiveConfig.projects ?? []).filter(p => p.concurrency !== undefined).map(p => [p.repo, p.concurrency!])));
 
   // Recover jobs from previous session
   queue.recover();
@@ -506,7 +506,7 @@ async function planCommand(args: CliArgs): Promise<void> {
     const { JobStore } = await import("./queue/job-store.js");
     const { JobQueue } = await import("./queue/job-queue.js");
     const store = new JobStore(dataDir);
-    const queue = new JobQueue(store, config.general.concurrency, async () => ({ error: "직접 실행 모드에서는 큐만 등록됩니다" }), config.general.stuckTimeoutMs);
+    const queue = new JobQueue(store, config.general.concurrency, async () => ({ error: "직접 실행 모드에서는 큐만 등록됩니다" }), config.general.stuckTimeoutMs, Object.fromEntries((config.projects ?? []).filter(p => p.concurrency !== undefined).map(p => [p.repo, p.concurrency!])));
 
     let enqueued = 0;
     for (const batch of plan.executionOrder) {


### PR DESCRIPTION
## Summary

Resolves #360 — feat: 프로젝트별 concurrency 설정 — 글로벌 + 프로젝트별 오버라이드

현재 JobQueue는 글로벌 concurrency만 사용하며, 프로젝트별 concurrency 설정이 config에 정의되어 있어도 실제로 적용되지 않습니다. types/config.ts, validator.ts, job-queue.ts에는 이미 projectConcurrency 지원이 구현되어 있으나, cli.ts에서 JobQueue 생성 시 config.projects[].concurrency 값을 전달하지 않아 연결이 끊어진 상태입니다.

## Requirements

- src/cli.ts에서 config.projects[].concurrency를 읽어 JobQueue 생성자에 전달
- 글로벌 concurrency가 기본값이고, 프로젝트별 concurrency가 오버라이드되도록 동작
- cli.ts의 두 곳(start 명령어, plan --execute)에서 모두 projectConcurrency 적용
- 통합 테스트로 config → JobQueue 연결 검증

## Implementation Phases

- Phase 0: cli.ts에 projectConcurrency 연결 — SUCCESS (40409c92)

## Risks

- 기존 동작 변경 없이 추가 파라미터만 전달하므로 위험 낮음
- projectConcurrency가 undefined인 경우 기존 글로벌 concurrency만 적용되어 하위 호환성 유지됨

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/360-feat-concurrency` → `develop`
- **Tokens**: 105 input, 8346 output{{#stats.cacheCreationTokens}}, 95125 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 823107 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #360