### PR TITLE
[AQ-#361] test: 프로젝트별 설정 오버라이드 검증 — commands/safety/review 독립 적용

### DIFF
--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -385,6 +385,213 @@ safety:
   });
 });
 
+describe("loadConfig - 프로젝트별 오버라이드 로딩", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `aq-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("should load project-level commands overrides from YAML", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "yarn test"
+      lint: "yarn lint"
+      build: "yarn build"
+`);
+    const config = loadConfig(testDir);
+
+    expect(config.projects).toHaveLength(1);
+    const project = config.projects![0];
+    expect(project.commands?.test).toBe("yarn test");
+    expect(project.commands?.lint).toBe("yarn lint");
+    expect(project.commands?.build).toBe("yarn build");
+  });
+
+  it("should load project-level typecheck command override from YAML", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      typecheck: "npx tsc --noEmit"
+      preInstall: "npm ci"
+`);
+    const config = loadConfig(testDir);
+
+    const project = config.projects![0];
+    expect(project.commands?.typecheck).toBe("npx tsc --noEmit");
+    expect(project.commands?.preInstall).toBe("npm ci");
+  });
+
+  it("should load project-level safety overrides from YAML", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    safety:
+      maxPhases: 5
+      maxFileChanges: 20
+`);
+    const config = loadConfig(testDir);
+
+    const project = config.projects![0];
+    expect(project.safety?.maxPhases).toBe(5);
+    expect(project.safety?.maxFileChanges).toBe(20);
+  });
+
+  it("should load project-level review overrides from YAML", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    review:
+      enabled: false
+      unifiedMode: true
+`);
+    const config = loadConfig(testDir);
+
+    const project = config.projects![0];
+    expect(project.review?.enabled).toBe(false);
+    expect(project.review?.unifiedMode).toBe(true);
+  });
+
+  it("should load all three override sections (commands, safety, review) simultaneously", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "pnpm test"
+      typecheck: "pnpm typecheck"
+    safety:
+      maxPhases: 8
+      maxFileChanges: 30
+    review:
+      enabled: true
+      unifiedMode: false
+`);
+    const config = loadConfig(testDir);
+
+    const project = config.projects![0];
+    expect(project.commands?.test).toBe("pnpm test");
+    expect(project.commands?.typecheck).toBe("pnpm typecheck");
+    expect(project.safety?.maxPhases).toBe(8);
+    expect(project.safety?.maxFileChanges).toBe(30);
+    expect(project.review?.enabled).toBe(true);
+    expect(project.review?.unifiedMode).toBe(false);
+  });
+
+  it("should keep project overrides independent across multiple projects", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo-a"
+    path: "/path/to/repo-a"
+    commands:
+      test: "jest"
+    safety:
+      maxPhases: 3
+  - repo: "owner/repo-b"
+    path: "/path/to/repo-b"
+    commands:
+      test: "vitest"
+    review:
+      enabled: false
+`);
+    const config = loadConfig(testDir);
+
+    expect(config.projects).toHaveLength(2);
+    const [projectA, projectB] = config.projects!;
+
+    expect(projectA.repo).toBe("owner/repo-a");
+    expect(projectA.commands?.test).toBe("jest");
+    expect(projectA.safety?.maxPhases).toBe(3);
+    expect(projectA.review).toBeUndefined();
+
+    expect(projectB.repo).toBe("owner/repo-b");
+    expect(projectB.commands?.test).toBe("vitest");
+    expect(projectB.safety).toBeUndefined();
+    expect(projectB.review?.enabled).toBe(false);
+  });
+
+  it("should not affect global config when project-level overrides are set", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+general:
+  projectName: "global-project"
+  logLevel: "warn"
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "custom-test"
+    safety:
+      maxPhases: 5
+`);
+    const config = loadConfig(testDir);
+
+    // Global config remains unchanged
+    expect(config.general.projectName).toBe("global-project");
+    expect(config.general.logLevel).toBe("warn");
+    expect(config.commands.test).toBe("npm test"); // global default
+    expect(config.safety.maxPhases).toBe(10); // global default
+
+    // Project overrides are stored separately
+    const project = config.projects![0];
+    expect(project.commands?.test).toBe("custom-test");
+    expect(project.safety?.maxPhases).toBe(5);
+  });
+
+  it("should load partial commands override without requiring all fields", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "yarn test"
+`);
+    const config = loadConfig(testDir);
+
+    const project = config.projects![0];
+    // Only test is overridden; other fields are undefined (not set)
+    expect(project.commands?.test).toBe("yarn test");
+    expect(project.commands?.lint).toBeUndefined();
+    expect(project.commands?.build).toBeUndefined();
+  });
+
+  it("should load project overrides from config.local.yml merged on top of config.yml", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "npm test"
+    safety:
+      maxPhases: 5
+`);
+    writeFileSync(join(testDir, "config.local.yml"), `
+projects:
+  - repo: "owner/repo"
+    path: "/path/to/repo"
+    commands:
+      test: "npm run test:ci"
+`);
+    const config = loadConfig(testDir);
+
+    // config.local.yml replaces the entire projects array (deepMerge on arrays replaces)
+    expect(config.projects).toHaveLength(1);
+    const project = config.projects![0];
+    expect(project.commands?.test).toBe("npm run test:ci");
+  });
+});
+
 describe("tryLoadConfig", () => {
   let testDir: string;
 

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -7,7 +7,8 @@ import {
   addProjectToConfig,
   removeProjectFromConfig,
   updateProjectInConfig,
-  initProject
+  initProject,
+  deepMerge
 } from "../../src/config/loader.js";
 import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
@@ -1550,5 +1551,101 @@ git:
     expect(config.general.dryRun).toBe(false);
     expect(config.safety.allowedLabels).toEqual(["bug", "feature"]);
     expect(config.commands.test).toBe("yarn test");
+  });
+});
+
+describe("deepMerge", () => {
+  it("should merge flat objects", () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: 3, c: 4 };
+    const result = deepMerge(target, source);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it("should recursively merge nested objects", () => {
+    const target = { outer: { a: 1, b: 2 } };
+    const source = { outer: { b: 99, c: 3 } };
+    const result = deepMerge(target, source);
+    expect(result).toEqual({ outer: { a: 1, b: 99, c: 3 } });
+  });
+
+  it("should replace arrays instead of concatenating", () => {
+    const target = { list: [1, 2, 3] };
+    const source = { list: [4, 5] };
+    const result = deepMerge(target, source);
+    expect((result as { list: number[] }).list).toEqual([4, 5]);
+  });
+
+  it("should return target when source is null", () => {
+    const target = { a: 1 };
+    const result = deepMerge(target, null);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("should return target when source is undefined", () => {
+    const target = { a: 1 };
+    const result = deepMerge(target, undefined);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("should return source when target is not a plain object", () => {
+    const source = { a: 1 };
+    const result = deepMerge("not-an-object", source);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("should return source primitive when source is not a plain object", () => {
+    const result = deepMerge({ a: 1 }, 42);
+    expect(result).toBe(42);
+  });
+
+  it("should handle deeply nested merges", () => {
+    const target = { a: { b: { c: 1, d: 2 } } };
+    const source = { a: { b: { d: 99, e: 3 } } };
+    const result = deepMerge(target, source);
+    expect(result).toEqual({ a: { b: { c: 1, d: 99, e: 3 } } });
+  });
+
+  it("should not mutate the original target", () => {
+    const target = { a: 1, b: { x: 10 } };
+    const source = { b: { x: 99 } };
+    deepMerge(target, source);
+    expect(target.b.x).toBe(10);
+  });
+
+  it("should prevent prototype pollution via __proto__", () => {
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>;
+    deepMerge({}, malicious);
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+  });
+
+  it("should prevent prototype pollution via constructor", () => {
+    const malicious = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}') as Record<string, unknown>;
+    deepMerge({}, malicious);
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+  });
+
+  it("should prevent prototype pollution via prototype key", () => {
+    const malicious = { prototype: { polluted: true } } as Record<string, unknown>;
+    deepMerge({}, malicious);
+    const obj = {} as Record<string, unknown>;
+    expect(obj["polluted"]).toBeUndefined();
+  });
+
+  it("should preserve target field when source field is null", () => {
+    const target = { a: { nested: 1 }, b: 2 };
+    const source = { a: null };
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    // deepMerge(target.a, null) returns target.a because source is null
+    expect(result["a"]).toEqual({ nested: 1 });
+    expect(result["b"]).toBe(2);
+  });
+
+  it("should merge source fields that do not exist in target", () => {
+    const target = { a: 1 };
+    const source = { b: { nested: true } };
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    expect(result["a"]).toBe(1);
+    expect(result["b"]).toEqual({ nested: true });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #361 — test: 프로젝트별 설정 오버라이드 검증 — commands/safety/review 독립 적용

프로젝트별 commands, safety, review 설정 오버라이드가 올바르게 동작하는지 검증하는 테스트가 부족합니다. 특히 loader.ts의 deepMerge 함수에 대한 단위 테스트가 없으며, loadConfig를 통한 프로젝트별 오버라이드 로딩 테스트가 loader.test.ts에 없습니다. 기존 project-override.test.ts는 resolveProject 함수만 테스트하고 있어 병합 로직 자체의 검증이 미흡합니다.

## Requirements

- 프로젝트별 commands (test, lint, build) 오버라이드 동작 테스트
- 프로젝트별 safety (maxPhases, sensitivePaths) 독립 적용 테스트
- 프로젝트별 review (rounds, simplify) 독립 적용 테스트
- 오버라이드 병합 로직 (deepMerge) 단위 테스트

## Implementation Phases

- Phase 0: deepMerge 단위 테스트 추가 — SUCCESS (c5f7ed24)
- Phase 1: 프로젝트별 오버라이드 로딩 테스트 추가 — SUCCESS (40615a0b)

## Risks

- deepMerge 테스트 추가 시 기존 테스트와 중복 가능성
- project-override.test.ts와의 테스트 범위 중복

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/361-test-commands-safety-review` → `develop`
- **Tokens**: 140 input, 17703 output{{#stats.cacheCreationTokens}}, 147876 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1827701 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #361