### PR TITLE
[AQ-#383] feat: Claude coordinator 신규 생성 — 워커 태스크 분배

### DIFF
--- a/src/claude/coordinator.ts
+++ b/src/claude/coordinator.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "crypto";
+import { runClaude } from "./claude-runner.js";
+import type { ClaudeRunOptions, ClaudeRunResult } from "./claude-runner.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+
+export type TaskStatus = "pending" | "running" | "completed" | "failed";
+
+export interface CoordinatorTask {
+  id: string;
+  options: ClaudeRunOptions;
+  submittedAt: string;
+  priority?: number;
+}
+
+export interface CoordinatorResult {
+  taskId: string;
+  status: TaskStatus;
+  result?: ClaudeRunResult;
+  error?: string;
+  completedAt?: string;
+  durationMs?: number;
+}
+
+/** Worker pool interface — implemented in Phase 3 (worker-pool integration) */
+export interface WorkerPool {
+  submitTask(task: CoordinatorTask): Promise<ClaudeRunResult>;
+  isAvailable(): boolean;
+}
+
+/**
+ * Coordinator manages task submission and result tracking.
+ *
+ * When multiAI is enabled and a worker pool is available, tasks are
+ * dispatched to the pool for parallel execution. Otherwise the coordinator
+ * falls back to the single claude-runner.
+ */
+export class Coordinator {
+  private readonly tasks = new Map<string, CoordinatorResult>();
+  private readonly waiters = new Map<string, Array<(result: CoordinatorResult) => void>>();
+  private readonly multiAIEnabled: boolean;
+  private readonly workerPool?: WorkerPool;
+
+  constructor(multiAIEnabled: boolean, workerPool?: WorkerPool) {
+    this.multiAIEnabled = multiAIEnabled;
+    this.workerPool = workerPool;
+  }
+
+  /**
+   * Submit a task for execution. Returns the task ID immediately.
+   * The task runs asynchronously in the background.
+   */
+  async submitTask(options: ClaudeRunOptions): Promise<string> {
+    const taskId = randomUUID();
+    const task: CoordinatorTask = {
+      id: taskId,
+      options,
+      submittedAt: new Date().toISOString(),
+    };
+
+    this.tasks.set(taskId, { taskId, status: "pending" });
+
+    // Fire-and-forget; errors are captured in the task result
+    this._executeTask(task).catch(() => undefined);
+
+    return taskId;
+  }
+
+  /**
+   * Returns the current status of a task, or undefined if not found.
+   */
+  getStatus(taskId: string): CoordinatorResult | undefined {
+    return this.tasks.get(taskId);
+  }
+
+  /**
+   * Waits until the given task reaches a terminal state (completed/failed).
+   * Resolves immediately if the task is already done.
+   */
+  async waitForCompletion(taskId: string): Promise<CoordinatorResult> {
+    const current = this.tasks.get(taskId);
+
+    if (!current) {
+      return { taskId, status: "failed", error: `Unknown task: ${taskId}` };
+    }
+
+    if (current.status === "completed" || current.status === "failed") {
+      return current;
+    }
+
+    return new Promise<CoordinatorResult>((resolve) => {
+      const queue = this.waiters.get(taskId) ?? [];
+      queue.push(resolve);
+      this.waiters.set(taskId, queue);
+    });
+  }
+
+  private async _executeTask(task: CoordinatorTask): Promise<void> {
+    const entry = this.tasks.get(task.id);
+    if (!entry) return;
+
+    entry.status = "running";
+
+    const logger = getLogger();
+    const useWorkerPool = this.multiAIEnabled && this.workerPool?.isAvailable() === true;
+
+    if (useWorkerPool) {
+      logger.debug(`[Coordinator] task ${task.id} → worker pool`);
+    } else {
+      logger.debug(`[Coordinator] task ${task.id} → claude-runner (fallback)`);
+    }
+
+    try {
+      let result: ClaudeRunResult;
+
+      if (useWorkerPool && this.workerPool) {
+        result = await this.workerPool.submitTask(task);
+      } else {
+        result = await runClaude(task.options);
+      }
+
+      const completed: CoordinatorResult = {
+        taskId: task.id,
+        status: result.success ? "completed" : "failed",
+        result,
+        error: result.success ? undefined : result.output,
+        completedAt: new Date().toISOString(),
+        durationMs: result.durationMs,
+      };
+
+      this.tasks.set(task.id, completed);
+      this._resolveWaiters(task.id, completed);
+    } catch (err: unknown) {
+      const failed: CoordinatorResult = {
+        taskId: task.id,
+        status: "failed",
+        error: getErrorMessage(err),
+        completedAt: new Date().toISOString(),
+      };
+
+      this.tasks.set(task.id, failed);
+      this._resolveWaiters(task.id, failed);
+    }
+  }
+
+  private _resolveWaiters(taskId: string, result: CoordinatorResult): void {
+    const queue = this.waiters.get(taskId);
+    if (!queue) return;
+
+    for (const resolve of queue) {
+      resolve(result);
+    }
+
+    this.waiters.delete(taskId);
+  }
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -159,6 +159,7 @@ export const DEFAULT_CONFIG: AQConfig = {
   },
   features: {
     parallelPhases: false,  // 안정성을 위해 기본값은 false
+    multiAI: false,         // 멀티 AI 워커 태스크 분배 (기본값은 false)
   },
   executionMode: "standard",
 };

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -286,6 +286,7 @@ const safetyConfigSchema = z.object({
 
 const featuresConfigSchema = z.object({
   parallelPhases: z.boolean(),
+  multiAI: z.boolean().default(false),
 });
 
 const projectConfigSchema = z.object({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -167,6 +167,8 @@ export interface SafetyConfig {
 export interface FeaturesConfig {
   /** 병렬 Phase 실행 활성화 여부 (안정성을 위해 기본값은 false) */
   parallelPhases: boolean;
+  /** 멀티 AI 워커를 활용한 태스크 분배 활성화 여부 (기본값은 false) */
+  multiAI: boolean;
 }
 
 export interface ExecutionModePreset {

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,7 +91,6 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
-  partial?: boolean;
   warnings?: string[];
   errors?: string[];
   commitHash?: string;

--- a/tests/claude/coordinator.test.ts
+++ b/tests/claude/coordinator.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Coordinator } from "../../src/claude/coordinator.js";
+import type { WorkerPool, CoordinatorTask } from "../../src/claude/coordinator.js";
+import type { ClaudeRunResult, ClaudeRunOptions } from "../../src/claude/claude-runner.js";
+
+vi.mock("../../src/claude/claude-runner.js", () => ({
+  runClaude: vi.fn(),
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { runClaude } from "../../src/claude/claude-runner.js";
+
+const mockRunClaude = vi.mocked(runClaude);
+
+const baseOptions: ClaudeRunOptions = {
+  prompt: "test prompt",
+  config: {
+    path: "claude",
+    model: "sonnet",
+    maxTurns: 10,
+    timeout: 30000,
+    additionalArgs: [],
+  },
+};
+
+const successResult: ClaudeRunResult = {
+  success: true,
+  output: "done",
+  durationMs: 100,
+};
+
+const failureResult: ClaudeRunResult = {
+  success: false,
+  output: "error output",
+  durationMs: 50,
+};
+
+function makeWorkerPool(available: boolean, result?: ClaudeRunResult): WorkerPool {
+  return {
+    isAvailable: vi.fn().mockReturnValue(available),
+    submitTask: vi.fn().mockResolvedValue(result ?? successResult),
+  };
+}
+
+describe("Coordinator — multiAI disabled (single execution)", () => {
+  beforeEach(() => {
+    mockRunClaude.mockReset();
+  });
+
+  it("submits task and completes via runClaude", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    expect(taskId).toBeTruthy();
+
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("completed");
+    expect(result.taskId).toBe(taskId);
+    expect(result.result).toEqual(successResult);
+    expect(mockRunClaude).toHaveBeenCalledWith(baseOptions);
+  });
+
+  it("marks task as failed when runClaude returns success=false", async () => {
+    mockRunClaude.mockResolvedValue(failureResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe(failureResult.output);
+  });
+
+  it("marks task as failed when runClaude throws", async () => {
+    mockRunClaude.mockRejectedValue(new Error("spawn failed"));
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("spawn failed");
+  });
+
+  it("ignores worker pool even if provided", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const pool = makeWorkerPool(true);
+    const coordinator = new Coordinator(false, pool);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    await coordinator.waitForCompletion(taskId);
+
+    expect(mockRunClaude).toHaveBeenCalledOnce();
+    expect(pool.submitTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("Coordinator — multiAI enabled", () => {
+  beforeEach(() => {
+    mockRunClaude.mockReset();
+  });
+
+  it("dispatches to worker pool when available", async () => {
+    const pool = makeWorkerPool(true, successResult);
+    const coordinator = new Coordinator(true, pool);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("completed");
+    expect(pool.submitTask).toHaveBeenCalledOnce();
+    expect(mockRunClaude).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runClaude when worker pool is unavailable", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const pool = makeWorkerPool(false);
+    const coordinator = new Coordinator(true, pool);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("completed");
+    expect(mockRunClaude).toHaveBeenCalledOnce();
+    expect(pool.submitTask).not.toHaveBeenCalled();
+  });
+
+  it("falls back to runClaude when no worker pool is provided", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(true);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("completed");
+    expect(mockRunClaude).toHaveBeenCalledOnce();
+  });
+
+  it("marks task as failed when worker pool throws", async () => {
+    const pool: WorkerPool = {
+      isAvailable: vi.fn().mockReturnValue(true),
+      submitTask: vi.fn().mockRejectedValue(new Error("pool error")),
+    };
+    const coordinator = new Coordinator(true, pool);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("pool error");
+  });
+});
+
+describe("Coordinator — getStatus", () => {
+  beforeEach(() => {
+    mockRunClaude.mockReset();
+  });
+
+  it("returns pending immediately after submitTask", async () => {
+    // Never resolves during this check
+    mockRunClaude.mockReturnValue(new Promise(() => undefined));
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const status = coordinator.getStatus(taskId);
+
+    expect(status).toBeDefined();
+    expect(["pending", "running"]).toContain(status!.status);
+  });
+
+  it("returns undefined for unknown task id", () => {
+    const coordinator = new Coordinator(false);
+    expect(coordinator.getStatus("no-such-id")).toBeUndefined();
+  });
+
+  it("returns completed after waitForCompletion resolves", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    await coordinator.waitForCompletion(taskId);
+
+    expect(coordinator.getStatus(taskId)?.status).toBe("completed");
+  });
+});
+
+describe("Coordinator — waitForCompletion edge cases", () => {
+  beforeEach(() => {
+    mockRunClaude.mockReset();
+  });
+
+  it("returns failed result for unknown task", async () => {
+    const coordinator = new Coordinator(false);
+    const result = await coordinator.waitForCompletion("unknown-id");
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("Unknown task");
+  });
+
+  it("resolves immediately for already-completed task", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    await coordinator.waitForCompletion(taskId);
+
+    // Second wait should also resolve
+    const result = await coordinator.waitForCompletion(taskId);
+    expect(result.status).toBe("completed");
+  });
+
+  it("multiple waiters receive the same result", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const [r1, r2] = await Promise.all([
+      coordinator.waitForCompletion(taskId),
+      coordinator.waitForCompletion(taskId),
+    ]);
+
+    expect(r1.status).toBe("completed");
+    expect(r2.status).toBe("completed");
+    expect(r1.taskId).toBe(r2.taskId);
+  });
+
+  it("records completedAt and durationMs on success", async () => {
+    mockRunClaude.mockResolvedValue(successResult);
+    const coordinator = new Coordinator(false);
+
+    const taskId = await coordinator.submitTask(baseOptions);
+    const result = await coordinator.waitForCompletion(taskId);
+
+    expect(result.completedAt).toBeTruthy();
+    expect(result.durationMs).toBe(successResult.durationMs);
+  });
+});

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -123,6 +123,7 @@ describe("validateConfig", () => {
     },
     features: {
       parallelPhases: false,
+      multiAI: false,
     },
     executionMode: "standard",
   };


### PR DESCRIPTION
## Summary

Resolves #383 — feat: Claude coordinator 신규 생성 — 워커 태스크 분배

현재 AQM은 단일 Claude 프로세스로 Phase를 실행하며, 멀티 AI 워커를 활용한 병렬 태스크 분배 기능이 없다. Coordinator 모듈을 신규 생성하여 향후 worker-pool과 통합할 수 있는 태스크 분배 인프라를 구축하고, features.multiAI 피처 플래그로 기능을 제어할 수 있도록 한다.

## Requirements

- src/claude/coordinator.ts 신규 생성
- 워커 풀 통합을 위한 태스크 분배 인터페이스 정의
- config.yml features.multiAI 피처 플래그 추가 (기본값 false)
- config 3곳 동시 수정: types/config.ts, defaults.ts, validator.ts
- npx tsc --noEmit 타입 체크 통과
- npx vitest run 테스트 통과

## Implementation Phases

- Phase 0: Config 필드 추가 — SUCCESS (cd42b0ac)
- Phase 1: Coordinator 모듈 구현 — SUCCESS (d9dcea22)
- Phase 2: Coordinator 테스트 작성 — SUCCESS (9c7964f2)

## Risks

- worker-pool 이슈가 아직 미구현 상태 — coordinator는 인터페이스만 정의하고 실제 워커 통합은 후속 이슈에서 처리
- 기존 claude-runner.ts와의 책임 경계가 모호해질 수 있음 — coordinator는 분배 로직만, runner는 실행 로직만 담당하도록 명확히 분리
- features.multiAI가 true일 때 fallback 동작 정의 필요 — worker-pool 없으면 단일 실행으로 fallback

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/383-feat-claude-coordinator` → `develop`
- **Tokens**: 145 input, 18069 output{{#stats.cacheCreationTokens}}, 177525 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1661219 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #383