### PR TITLE
[AQ-#385] refactor: config sources 디렉토리 — managed/user/project/cli/env 로더 분리

### DIFF
--- a/src/config/sources/cli-source.ts
+++ b/src/config/sources/cli-source.ts
@@ -1,0 +1,16 @@
+import type { ConfigSource, LoadContext } from "./types.js";
+
+/**
+ * CLI 옵션 오버라이드를 처리하는 설정 소스.
+ * LoadContext.configOverrides를 partial config로 반환한다.
+ */
+export class CliSource implements ConfigSource {
+  readonly name = "cli";
+
+  load(context: LoadContext): Record<string, unknown> | null {
+    if (!context.configOverrides || Object.keys(context.configOverrides).length === 0) {
+      return null;
+    }
+    return context.configOverrides;
+  }
+}

--- a/src/config/sources/env-source.ts
+++ b/src/config/sources/env-source.ts
@@ -1,0 +1,16 @@
+import { parseEnvVars } from "../env-parser.js";
+import type { ConfigSource, LoadContext, SourceResult } from "./types.js";
+
+/**
+ * AQM_* 환경변수로부터 설정을 로드하는 소스.
+ * 내부적으로 기존 parseEnvVars를 호출한다.
+ */
+export class EnvSource implements ConfigSource {
+  readonly name = "env";
+
+  load(context: LoadContext): SourceResult {
+    const env = context.envVars ?? process.env;
+    const result = parseEnvVars(env);
+    return Object.keys(result).length > 0 ? result : null;
+  }
+}

--- a/src/config/sources/index.ts
+++ b/src/config/sources/index.ts
@@ -10,3 +10,5 @@ export {
   deepMerge,
   parseYamlSafely,
 } from "./types.js";
+
+export { ProjectSource } from "./project-source.js";

--- a/src/config/sources/index.ts
+++ b/src/config/sources/index.ts
@@ -1,0 +1,12 @@
+export type {
+  ConfigSource,
+  LoadContext,
+  SourceResult,
+  ConfigLoadResult,
+} from "./types.js";
+
+export {
+  isRecord,
+  deepMerge,
+  parseYamlSafely,
+} from "./types.js";

--- a/src/config/sources/managed-source.ts
+++ b/src/config/sources/managed-source.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_CONFIG } from "../defaults.js";
+import type { ConfigSource, LoadContext, SourceResult } from "./types.js";
+
+/**
+ * ManagedSource — DEFAULT_CONFIG를 제공하는 최하위 우선순위 소스 (priority: 0)
+ */
+export class ManagedSource implements ConfigSource {
+  readonly name = "managed";
+
+  load(_context: LoadContext): SourceResult {
+    return DEFAULT_CONFIG as unknown as Record<string, unknown>;
+  }
+}

--- a/src/config/sources/project-source.ts
+++ b/src/config/sources/project-source.ts
@@ -1,0 +1,33 @@
+import { readFileSync, existsSync } from "fs";
+import type { ConfigSource, LoadContext, SourceResult } from "./types.js";
+import { parseYamlSafely, isRecord, deepMerge } from "./types.js";
+
+/**
+ * ProjectSource — config.yml + config.local.yml 로딩
+ *
+ * config.yml은 필수 파일이며 없으면 에러를 던진다.
+ * config.local.yml은 선택 파일이며 존재할 경우 config.yml 위에 병합된다.
+ */
+export class ProjectSource implements ConfigSource {
+  readonly name = "project";
+
+  load(context: LoadContext): SourceResult {
+    const { projectRoot } = context;
+    const baseConfigPath = `${projectRoot}/config.yml`;
+    const localConfigPath = `${projectRoot}/config.local.yml`;
+
+    if (!existsSync(baseConfigPath)) {
+      throw new Error(`config.yml not found at ${baseConfigPath}`);
+    }
+
+    const baseRaw = parseYamlSafely(readFileSync(baseConfigPath, "utf-8"), baseConfigPath);
+    let result: Record<string, unknown> = isRecord(baseRaw) ? baseRaw : {};
+
+    if (existsSync(localConfigPath)) {
+      const localRaw = parseYamlSafely(readFileSync(localConfigPath, "utf-8"), localConfigPath);
+      result = deepMerge<Record<string, unknown>>(result, localRaw);
+    }
+
+    return result;
+  }
+}

--- a/src/config/sources/types.ts
+++ b/src/config/sources/types.ts
@@ -1,0 +1,131 @@
+import { parse as parseYaml } from "yaml";
+import { AQConfig } from "../../types/config.js";
+
+/**
+ * 설정 소스 로딩 컨텍스트
+ */
+export interface LoadContext {
+  /** 프로젝트 루트 경로 (config.yml이 위치한 디렉토리) */
+  projectRoot: string;
+  /** AQM_* 환경변수 (env 소스에서 사용) */
+  envVars?: Record<string, string | undefined>;
+  /** CLI 오버라이드 옵션 */
+  configOverrides?: Record<string, unknown>;
+}
+
+/**
+ * 설정 소스 인터페이스 — 각 설정 소스는 이 인터페이스를 구현한다
+ */
+export interface ConfigSource {
+  /** 소스 식별자 (로그/디버깅용) */
+  readonly name: string;
+  /**
+   * 설정을 로드하여 partial config 객체를 반환한다.
+   * 해당 소스에서 설정을 로드할 수 없으면 null 또는 빈 객체를 반환한다.
+   */
+  load(context: LoadContext): Promise<Record<string, unknown> | null> | Record<string, unknown> | null;
+}
+
+/**
+ * ConfigSource.load() 결과 타입
+ */
+export type SourceResult = Record<string, unknown> | null;
+
+/**
+ * 전체 설정 로딩 결과
+ */
+export interface ConfigLoadResult {
+  config: AQConfig | null;
+  error?: {
+    type: 'not_found' | 'yaml_syntax' | 'validation';
+    message: string;
+    details?: string[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 공통 유틸리티
+// ---------------------------------------------------------------------------
+
+/**
+ * 타입 가드: 값이 Record<string, unknown>인지 확인
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null &&
+         typeof value === "object" &&
+         !Array.isArray(value);
+}
+
+/**
+ * Deep merge — source를 target에 재귀 병합한다.
+ * 배열은 source 값으로 대체된다 (concat 하지 않음).
+ */
+export function deepMerge<T = Record<string, unknown>>(target: unknown, source: unknown): T {
+  if (source === null || source === undefined) {
+    return target as T;
+  }
+  if (!isRecord(source)) {
+    return source as T;
+  }
+  if (!isRecord(target)) {
+    return source as T;
+  }
+
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+    result[key] = deepMerge(target[key], source[key]);
+  }
+  return result as T;
+}
+
+/**
+ * YAML 에러 객체가 code 프로퍼티를 가지는지 확인하는 타입 가드
+ */
+function hasErrorCode(error: Error): error is Error & { code: string } {
+  return 'code' in error && typeof (error as Error & { code: unknown }).code === 'string';
+}
+
+/**
+ * YAML 탭 문자 에러를 사용자 친화적인 메시지로 변환
+ */
+function formatYamlTabError(error: unknown, filePath: string): Error {
+  if (error instanceof Error &&
+      error.constructor.name === 'YAMLParseError' &&
+      hasErrorCode(error) &&
+      error.code === 'TAB_AS_INDENT') {
+    const lineMatch = error.message.match(/line (\d+)/);
+    const lineNumber = lineMatch?.[1] ?? '?';
+
+    const friendlyMessage = `❌ YAML 설정 파일에 탭 문자가 포함되어 있습니다.
+   파일: ${filePath}
+   위치: ${lineNumber}번째 줄
+
+   해결방법: YAML 파일에서는 들여쓰기에 탭 문자를 사용할 수 없습니다. 탭 문자를 스페이스(공백)로 교체해주세요.
+
+   예시:
+   # 잘못된 예 (탭 문자 사용)
+   general:
+   →→projectName: "my-project"
+
+   # 올바른 예 (스페이스 사용)
+   general:
+     projectName: "my-project"
+
+   팁: 에디터에서 "공백 표시" 기능을 활성화하면 탭 문자와 스페이스를 구분할 수 있습니다.`;
+
+    return new Error(friendlyMessage);
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * YAML 파싱을 수행하되 탭 문자 에러를 친절하게 처리
+ */
+export function parseYamlSafely(content: string, filePath: string): unknown {
+  try {
+    return parseYaml(content);
+  } catch (error: unknown) {
+    throw formatYamlTabError(error, filePath);
+  }
+}

--- a/src/config/sources/user-source.ts
+++ b/src/config/sources/user-source.ts
@@ -1,0 +1,45 @@
+import { readFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import type { ConfigSource, LoadContext, SourceResult } from "./types.js";
+import { isRecord, parseYamlSafely } from "./types.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+
+/**
+ * 사용자 전역 설정 소스 (~/.aqm/config.yml)
+ * 파일이 없으면 null 반환, 있으면 YAML 파싱하여 partial config 반환.
+ */
+export class UserSource implements ConfigSource {
+  readonly name = "user";
+
+  private readonly configPath: string;
+
+  constructor(configPath?: string) {
+    this.configPath = configPath ?? join(homedir(), ".aqm", "config.yml");
+  }
+
+  load(_context: LoadContext): SourceResult {
+    if (!existsSync(this.configPath)) {
+      return null;
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(this.configPath, "utf-8");
+    } catch (err: unknown) {
+      throw new Error(`사용자 설정 파일 읽기 실패 (${this.configPath}): ${getErrorMessage(err)}`);
+    }
+
+    const parsed = parseYamlSafely(content, this.configPath);
+
+    if (parsed === null || parsed === undefined) {
+      return null;
+    }
+
+    if (!isRecord(parsed)) {
+      throw new Error(`사용자 설정 파일 형식 오류 (${this.configPath}): YAML 최상위 값은 객체여야 합니다.`);
+    }
+
+    return parsed;
+  }
+}

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,6 +91,8 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
+  /** 부분 성공 여부 (일부 파일만 성공, tsc 오류가 일부 파일에만 있는 경우 등) */
+  partial?: boolean;
   warnings?: string[];
   errors?: string[];
   commitHash?: string;

--- a/tests/config/sources/cli-source.test.ts
+++ b/tests/config/sources/cli-source.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { CliSource } from "../../../src/config/sources/cli-source.js";
+import type { LoadContext } from "../../../src/config/sources/types.js";
+
+const baseContext: LoadContext = { projectRoot: "/fake/root" };
+
+describe("CliSource", () => {
+  it("should have name 'cli'", () => {
+    const source = new CliSource();
+    expect(source.name).toBe("cli");
+  });
+
+  it("should return null when configOverrides is undefined", () => {
+    const source = new CliSource();
+    expect(source.load(baseContext)).toBeNull();
+  });
+
+  it("should return null when configOverrides is empty object", () => {
+    const source = new CliSource();
+    const context: LoadContext = { ...baseContext, configOverrides: {} };
+    expect(source.load(context)).toBeNull();
+  });
+
+  it("should return configOverrides when provided", () => {
+    const source = new CliSource();
+    const overrides = { general: { logLevel: "debug" } };
+    const context: LoadContext = { ...baseContext, configOverrides: overrides };
+    expect(source.load(context)).toEqual(overrides);
+  });
+
+  it("should return configOverrides as-is (no deep copy)", () => {
+    const source = new CliSource();
+    const overrides = { general: { concurrency: 3 }, safety: { maxPhases: 5 } };
+    const context: LoadContext = { ...baseContext, configOverrides: overrides };
+    const result = source.load(context);
+    expect(result).toBe(overrides);
+  });
+
+  it("should handle nested configOverrides", () => {
+    const source = new CliSource();
+    const overrides = {
+      general: { projectName: "test", logLevel: "info" },
+      safety: { allowedLabels: ["bug", "enhancement"] }
+    };
+    const context: LoadContext = { ...baseContext, configOverrides: overrides };
+    expect(source.load(context)).toEqual(overrides);
+  });
+
+  it("should implement ConfigSource interface synchronously", () => {
+    const source = new CliSource();
+    const overrides = { general: { dryRun: true } };
+    const context: LoadContext = { ...baseContext, configOverrides: overrides };
+    const result = source.load(context);
+    // Should not be a Promise
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result).toEqual(overrides);
+  });
+});

--- a/tests/config/sources/env-source.test.ts
+++ b/tests/config/sources/env-source.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { EnvSource } from "../../../src/config/sources/env-source.js";
+import type { LoadContext } from "../../../src/config/sources/types.js";
+
+const makeContext = (envVars?: Record<string, string | undefined>): LoadContext => ({
+  projectRoot: "/tmp/test-project",
+  envVars,
+});
+
+describe("EnvSource", () => {
+  it("name이 'env'이어야 한다", () => {
+    const source = new EnvSource();
+    expect(source.name).toBe("env");
+  });
+
+  it("AQM_* 환경변수를 파싱하여 config 객체를 반환한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_GENERAL_PROJECT_NAME: "test-project",
+      AQM_GENERAL_LOG_LEVEL: "debug",
+    }));
+
+    expect(result).toEqual({
+      general: {
+        projectName: "test-project",
+        logLevel: "debug",
+      },
+    });
+  });
+
+  it("숫자 값을 올바르게 파싱한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_GENERAL_CONCURRENCY: "3",
+      AQM_SAFETY_MAX_PHASES: "10",
+    }));
+
+    expect(result).toEqual({
+      general: { concurrency: 3 },
+      safety: { maxPhases: 10 },
+    });
+  });
+
+  it("불리언 값을 올바르게 파싱한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_GENERAL_DRY_RUN: "true",
+      AQM_SAFETY_REQUIRE_TESTS: "false",
+    }));
+
+    expect(result).toEqual({
+      general: { dryRun: true },
+      safety: { requireTests: false },
+    });
+  });
+
+  it("콤마 구분 배열을 올바르게 파싱한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_GIT_ALLOWED_REPOS: "owner/repo1,owner/repo2",
+    }));
+
+    expect(result).toEqual({
+      git: { allowedRepos: ["owner/repo1", "owner/repo2"] },
+    });
+  });
+
+  it("AQM_* 변수가 없으면 null을 반환한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      PATH: "/usr/bin",
+      USER: "test",
+    }));
+
+    expect(result).toBeNull();
+  });
+
+  it("빈 envVars이면 null을 반환한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({}));
+
+    expect(result).toBeNull();
+  });
+
+  it("AQM_* 이외의 환경변수는 무시한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      NOT_AQM_VAR: "ignored",
+      AQM_GENERAL_PROJECT_NAME: "included",
+    }));
+
+    expect(result).toEqual({
+      general: { projectName: "included" },
+    });
+  });
+
+  it("context.envVars가 없으면 process.env를 사용한다", () => {
+    const source = new EnvSource();
+    // process.env를 직접 사용하므로 에러 없이 실행되어야 함
+    expect(() => source.load({ projectRoot: "/tmp" })).not.toThrow();
+  });
+
+  it("undefined 환경변수 값은 무시한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_GENERAL_PROJECT_NAME: "test",
+      AQM_GENERAL_LOG_LEVEL: undefined,
+    }));
+
+    expect(result).toEqual({
+      general: { projectName: "test" },
+    });
+  });
+
+  it("SECTION만 있고 KEY가 없는 형식은 무시한다", () => {
+    const source = new EnvSource();
+    const result = source.load(makeContext({
+      AQM_SECTION: "ignored",
+      AQM_GENERAL_VALID: "included",
+    }));
+
+    expect(result).toEqual({
+      general: { valid: "included" },
+    });
+  });
+});

--- a/tests/config/sources/managed-source.test.ts
+++ b/tests/config/sources/managed-source.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { ManagedSource } from "../../../src/config/sources/managed-source.js";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults.js";
+
+describe("ManagedSource", () => {
+  const source = new ManagedSource();
+  const context = { projectRoot: "/tmp/test" };
+
+  it("name이 'managed'이어야 한다", () => {
+    expect(source.name).toBe("managed");
+  });
+
+  it("DEFAULT_CONFIG를 그대로 반환한다", () => {
+    const result = source.load(context);
+    expect(result).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("null을 반환하지 않는다", () => {
+    const result = source.load(context);
+    expect(result).not.toBeNull();
+  });
+
+  it("동기적으로 결과를 반환한다 (Promise 아님)", () => {
+    const result = source.load(context);
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it("general.logLevel 기본값이 info이다", () => {
+    const result = source.load(context) as Record<string, unknown>;
+    const general = result["general"] as Record<string, unknown>;
+    expect(general["logLevel"]).toBe("info");
+  });
+
+  it("매 호출마다 동일한 값을 반환한다", () => {
+    const r1 = source.load(context);
+    const r2 = source.load(context);
+    expect(r1).toEqual(r2);
+  });
+});

--- a/tests/config/sources/project-source.test.ts
+++ b/tests/config/sources/project-source.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ProjectSource } from "../../../src/config/sources/project-source.js";
+
+describe("ProjectSource", () => {
+  let tmpDir: string;
+  let source: ProjectSource;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `aqm-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    source = new ProjectSource();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should have name 'project'", () => {
+    expect(source.name).toBe("project");
+  });
+
+  it("should throw when config.yml is not found", () => {
+    expect(() => source.load({ projectRoot: tmpDir })).toThrow(
+      `config.yml not found at ${tmpDir}/config.yml`
+    );
+  });
+
+  it("should load config.yml successfully", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: test-project
+  logLevel: debug
+`);
+
+    const result = source.load({ projectRoot: tmpDir });
+
+    expect(result).toEqual({
+      general: {
+        projectName: "test-project",
+        logLevel: "debug",
+      },
+    });
+  });
+
+  it("should merge config.local.yml on top of config.yml", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: base-project
+  logLevel: info
+git:
+  defaultBaseBranch: main
+`);
+    writeFileSync(join(tmpDir, "config.local.yml"), `
+general:
+  logLevel: debug
+`);
+
+    const result = source.load({ projectRoot: tmpDir });
+
+    expect(result).toMatchObject({
+      general: {
+        projectName: "base-project",
+        logLevel: "debug",
+      },
+      git: {
+        defaultBaseBranch: "main",
+      },
+    });
+  });
+
+  it("should not require config.local.yml", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: no-local
+`);
+
+    expect(() => source.load({ projectRoot: tmpDir })).not.toThrow();
+    const result = source.load({ projectRoot: tmpDir });
+    expect(result).toMatchObject({ general: { projectName: "no-local" } });
+  });
+
+  it("should throw on YAML syntax error in config.yml", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: [unclosed
+`);
+
+    expect(() => source.load({ projectRoot: tmpDir })).toThrow();
+  });
+
+  it("should throw on YAML syntax error in config.local.yml", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: base
+`);
+    writeFileSync(join(tmpDir, "config.local.yml"), `
+general:
+  logLevel: [unclosed
+`);
+
+    expect(() => source.load({ projectRoot: tmpDir })).toThrow();
+  });
+
+  it("should handle empty config.yml as empty object", () => {
+    writeFileSync(join(tmpDir, "config.yml"), "");
+
+    const result = source.load({ projectRoot: tmpDir });
+
+    expect(result).toEqual({});
+  });
+
+  it("should return null when config.yml parses to a non-object", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `- item1\n- item2`);
+
+    const result = source.load({ projectRoot: tmpDir });
+
+    expect(result).toEqual({});
+  });
+
+  it("should deep merge nested config.local.yml fields", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: base
+  logLevel: info
+safety:
+  allowedLabels:
+    - enhancement
+    - bug
+`);
+    writeFileSync(join(tmpDir, "config.local.yml"), `
+safety:
+  allowedLabels:
+    - local-only
+`);
+
+    const result = source.load({ projectRoot: tmpDir });
+
+    expect(result).toMatchObject({
+      general: { projectName: "base", logLevel: "info" },
+      safety: { allowedLabels: ["local-only"] },
+    });
+  });
+
+  it("should ignore context.envVars and context.configOverrides (not project source's concern)", () => {
+    writeFileSync(join(tmpDir, "config.yml"), `
+general:
+  projectName: base
+`);
+
+    const result = source.load({
+      projectRoot: tmpDir,
+      envVars: { AQM_GENERAL_PROJECT_NAME: "from-env" },
+      configOverrides: { general: { projectName: "from-cli" } },
+    });
+
+    expect(result).toMatchObject({ general: { projectName: "base" } });
+  });
+});

--- a/tests/config/sources/user-source.test.ts
+++ b/tests/config/sources/user-source.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { UserSource } from "../../../src/config/sources/user-source.js";
+
+function makeContext(projectRoot = "/tmp/project") {
+  return { projectRoot };
+}
+
+describe("UserSource", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `user-source-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    configPath = join(tmpDir, "config.yml");
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("name", () => {
+    it("소스 이름이 'user'여야 한다", () => {
+      const source = new UserSource(configPath);
+      expect(source.name).toBe("user");
+    });
+  });
+
+  describe("load() — 파일 없음", () => {
+    it("설정 파일이 없으면 null을 반환한다", () => {
+      const source = new UserSource(join(tmpDir, "nonexistent.yml"));
+      const result = source.load(makeContext());
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("load() — 정상 파일", () => {
+    it("유효한 YAML 파일을 파싱하여 반환한다", () => {
+      writeFileSync(configPath, `
+general:
+  projectName: "my-project"
+  logLevel: "debug"
+`);
+      const source = new UserSource(configPath);
+      const result = source.load(makeContext());
+
+      expect(result).toEqual({
+        general: {
+          projectName: "my-project",
+          logLevel: "debug",
+        },
+      });
+    });
+
+    it("중첩 객체를 올바르게 파싱한다", () => {
+      writeFileSync(configPath, `
+general:
+  dryRun: true
+  concurrency: 3
+safety:
+  maxPhases: 5
+  allowedLabels:
+    - bug
+    - enhancement
+`);
+      const source = new UserSource(configPath);
+      const result = source.load(makeContext());
+
+      expect(result).toEqual({
+        general: { dryRun: true, concurrency: 3 },
+        safety: { maxPhases: 5, allowedLabels: ["bug", "enhancement"] },
+      });
+    });
+
+    it("빈 YAML 파일(빈 문서)이면 null을 반환한다", () => {
+      writeFileSync(configPath, "");
+      const source = new UserSource(configPath);
+      const result = source.load(makeContext());
+      expect(result).toBeNull();
+    });
+
+    it("null YAML 문서이면 null을 반환한다", () => {
+      writeFileSync(configPath, "null\n");
+      const source = new UserSource(configPath);
+      const result = source.load(makeContext());
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("load() — 오류 케이스", () => {
+    it("YAML 문법 오류가 있으면 에러를 던진다", () => {
+      writeFileSync(configPath, "key: [unclosed");
+      const source = new UserSource(configPath);
+      expect(() => source.load(makeContext())).toThrow();
+    });
+
+    it("최상위 값이 배열이면 에러를 던진다", () => {
+      writeFileSync(configPath, "- item1\n- item2\n");
+      const source = new UserSource(configPath);
+      expect(() => source.load(makeContext())).toThrow(/객체여야/);
+    });
+
+    it("최상위 값이 스칼라이면 에러를 던진다", () => {
+      writeFileSync(configPath, "just-a-string\n");
+      const source = new UserSource(configPath);
+      expect(() => source.load(makeContext())).toThrow(/객체여야/);
+    });
+  });
+
+  describe("기본 경로", () => {
+    it("configPath를 생략하면 기본값(~/.aqm/config.yml)을 사용한다", () => {
+      const source = new UserSource();
+      // 기본 경로는 존재하지 않을 가능성이 높으므로 null 또는 객체를 반환
+      // 에러가 발생하지 않아야 함
+      expect(() => source.load(makeContext())).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #385 — refactor: config sources 디렉토리 — managed/user/project/cli/env 로더 분리

현재 src/config/loader.ts에 모든 설정 소스 로딩 로직이 혼재되어 있어 유지보수와 테스트가 어렵습니다. DEFAULT_CONFIG, config.yml, config.local.yml, 환경변수(AQM_*), CLI 옵션 등 5가지 설정 소스를 각각 독립적인 모듈로 분리하여 단일 책임 원칙을 적용하고, 각 소스별 단위 테스트를 통해 안정성을 확보해야 합니다.

## Requirements

- src/config/sources/ 디렉토리 신규 생성
- managed-source.ts: 시스템 기본값(DEFAULT_CONFIG) 제공 로더
- user-source.ts: 사용자 전역 설정(~/.aqm/config.yml) 로더
- project-source.ts: 프로젝트 설정(config.yml, config.local.yml) 로더
- cli-source.ts: CLI 옵션 오버라이드 로더
- env-source.ts: 환경변수(AQM_*) 로더 (기존 env-parser.ts 기반)
- 각 소스별 단위 테스트 작성
- 공통 ConfigSource 인터페이스 정의
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: 공통 인터페이스 및 타입 정의 — SUCCESS (facd717e)
- Phase 1: managed-source 구현 — SUCCESS (039a797e)
- Phase 2: env-source 구현 — SUCCESS (039a797e)
- Phase 3: user-source 구현 — SUCCESS (398b263b)
- Phase 4: project-source 구현 — SUCCESS (398b263b)
- Phase 5: cli-source 구현 — SUCCESS (398b263b)

## Risks

- 기존 loader.ts와의 인터페이스 호환성 유지 필요
- env-parser.ts의 기존 함수들이 외부에서 사용 중일 수 있음 — re-export 필요
- user-source의 ~/.aqm/ 경로가 플랫폼별로 다를 수 있음
- deepMerge 유틸리티 중복 방지 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 6/6 completed
- **Branch**: `aq/385-refactor-config-sources-managed-user-project-cli-e` → `develop`
- **Tokens**: 219 input, 26629 output{{#stats.cacheCreationTokens}}, 248068 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2832132 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #385