### PR TITLE
[AQ-#381] fix: config-watcher 메모리 누수 점검 + 폴링 주기 동적 조절

### DIFF
--- a/src/config/config-watcher.ts
+++ b/src/config/config-watcher.ts
@@ -18,6 +18,7 @@ export class ConfigWatcher extends EventEmitter {
   private debounceTimer: NodeJS.Timeout | null = null;
   private pendingChanges: Set<string> = new Set();
   private errorCounts: Map<string, number> = new Map();
+  private restartTimers: Set<NodeJS.Timeout> = new Set();
   private readonly maxErrorRetries = 3;
   private readonly errorRetryDelay = 1000; // 1 second
 
@@ -63,6 +64,12 @@ export class ConfigWatcher extends EventEmitter {
         logger.warn(`Error closing watcher for ${path}: ${err}`);
       }
     }
+
+    // Clear all pending restart timers
+    for (const timer of this.restartTimers) {
+      clearTimeout(timer);
+    }
+    this.restartTimers.clear();
 
     // Clear all maps and sets
     this.watchers.clear();
@@ -215,9 +222,11 @@ export class ConfigWatcher extends EventEmitter {
     // Attempt to restart the watcher if we haven't exceeded retry limit
     if (errorCount <= this.maxErrorRetries) {
       logger.info(`Attempting to restart watcher for ${filePath} in ${this.errorRetryDelay}ms`);
-      setTimeout(() => {
+      const timer = setTimeout(() => {
+        this.restartTimers.delete(timer);
         this.restartWatcher(filePath, type);
       }, this.errorRetryDelay);
+      this.restartTimers.add(timer);
     } else {
       logger.error(`Maximum retry attempts exceeded for ${filePath}. Disabling watcher for this file.`);
       this.errorCounts.delete(filePath); // Clean up error count

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -10,6 +10,8 @@ export const DEFAULT_CONFIG: AQConfig = {
     concurrency: 1,
     stuckTimeoutMs: 600000,
     pollingIntervalMs: 60000,
+    idlePollingIntervalMs: 300000,
+    idleThresholdCycles: 3,
     maxJobs: 500,
     autoUpdate: false,
   },

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -151,8 +151,8 @@ const generalConfigSchema = z.object({
   targetRoot: z.string().optional(),
   stuckTimeoutMs: z.number().int().min(60000),
   pollingIntervalMs: z.number().int().min(10000),
-  idlePollingIntervalMs: z.number().int().min(10000),
-  idleThresholdCycles: z.number().int().min(1),
+  idlePollingIntervalMs: z.number().int().min(10000).default(300000),
+  idleThresholdCycles: z.number().int().min(1).default(3),
   maxJobs: z.number().int().min(1),
   autoUpdate: z.boolean(),
 });

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -151,6 +151,8 @@ const generalConfigSchema = z.object({
   targetRoot: z.string().optional(),
   stuckTimeoutMs: z.number().int().min(60000),
   pollingIntervalMs: z.number().int().min(10000),
+  idlePollingIntervalMs: z.number().int().min(10000),
+  idleThresholdCycles: z.number().int().min(1),
   maxJobs: z.number().int().min(1),
   autoUpdate: z.boolean(),
 });

--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -28,6 +28,7 @@ export class IssuePoller {
   private selfUpdater: SelfUpdater | undefined;
   private onUpdateAvailable?: UpdateAvailableCallback;
   private pollingErrors = new Map<string, { count: number; lastErrorAt: number }>(); // repo -> error state
+  private consecutiveIdleCycles = 0; // 연속 idle 사이클 카운터
 
   constructor(
     config: AQConfig,
@@ -62,12 +63,21 @@ export class IssuePoller {
     return this.running;
   }
 
+  getCurrentPollingInterval(): number {
+    const { pollingIntervalMs, idlePollingIntervalMs, idleThresholdCycles } = this.config.general;
+    if (this.consecutiveIdleCycles >= idleThresholdCycles) {
+      return idlePollingIntervalMs;
+    }
+    return pollingIntervalMs;
+  }
+
   private scheduleNext(): void {
     if (!this.running) return;
+    const interval = this.getCurrentPollingInterval();
     this.timer = setTimeout(async () => {
       await this.poll();
       this.scheduleNext();
-    }, this.config.general.pollingIntervalMs);
+    }, interval);
   }
 
   private async poll(): Promise<void> {
@@ -75,6 +85,7 @@ export class IssuePoller {
     const triggerLabels = this.config.safety.allowedLabels;
     const ghPath = this.config.commands.ghCli.path;
     const ghTimeout = this.config.commands.ghCli.timeout;
+    let foundNewActivity = false;
 
     logger.debug(`폴링 사이클 시작 — 프로젝트 ${projects.length}개, 레이블: [${triggerLabels.join(", ")}]`);
 
@@ -107,7 +118,10 @@ export class IssuePoller {
       const projectTimeout = p.commands?.ghCli?.timeout ?? ghTimeout;
       return triggerLabels.map(l => this.pollProjectLabel(p.repo, l, ghPath, projectTimeout));
     });
-    await Promise.allSettled(issueTasks);
+    const issueResults = await Promise.allSettled(issueTasks);
+    if (issueResults.some(r => r.status === "fulfilled" && r.value === true)) {
+      foundNewActivity = true;
+    }
 
     // PR 충돌 체크 (활성 프로젝트만)
     const prTasks = activeProjects.map(p => {
@@ -117,7 +131,21 @@ export class IssuePoller {
     await Promise.allSettled(prTasks);
 
     // 2. Failed job 감지 및 재큐잉
-    await this.pollFailedJobs();
+    const hadFailedJobActivity = await this.pollFailedJobs();
+    if (hadFailedJobActivity) {
+      foundNewActivity = true;
+    }
+
+    // idle 카운터 업데이트
+    if (foundNewActivity) {
+      this.consecutiveIdleCycles = 0;
+    } else {
+      this.consecutiveIdleCycles++;
+      const { idleThresholdCycles, idlePollingIntervalMs } = this.config.general;
+      if (this.consecutiveIdleCycles === idleThresholdCycles) {
+        logger.info(`idle 상태 감지 (${idleThresholdCycles}회 연속) — 폴링 간격 ${idlePollingIntervalMs}ms로 전환`);
+      }
+    }
   }
 
   private async checkForUpdates(): Promise<void> {
@@ -142,8 +170,9 @@ export class IssuePoller {
     label: string,
     ghPath: string,
     timeout: number
-  ): Promise<void> {
+  ): Promise<boolean> {
     let issues: RawIssue[];
+    let enqueuedAny = false;
     try {
       const result = await runCli(
         ghPath,
@@ -161,7 +190,7 @@ export class IssuePoller {
       if (result.exitCode !== 0) {
         logger.warn(`이슈 목록 조회 실패 (${repo}, label=${label}): ${result.stderr || result.stdout}`);
         this.trackPollingFailure(repo, `이슈 목록 조회 실패 (exit ${result.exitCode})`);
-        return;
+        return false;
       }
 
       issues = JSON.parse(result.stdout) as RawIssue[];
@@ -171,7 +200,7 @@ export class IssuePoller {
       const errorMsg = getErrorMessage(err);
       logger.warn(`폴링 중 오류 (${repo}, label=${label}): ${errorMsg}`);
       this.trackPollingFailure(repo, errorMsg);
-      return;
+      return false;
     }
 
     logger.debug(`${repo} — 레이블 "${label}" 오픈 이슈 ${issues.length}개 조회됨`);
@@ -198,7 +227,9 @@ export class IssuePoller {
       }
       logger.info(`새 이슈 발견 — #${issue.number} "${issue.title}" (${repo}), 큐에 추가`);
       this.queue.enqueue(issue.number, repo);
+      enqueuedAny = true;
     }
+    return enqueuedAny;
   }
 
   private async checkProjectPrConflicts(repo: string, ghPath: string, timeout: number): Promise<void> {
@@ -280,17 +311,18 @@ ${filesList}베이스 브랜치의 변경으로 인해 이 PR에서 머지 충�
 _자동 생성된 알림 — AQM PR 모니터링_`;
   }
 
-  private async pollFailedJobs(): Promise<void> {
+  private async pollFailedJobs(): Promise<boolean> {
     try {
       const failedJobs = this.store.findFailedJobsForRetry();
 
       if (failedJobs.length === 0) {
         logger.debug("재시도할 실패 job 없음");
-        return;
+        return false;
       }
 
       logger.info(`실패 job ${failedJobs.length}개 발견, 재큐잉 시작`);
 
+      let enqueuedAny = false;
       for (const job of failedJobs) {
         logger.info(`실패 job 재큐잉 — #${job.issueNumber} "${job.repo}" (job: ${job.id})`);
 
@@ -299,12 +331,15 @@ _자동 생성된 알림 — AQM PR 모니터링_`;
 
         if (newJob) {
           logger.info(`재큐잉 성공 — 새 job: ${newJob.id}`);
+          enqueuedAny = true;
         } else {
           logger.warn(`재큐잉 실패 — #${job.issueNumber} (${job.repo})`);
         }
       }
+      return enqueuedAny;
     } catch (err: unknown) {
       logger.warn(`Failed job 폴링 중 오류: ${getErrorMessage(err)}`);
+      return false;
     }
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,6 +29,8 @@ export interface GeneralConfig {
   targetRoot?: string;
   stuckTimeoutMs: number;
   pollingIntervalMs: number;
+  idlePollingIntervalMs: number;
+  idleThresholdCycles: number;
   maxJobs: number;
   autoUpdate: boolean;
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,7 +91,6 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
-  partial?: boolean;
   warnings?: string[];
   errors?: string[];
   commitHash?: string;

--- a/tests/config/config-watcher.test.ts
+++ b/tests/config/config-watcher.test.ts
@@ -288,6 +288,21 @@ general:
     expect((watcher as any).errorCounts.size).toBe(0);
   });
 
+  it("should clear pending restart timers on stopWatching", () => {
+    watcher.startWatching();
+
+    // Trigger an error that schedules a restart timer
+    (watcher as any).handleWatcherError(configPath, 'base', new Error('Test error'));
+
+    // Verify a restart timer was scheduled
+    expect((watcher as any).restartTimers.size).toBeGreaterThan(0);
+
+    // Stop watching — should clear all restart timers
+    watcher.stopWatching();
+
+    expect((watcher as any).restartTimers.size).toBe(0);
+  });
+
   it("should attempt to restart watcher after error", () => {
     return new Promise<void>((done) => {
       let errorHandled = false;

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -23,6 +23,8 @@ describe("validateConfig", () => {
       concurrency: 2,
       stuckTimeoutMs: 600000,
       pollingIntervalMs: 60000,
+      idlePollingIntervalMs: 300000,
+      idleThresholdCycles: 3,
       maxJobs: 100,
       autoUpdate: false,
     },

--- a/tests/e2e/polling-integration.test.ts
+++ b/tests/e2e/polling-integration.test.ts
@@ -883,4 +883,123 @@ describe("E2E: polling integration", () => {
 
     expect(queue.enqueue).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // Dynamic polling interval tests
+  // -------------------------------------------------------------------------
+
+  // 21. idle 상태 감지: 연속 idle 사이클이 임계값에 도달하면 idle 간격 반환
+  it("switches to idle polling interval after consecutive idle cycles reach threshold", async () => {
+    const store = makeJobStore();
+    const queue = makeJobQueue(store);
+
+    const config = makeConfig();
+    config.general.idleThresholdCycles = 3;
+    config.general.idlePollingIntervalMs = 500;
+
+    mockRunCli.mockResolvedValue({ stdout: makeGhIssueListResponse([]), stderr: "", exitCode: 0 });
+
+    poller = new IssuePoller(config, store as any, queue as any);
+
+    // 초기 상태: 일반 간격
+    expect((poller as any).getCurrentPollingInterval()).toBe(config.general.pollingIntervalMs);
+
+    // 임계값 미만 사이클 — 아직 일반 간격
+    await (poller as any).poll();
+    await (poller as any).poll();
+    expect((poller as any).consecutiveIdleCycles).toBe(2);
+    expect((poller as any).getCurrentPollingInterval()).toBe(config.general.pollingIntervalMs);
+
+    // 임계값 도달 — idle 간격으로 전환
+    await (poller as any).poll();
+    expect((poller as any).consecutiveIdleCycles).toBe(3);
+    expect((poller as any).getCurrentPollingInterval()).toBe(500);
+  });
+
+  // 22. 간격 전환: idle 이후 추가 사이클에서도 idle 간격 유지
+  it("maintains idle polling interval for subsequent idle cycles beyond threshold", async () => {
+    const store = makeJobStore();
+    const queue = makeJobQueue(store);
+
+    const config = makeConfig();
+    config.general.idleThresholdCycles = 2;
+    config.general.idlePollingIntervalMs = 600;
+
+    mockRunCli.mockResolvedValue({ stdout: makeGhIssueListResponse([]), stderr: "", exitCode: 0 });
+
+    poller = new IssuePoller(config, store as any, queue as any);
+
+    // 임계값 도달
+    await (poller as any).poll();
+    await (poller as any).poll();
+    expect((poller as any).getCurrentPollingInterval()).toBe(600);
+
+    // 임계값 초과 이후에도 idle 간격 유지
+    await (poller as any).poll();
+    await (poller as any).poll();
+    expect((poller as any).consecutiveIdleCycles).toBe(4);
+    expect((poller as any).getCurrentPollingInterval()).toBe(600);
+  });
+
+  // 23. 활동 재개 시 복귀: 새 이슈 감지 시 idle 카운터 리셋, 일반 간격으로 복귀
+  it("resets idle counter and restores normal polling interval when new activity is detected", async () => {
+    const store = makeJobStore();
+    const queue = makeJobQueue(store);
+
+    const config = makeConfig();
+    config.general.idleThresholdCycles = 2;
+    config.general.idlePollingIntervalMs = 600;
+
+    mockRunCli.mockResolvedValue({ stdout: makeGhIssueListResponse([]), stderr: "", exitCode: 0 });
+
+    poller = new IssuePoller(config, store as any, queue as any);
+
+    // idle 상태로 진입
+    await (poller as any).poll();
+    await (poller as any).poll();
+    expect((poller as any).getCurrentPollingInterval()).toBe(600);
+
+    // 새 이슈 감지 → 활동 재개
+    mockRunCli.mockResolvedValue({
+      stdout: makeGhIssueListResponse([{ number: 200, title: "New task", labels: ["aq-task"] }]),
+      stderr: "",
+      exitCode: 0,
+    });
+    await (poller as any).poll();
+
+    // 카운터 리셋, 일반 간격으로 복귀
+    expect((poller as any).consecutiveIdleCycles).toBe(0);
+    expect((poller as any).getCurrentPollingInterval()).toBe(config.general.pollingIntervalMs);
+  });
+
+  // 24. 활동 재개: failed job 재큐잉도 활동으로 인정해 idle 카운터 리셋
+  it("resets idle counter when failed job re-queuing counts as activity", async () => {
+    const oldFailureTime = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    const store = makeJobStore();
+    const queue = makeJobQueue(store);
+
+    const config = makeConfig();
+    config.general.idleThresholdCycles = 1;
+    config.general.idlePollingIntervalMs = 800;
+
+    mockRunCli.mockResolvedValue({ stdout: makeGhIssueListResponse([]), stderr: "", exitCode: 0 });
+
+    // 첫 번째 poll: failed job 없음 + 이슈 없음 → idle 상태 진입
+    store.findFailedJobsForRetry.mockReturnValueOnce([]);
+    poller = new IssuePoller(config, store as any, queue as any);
+    await (poller as any).poll();
+    expect((poller as any).consecutiveIdleCycles).toBe(1);
+    expect((poller as any).getCurrentPollingInterval()).toBe(800);
+
+    // 두 번째 poll: failed job 반환 → 재큐잉 활동 감지
+    store.findFailedJobsForRetry.mockReturnValueOnce([
+      { id: "aq-110-0", issueNumber: 110, repo: "test/repo", status: "failure", createdAt: new Date().toISOString(), completedAt: oldFailureTime }
+    ]);
+
+    await (poller as any).poll();
+
+    // failed job 재큐잉으로 활동 감지 → 카운터 리셋
+    expect((poller as any).consecutiveIdleCycles).toBe(0);
+    expect((poller as any).getCurrentPollingInterval()).toBe(config.general.pollingIntervalMs);
+  });
 });

--- a/tests/polling/issue-poller.test.ts
+++ b/tests/polling/issue-poller.test.ts
@@ -854,4 +854,87 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(400, "test/repo");
     });
   });
+
+  describe("동적 폴링 간격 (idle 상태 추적)", () => {
+    it("getCurrentPollingInterval - idle 임계값 미만이면 기본 간격 반환", () => {
+      const config = makeConfig();
+      config.general.pollingIntervalMs = 60000;
+      config.general.idlePollingIntervalMs = 300000;
+      config.general.idleThresholdCycles = 3;
+      const p = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      expect(p.getCurrentPollingInterval()).toBe(60000);
+    });
+
+    it("getCurrentPollingInterval - idle 임계값 도달 시 idle 간격 반환", async () => {
+      const config = makeConfig();
+      config.general.pollingIntervalMs = 60000;
+      config.general.idlePollingIntervalMs = 300000;
+      config.general.idleThresholdCycles = 2;
+      const p = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      mockRunCli.mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+      mockListOpenPrs.mockResolvedValue([]);
+
+      // 2회 연속 idle 사이클
+      await (p as any).poll();
+      await (p as any).poll();
+
+      expect(p.getCurrentPollingInterval()).toBe(300000);
+    });
+
+    it("새 이슈 발견 시 idle 카운터 리셋", async () => {
+      const config = makeConfig();
+      config.general.pollingIntervalMs = 60000;
+      config.general.idlePollingIntervalMs = 300000;
+      config.general.idleThresholdCycles = 1;
+      config.safety.allowedLabels = ["aqm:ready"];
+      const p = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      mockListOpenPrs.mockResolvedValue([]);
+
+      // 첫 사이클: idle (이슈 없음)
+      mockRunCli.mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+      await (p as any).poll();
+      expect(p.getCurrentPollingInterval()).toBe(300000); // idle 전환
+
+      // 두번째 사이클: 새 이슈 발견 → idle 카운터 리셋
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockRunCli.mockResolvedValueOnce({
+        stdout: JSON.stringify([{ number: 42, title: "New issue", labels: [] }]),
+        stderr: "",
+        exitCode: 0
+      });
+      mockQueue.enqueue.mockReturnValue({ id: "job-1" });
+      await (p as any).poll();
+
+      expect(p.getCurrentPollingInterval()).toBe(60000); // 기본 간격으로 복귀
+    });
+
+    it("failed job 재큐잉 시 idle 카운터 리셋", async () => {
+      const failedJob = { id: "job-old", issueNumber: 10, repo: "test/repo" };
+      mockStore.findFailedJobsForRetry.mockReturnValue([failedJob]);
+      mockQueue.enqueue.mockReturnValue({ id: "job-new" });
+
+      const config = makeConfig();
+      config.general.pollingIntervalMs = 60000;
+      config.general.idlePollingIntervalMs = 300000;
+      config.general.idleThresholdCycles = 1;
+      const p = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // 먼저 idle 상태로 진입 (failed job 없는 첫 사이클)
+      mockStore.findFailedJobsForRetry.mockReturnValueOnce([]);
+      mockRunCli.mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+      mockListOpenPrs.mockResolvedValue([]);
+      await (p as any).poll();
+      expect(p.getCurrentPollingInterval()).toBe(300000);
+
+      // failed job 재큐잉 사이클
+      mockStore.findFailedJobsForRetry.mockReturnValueOnce([failedJob]);
+      mockRunCli.mockResolvedValueOnce({ stdout: "[]", stderr: "", exitCode: 0 });
+      await (p as any).poll();
+
+      expect(p.getCurrentPollingInterval()).toBe(60000); // idle 카운터 리셋
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #381 — fix: config-watcher 메모리 누수 점검 + 폴링 주기 동적 조절

config-watcher.ts에서 handleWatcherError의 setTimeout으로 예약된 restart 타이머가 stopWatching() 호출 시 정리되지 않아 메모리 누수 가능성이 있다. 또한 issue-poller.ts는 고정 폴링 간격만 사용하여 idle 상태에서도 불필요한 리소스를 소모한다. idle 상태 시 폴링 간격을 늘리고 활동 재개 시 원래 간격으로 복귀하는 동적 조절이 필요하다.

## Requirements

- config-watcher.ts: restart 대기 타이머 추적 및 stopWatching()에서 정리
- issue-poller.ts: idle 상태 감지 로직 추가 (새 이슈/잡 없음)
- idle 상태 시 폴링 간격 늘리기 (기본 1분 → 5분)
- 활동 재개 시 원래 간격 복귀
- config에 idlePollingIntervalMs 설정 필드 추가
- 기존 테스트 통과 + 새 기능 테스트 추가

## Implementation Phases

- Phase 0: config-watcher 메모리 누수 수정 — SUCCESS (a43a7f42)
- Phase 1: config 설정 필드 추가 — SUCCESS (a43a7f42)
- Phase 2: IssuePoller 동적 폴링 구현 — SUCCESS (981ed38a)
- Phase 3: 테스트 추가 및 검증 — SUCCESS (5ff8c196)

## Risks

- 폴링 간격 변경이 기존 동작에 영향을 줄 수 있음
- idle 판정 기준이 부정확할 경우 불필요한 간격 전환 발생
- 타이머 정리 로직이 race condition을 유발할 수 있음

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/381-fix-config-watcher` → `develop`
- **Tokens**: 279 input, 36842 output{{#stats.cacheCreationTokens}}, 255495 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 4356783 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #381