### PR TITLE
[AQ-#350] refactor: safety-checker 규칙 엔진 위임 — 기존 guard 로직 전환

### DIFF
--- a/src/safety/sensitive-path-guard.ts
+++ b/src/safety/sensitive-path-guard.ts
@@ -1,4 +1,4 @@
-import { minimatch } from "minimatch";
+import { checkPathsAgainstRules } from "./rule-engine.js";
 import { SafetyViolationError } from "../types/errors.js";
 
 /**
@@ -9,21 +9,26 @@ export function checkSensitivePaths(
   changedFiles: string[],
   sensitivePaths: string[]
 ): void {
-  const violations: string[] = [];
+  try {
+    checkPathsAgainstRules(changedFiles, {
+      allow: [],
+      deny: sensitivePaths,
+      strategy: "deny-first"
+    });
+  } catch (err: unknown) {
+    if (err instanceof SafetyViolationError) {
+      // Re-wrap RuleEngine errors as SensitivePathGuard errors to maintain API compatibility
+      const violations = err.details?.violations;
+      const violationsText = Array.isArray(violations) && violations.length > 0
+        ? violations.join("\n")
+        : err.message;
 
-  for (const file of changedFiles) {
-    for (const pattern of sensitivePaths) {
-      if (minimatch(file, pattern, { dot: true })) {
-        violations.push(`${file} matches sensitive pattern "${pattern}"`);
-      }
+      throw new SafetyViolationError(
+        "SensitivePathGuard",
+        `Sensitive files modified:\n${violationsText}`,
+        err.details
+      );
     }
-  }
-
-  if (violations.length > 0) {
-    throw new SafetyViolationError(
-      "SensitivePathGuard",
-      `Sensitive files modified:\n${violations.join("\n")}`,
-      { violations }
-    );
+    throw err;
   }
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,7 +91,6 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
-  partial?: boolean;
   warnings?: string[];
   errors?: string[];
   commitHash?: string;


### PR DESCRIPTION
## Summary

Resolves #350 — refactor: safety-checker 규칙 엔진 위임 — 기존 guard 로직 전환

sensitive-path-guard.ts에서 minimatch를 직접 사용하여 민감 경로를 체크하는 로직이 하드코딩되어 있다. rule-engine.ts에 이미 allow/deny 규칙 기반 범용 경로 체크 로직이 구현되어 있으므로, 중복 로직을 제거하고 sensitive-path-guard가 rule-engine을 내부적으로 활용하도록 리팩토링하여 코드 재사용성과 일관성을 높인다.

## Requirements

- sensitive-path-guard.ts가 rule-engine의 checkPathsAgainstRules를 내부적으로 사용하도록 위임
- 기존 checkSensitivePaths 함수 시그니처 및 동작 완전 유지 (breaking change 없음)
- SafetyViolationError의 guard 이름은 'SensitivePathGuard' 유지
- 기존 테스트 전체 통과

## Implementation Phases

- Phase 0: 규칙 엔진 타입 정의 — SUCCESS (cbceeb1e)
- Phase 1: 규칙 엔진 코어 구현 — SUCCESS (4ef79fdf)
- Phase 2: 기존 guard를 Rule로 래핑 — SUCCESS (4ef79fdf)
- Phase 3: safety-checker를 rule-engine으로 전환 — SUCCESS (e6667a7b)
- Phase 4: 규칙 엔진 테스트 추가 — SUCCESS (38f3d62f)

## Risks

- 에러 메시지 포맷 변경으로 기존 테스트 실패 가능성 — rule-engine의 에러 메시지를 래핑하여 기존 포맷 유지 필요
- rule-engine은 allow 패턴도 지원하지만 sensitive-path-guard는 deny-only로 사용 — 불필요한 allow 빈 배열 전달 확인

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/350-refactor-safety-checker-guard` → `develop`
- **Tokens**: 52 input, 3205 output{{#stats.cacheCreationTokens}}, 47933 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 198386 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #350