### PR TITLE
[AQ-#386] refactor: config loader 5단계 병합 — Managed→User→Project→CLI→Env 우선순위

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,9 +1,14 @@
 import { readFileSync, existsSync, writeFileSync } from "fs";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { AQConfig, ProjectConfig, InitCommandOptions } from "../types/config.js";
-import { DEFAULT_CONFIG } from "./defaults.js";
 import { validateConfig } from "./validator.js";
-import { parseEnvVars } from "./env-parser.js";
+import { ManagedSource } from "./sources/managed-source.js";
+import { UserSource } from "./sources/user-source.js";
+import { ProjectSource } from "./sources/project-source.js";
+import { CliSource } from "./sources/cli-source.js";
+import { EnvSource } from "./sources/env-source.js";
+import type { ConfigSources } from "./sources/types.js";
+import { SOURCE_PRIORITY_ORDER } from "./sources/types.js";
 
 export interface TryLoadConfigResult {
   config: AQConfig | null;
@@ -57,7 +62,7 @@ function formatYamlTabError(error: unknown, filePath: string): Error {
 /**
  * YAML 파싱을 수행하되 탭 문자 에러를 친절하게 처리
  */
-function parseYamlSafely(content: string, filePath: string): unknown {
+export function parseYamlSafely(content: string, filePath: string): unknown {
   try {
     return parseYaml(content);
   } catch (error: unknown) {
@@ -104,37 +109,28 @@ export interface LoadConfigOptions {
 export function loadConfig(projectRoot: string): AQConfig;
 export function loadConfig(projectRoot: string, options: LoadConfigOptions): AQConfig;
 export function loadConfig(projectRoot: string, options?: LoadConfigOptions): AQConfig {
-  const baseConfigPath = `${projectRoot}/config.yml`;
-  const localConfigPath = `${projectRoot}/config.local.yml`;
+  const sources: ConfigSources = {
+    managed: new ManagedSource(),
+    user: new UserSource(),
+    project: new ProjectSource(projectRoot),
+  };
 
-  let config = structuredClone(DEFAULT_CONFIG);
-
-  if (!existsSync(baseConfigPath)) {
-    throw new Error(`config.yml not found at ${baseConfigPath}`);
-  }
-
-  // 1. Load and merge base config.yml
-  const baseRaw = parseYamlSafely(readFileSync(baseConfigPath, "utf-8"), baseConfigPath);
-  config = deepMerge(config, baseRaw);
-
-  // 2. Load and merge config.local.yml if exists
-  if (existsSync(localConfigPath)) {
-    const localRaw = parseYamlSafely(readFileSync(localConfigPath, "utf-8"), localConfigPath);
-    config = deepMerge(config, localRaw);
-  }
-
-  // 3. Apply environment variables (AQM_*)
-  if (options?.envVars !== undefined) {
-    const envConfig = parseEnvVars(options.envVars);
-    config = deepMerge(config, envConfig);
-  }
-
-  // 4. Apply CLI config overrides
   if (options?.configOverrides) {
-    config = deepMerge(config, options.configOverrides);
+    sources.cli = new CliSource(options.configOverrides);
   }
 
-  return validateConfig(config);
+  if (options?.envVars !== undefined) {
+    sources.env = new EnvSource(options.envVars);
+  }
+
+  let merged: Record<string, unknown> = {};
+  for (const name of SOURCE_PRIORITY_ORDER) {
+    const source = sources[name];
+    if (!source) continue;
+    merged = deepMerge(merged, source.load() as Record<string, unknown>);
+  }
+
+  return validateConfig(merged);
 }
 
 // Overloaded function signatures for tryLoadConfig
@@ -142,7 +138,6 @@ export function tryLoadConfig(projectRoot: string): TryLoadConfigResult;
 export function tryLoadConfig(projectRoot: string, options: LoadConfigOptions): TryLoadConfigResult;
 export function tryLoadConfig(projectRoot: string, options?: LoadConfigOptions): TryLoadConfigResult {
   const baseConfigPath = `${projectRoot}/config.yml`;
-  const localConfigPath = `${projectRoot}/config.local.yml`;
 
   // Check if base config exists
   if (!existsSync(baseConfigPath)) {
@@ -155,65 +150,34 @@ export function tryLoadConfig(projectRoot: string, options?: LoadConfigOptions):
     };
   }
 
-  let config = structuredClone(DEFAULT_CONFIG);
+  const sources: ConfigSources = {
+    managed: new ManagedSource(),
+    user: new UserSource(),
+    project: new ProjectSource(projectRoot),
+  };
 
-  // Try to parse base config
-  try {
-    const baseRaw = parseYamlSafely(readFileSync(baseConfigPath, "utf-8"), baseConfigPath);
-    config = deepMerge(config, baseRaw);
-  } catch (err: unknown) {
-    return {
-      config: null,
-      error: {
-        type: 'yaml_syntax',
-        message: `Failed to parse config.yml: ${err instanceof Error ? err.message : 'Unknown error'}`
-      }
-    };
-  }
-
-  // Try to merge local config if exists
-  try {
-    const localRaw = parseYamlSafely(readFileSync(localConfigPath, "utf-8"), localConfigPath);
-    config = deepMerge(config, localRaw);
-  } catch (err: unknown) {
-    // Only fail on non-ENOENT errors (file exists but can't parse)
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code !== "ENOENT") {
-      return {
-        config: null,
-        error: {
-          type: 'yaml_syntax',
-          message: `Failed to parse config.local.yml: ${err.message}`
-        }
-      };
-    }
-  }
-
-  // Apply environment variables (AQM_*)
-  if (options?.envVars !== undefined) {
-    try {
-      const envConfig = parseEnvVars(options.envVars);
-      config = deepMerge(config, envConfig);
-    } catch (err: unknown) {
-      return {
-        config: null,
-        error: {
-          type: 'validation',
-          message: `Failed to parse environment variables: ${err instanceof Error ? err.message : 'Unknown error'}`
-        }
-      };
-    }
-  }
-
-  // Apply CLI config overrides
   if (options?.configOverrides) {
+    sources.cli = new CliSource(options.configOverrides);
+  }
+
+  if (options?.envVars !== undefined) {
+    sources.env = new EnvSource(options.envVars);
+  }
+
+  let merged: Record<string, unknown> = {};
+
+  for (const name of SOURCE_PRIORITY_ORDER) {
+    const source = sources[name];
+    if (!source) continue;
     try {
-      config = deepMerge(config, options.configOverrides);
+      merged = deepMerge(merged, source.load() as Record<string, unknown>);
     } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
       return {
         config: null,
         error: {
-          type: 'validation',
-          message: `Failed to apply config overrides: ${err instanceof Error ? err.message : 'Unknown error'}`
+          type: name === 'project' ? 'yaml_syntax' : 'validation',
+          message
         }
       };
     }
@@ -221,7 +185,7 @@ export function tryLoadConfig(projectRoot: string, options?: LoadConfigOptions):
 
   // Try to validate config
   try {
-    const validatedConfig = validateConfig(config);
+    const validatedConfig = validateConfig(merged);
     return { config: validatedConfig };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown validation error';

--- a/src/config/sources/cli-source.ts
+++ b/src/config/sources/cli-source.ts
@@ -1,0 +1,14 @@
+import type { ConfigSource } from "./types.js";
+
+/**
+ * CLI 오버라이드 소스 — --set key=value 형태로 전달된 configOverrides 처리
+ */
+export class CliSource implements ConfigSource {
+  readonly name = "cli";
+
+  constructor(private readonly overrides: Record<string, unknown>) {}
+
+  load(): Record<string, unknown> {
+    return this.overrides;
+  }
+}

--- a/src/config/sources/env-source.ts
+++ b/src/config/sources/env-source.ts
@@ -1,0 +1,15 @@
+import type { ConfigSource } from "./types.js";
+import { parseEnvVars } from "../env-parser.js";
+
+/**
+ * 환경변수 소스 — AQM_* 환경변수를 파싱하여 config로 변환
+ */
+export class EnvSource implements ConfigSource {
+  readonly name = "env";
+
+  constructor(private readonly env: Record<string, string | undefined> = process.env) {}
+
+  load(): Record<string, unknown> {
+    return parseEnvVars(this.env);
+  }
+}

--- a/src/config/sources/index.ts
+++ b/src/config/sources/index.ts
@@ -1,0 +1,29 @@
+import { deepMerge } from "../loader.js";
+import { validateConfig } from "../validator.js";
+import { DEFAULT_CONFIG } from "../defaults.js";
+import type { ConfigSource, ConfigSources, MergeResult, SourceName } from "./types.js";
+import { SOURCE_PRIORITY_ORDER } from "./types.js";
+
+export type { ConfigSource, ConfigSources, MergeResult, SourceName };
+export { SOURCE_PRIORITY_ORDER };
+
+/**
+ * 5단계 소스를 우선순위 순서로 병합하여 최종 config를 반환
+ * 우선순위 (낮음→높음): Managed → User → Project → CLI → Env
+ */
+export async function mergeSources(sources: ConfigSources): Promise<MergeResult> {
+  let merged: Record<string, unknown> = structuredClone(DEFAULT_CONFIG) as unknown as Record<string, unknown>;
+  const loadedSources: SourceName[] = [];
+
+  for (const name of SOURCE_PRIORITY_ORDER) {
+    const source = sources[name];
+    if (!source) continue;
+
+    const partial = await source.load();
+    merged = deepMerge(merged, partial);
+    loadedSources.push(name);
+  }
+
+  const config = validateConfig(merged);
+  return { config, sources: loadedSources };
+}

--- a/src/config/sources/index.ts
+++ b/src/config/sources/index.ts
@@ -6,6 +6,9 @@ import { SOURCE_PRIORITY_ORDER } from "./types.js";
 
 export type { ConfigSource, ConfigSources, MergeResult, SourceName };
 export { SOURCE_PRIORITY_ORDER };
+export { ManagedSource } from "./managed-source.js";
+export { UserSource } from "./user-source.js";
+export { ProjectSource } from "./project-source.js";
 
 /**
  * 5단계 소스를 우선순위 순서로 병합하여 최종 config를 반환

--- a/src/config/sources/managed-source.ts
+++ b/src/config/sources/managed-source.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_CONFIG } from "../defaults.js";
+import type { ConfigSource } from "./types.js";
+
+/**
+ * Managed source — AQM 내부 기본값(DEFAULT_CONFIG)을 제공
+ * 5단계 병합에서 가장 낮은 우선순위
+ */
+export class ManagedSource implements ConfigSource {
+  readonly name = "managed";
+
+  load(): Record<string, unknown> {
+    return structuredClone(DEFAULT_CONFIG) as unknown as Record<string, unknown>;
+  }
+}

--- a/src/config/sources/project-source.ts
+++ b/src/config/sources/project-source.ts
@@ -1,0 +1,52 @@
+import { readFileSync, existsSync } from "fs";
+import { parse as parseYaml } from "yaml";
+import { deepMerge } from "../loader.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import type { ConfigSource } from "./types.js";
+
+/**
+ * Project source — config.yml + config.local.yml 로드
+ * config.yml은 필수, config.local.yml은 선택적
+ */
+export class ProjectSource implements ConfigSource {
+  readonly name = "project";
+  private readonly projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+  }
+
+  load(): Record<string, unknown> {
+    const baseConfigPath = `${this.projectRoot}/config.yml`;
+    const localConfigPath = `${this.projectRoot}/config.local.yml`;
+
+    if (!existsSync(baseConfigPath)) {
+      throw new Error(`config.yml not found at ${baseConfigPath}`);
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const content = readFileSync(baseConfigPath, "utf-8");
+      const parsed = parseYaml(content);
+      config = (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed))
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch (err: unknown) {
+      throw new Error(`Failed to parse config.yml: ${getErrorMessage(err)}`);
+    }
+
+    if (existsSync(localConfigPath)) {
+      try {
+        const localContent = readFileSync(localConfigPath, "utf-8");
+        const localParsed = parseYaml(localContent);
+        if (localParsed !== null && typeof localParsed === "object" && !Array.isArray(localParsed)) {
+          config = deepMerge(config, localParsed as Record<string, unknown>);
+        }
+      } catch (err: unknown) {
+        throw new Error(`Failed to parse config.local.yml: ${getErrorMessage(err)}`);
+      }
+    }
+
+    return config;
+  }
+}

--- a/src/config/sources/project-source.ts
+++ b/src/config/sources/project-source.ts
@@ -1,8 +1,17 @@
 import { readFileSync, existsSync } from "fs";
-import { parse as parseYaml } from "yaml";
-import { deepMerge } from "../loader.js";
+import { deepMerge, parseYamlSafely } from "../loader.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import type { ConfigSource } from "./types.js";
+
+/**
+ * YAML 에러를 래핑: 탭 에러(친화적 메시지)는 그대로, 다른 에러는 파일명 접두사 추가
+ */
+function wrapYamlError(err: unknown, fileName: string): Error {
+  if (err instanceof Error && err.message.includes('YAML 설정 파일에 탭 문자가 포함되어 있습니다')) {
+    return err;
+  }
+  return new Error(`Failed to parse ${fileName}: ${getErrorMessage(err)}`);
+}
 
 /**
  * Project source — config.yml + config.local.yml 로드
@@ -27,23 +36,23 @@ export class ProjectSource implements ConfigSource {
     let config: Record<string, unknown>;
     try {
       const content = readFileSync(baseConfigPath, "utf-8");
-      const parsed = parseYaml(content);
+      const parsed = parseYamlSafely(content, baseConfigPath);
       config = (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed))
         ? (parsed as Record<string, unknown>)
         : {};
     } catch (err: unknown) {
-      throw new Error(`Failed to parse config.yml: ${getErrorMessage(err)}`);
+      throw wrapYamlError(err, "config.yml");
     }
 
     if (existsSync(localConfigPath)) {
       try {
         const localContent = readFileSync(localConfigPath, "utf-8");
-        const localParsed = parseYaml(localContent);
+        const localParsed = parseYamlSafely(localContent, localConfigPath);
         if (localParsed !== null && typeof localParsed === "object" && !Array.isArray(localParsed)) {
           config = deepMerge(config, localParsed as Record<string, unknown>);
         }
       } catch (err: unknown) {
-        throw new Error(`Failed to parse config.local.yml: ${getErrorMessage(err)}`);
+        throw wrapYamlError(err, "config.local.yml");
       }
     }
 

--- a/src/config/sources/types.ts
+++ b/src/config/sources/types.ts
@@ -1,0 +1,33 @@
+import type { AQConfig } from "../../types/config.js";
+
+/**
+ * Config source 인터페이스 — 각 소스는 partial config를 제공
+ */
+export interface ConfigSource {
+  readonly name: string;
+  load(): Record<string, unknown> | Promise<Record<string, unknown>>;
+}
+
+/**
+ * 5단계 병합 순서 (우선순위 낮음 → 높음)
+ * Managed → User → Project → CLI → Env
+ */
+export const SOURCE_PRIORITY_ORDER = ['managed', 'user', 'project', 'cli', 'env'] as const;
+
+export type SourceName = typeof SOURCE_PRIORITY_ORDER[number];
+
+/**
+ * 5단계 소스 세트 — 각 소스는 선택적으로 제공
+ */
+export interface ConfigSources {
+  managed?: ConfigSource; // 관리형 기본값 (AQM 내부)
+  user?: ConfigSource;    // 사용자 레벨 설정 (~/.aqm/config.yml)
+  project?: ConfigSource; // 프로젝트 레벨 설정 (config.yml + config.local.yml)
+  cli?: ConfigSource;     // CLI 오버라이드
+  env?: ConfigSource;     // 환경변수 오버라이드 (AQM_*)
+}
+
+export interface MergeResult {
+  config: AQConfig;
+  sources: SourceName[]; // 실제 로드된 소스 목록
+}

--- a/src/config/sources/user-source.ts
+++ b/src/config/sources/user-source.ts
@@ -1,0 +1,40 @@
+import { readFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { parse as parseYaml } from "yaml";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import type { ConfigSource } from "./types.js";
+
+/**
+ * User source — ~/.aqm/config.yml 로드
+ * 파일이 없으면 빈 객체 반환 (선택적 소스)
+ */
+export class UserSource implements ConfigSource {
+  readonly name = "user";
+  private readonly configPath: string;
+
+  constructor(configPath?: string) {
+    this.configPath = configPath ?? `${homedir()}/.aqm/config.yml`;
+  }
+
+  load(): Record<string, unknown> {
+    if (!existsSync(this.configPath)) {
+      return {};
+    }
+
+    const logger = getLogger();
+    try {
+      const content = readFileSync(this.configPath, "utf-8");
+      const parsed = parseYaml(content);
+      if (parsed === null || parsed === undefined) return {};
+      if (typeof parsed !== "object" || Array.isArray(parsed)) {
+        logger.warn(`User config at ${this.configPath} is not an object, skipping`);
+        return {};
+      }
+      return parsed as Record<string, unknown>;
+    } catch (err: unknown) {
+      logger.warn(`Failed to load user config from ${this.configPath}: ${getErrorMessage(err)}`);
+      return {};
+    }
+  }
+}

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,6 +91,8 @@ export interface PhaseResult {
   phaseIndex: number;
   phaseName: string;
   success: boolean;
+  /** 부분 성공 여부 - true인 경우 일부 파일만 처리됨 */
+  partial?: boolean;
   warnings?: string[];
   errors?: string[];
   commitHash?: string;

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1402,7 +1402,7 @@ git:
     expect(config.general.concurrency).toBe(5);              // From env var (converted to number)
   });
 
-  it("should apply CLI overrides over env vars and config files", () => {
+  it("should apply env vars over CLI overrides (env has highest priority)", () => {
     writeFileSync(join(testDir, "config.yml"), `
 general:
   projectName: "test-project"
@@ -1428,9 +1428,9 @@ git:
     const config = loadConfig(testDir, { envVars, configOverrides });
 
     expect(config.general.projectName).toBe("test-project");  // From config file
-    expect(config.general.logLevel).toBe("warn");            // From CLI override
+    expect(config.general.logLevel).toBe("debug");            // From env var (env > CLI)
     expect(config.general.concurrency).toBe(5);              // From env var
-    expect(config.general.dryRun).toBe(true);                // From CLI override
+    expect(config.general.dryRun).toBe(true);                // From CLI override (env doesn't set this)
   });
 
   it("should handle nested CLI overrides", () => {

--- a/tests/config/sources/cli-source.test.ts
+++ b/tests/config/sources/cli-source.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { CliSource } from "../../../src/config/sources/cli-source.js";
+
+describe("CliSource", () => {
+  it("should have name 'cli'", () => {
+    const source = new CliSource({});
+    expect(source.name).toBe("cli");
+  });
+
+  it("should return the overrides as-is", () => {
+    const overrides = { general: { logLevel: "debug" }, safety: { maxPhases: 5 } };
+    const source = new CliSource(overrides);
+    expect(source.load()).toEqual(overrides);
+  });
+
+  it("should return empty object when no overrides", () => {
+    const source = new CliSource({});
+    expect(source.load()).toEqual({});
+  });
+
+  it("should return the same reference passed in", () => {
+    const overrides = { general: { concurrency: 2 } };
+    const source = new CliSource(overrides);
+    expect(source.load()).toBe(overrides);
+  });
+
+  it("should handle nested override objects", () => {
+    const overrides = {
+      commands: { claudeCli: { model: "claude-haiku-4-5-20251001" } },
+    };
+    const source = new CliSource(overrides);
+    const result = source.load();
+    expect(result).toHaveProperty("commands.claudeCli.model", "claude-haiku-4-5-20251001");
+  });
+});

--- a/tests/config/sources/env-source.test.ts
+++ b/tests/config/sources/env-source.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { EnvSource } from "../../../src/config/sources/env-source.js";
+
+describe("EnvSource", () => {
+  it("should have name 'env'", () => {
+    const source = new EnvSource({});
+    expect(source.name).toBe("env");
+  });
+
+  it("should return empty object for empty env", () => {
+    const source = new EnvSource({});
+    expect(source.load()).toEqual({});
+  });
+
+  it("should parse AQM_GENERAL_LOG_LEVEL into general.logLevel", () => {
+    const source = new EnvSource({ AQM_GENERAL_LOG_LEVEL: "debug" });
+    const result = source.load();
+    expect(result).toHaveProperty("general.logLevel", "debug");
+  });
+
+  it("should parse numeric values", () => {
+    const source = new EnvSource({ AQM_GENERAL_CONCURRENCY: "3" });
+    const result = source.load();
+    expect(result).toHaveProperty("general.concurrency", 3);
+  });
+
+  it("should parse boolean values", () => {
+    const source = new EnvSource({ AQM_GENERAL_DRY_RUN: "true" });
+    const result = source.load();
+    expect(result).toHaveProperty("general.dryRun", true);
+  });
+
+  it("should parse comma-separated values as arrays", () => {
+    const source = new EnvSource({ AQM_GIT_ALLOWED_REPOS: "owner/repo1,owner/repo2" });
+    const result = source.load();
+    expect(result).toHaveProperty("git.allowedRepos", ["owner/repo1", "owner/repo2"]);
+  });
+
+  it("should ignore non-AQM_ prefixed variables", () => {
+    const source = new EnvSource({ NODE_ENV: "test", PATH: "/usr/bin" });
+    expect(source.load()).toEqual({});
+  });
+
+  it("should ignore AQM_ variables without a section_key structure", () => {
+    const source = new EnvSource({ AQM_NOKEY: "value" });
+    expect(source.load()).toEqual({});
+  });
+
+  it("should use process.env when no env is passed", () => {
+    // Just verify it doesn't throw and returns an object
+    const source = new EnvSource();
+    expect(typeof source.load()).toBe("object");
+  });
+});

--- a/tests/config/sources/managed-source.test.ts
+++ b/tests/config/sources/managed-source.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { ManagedSource } from "../../../src/config/sources/managed-source.js";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults.js";
+
+describe("ManagedSource", () => {
+  it("should have name 'managed'", () => {
+    const source = new ManagedSource();
+    expect(source.name).toBe("managed");
+  });
+
+  it("should return DEFAULT_CONFIG values", () => {
+    const source = new ManagedSource();
+    const result = source.load();
+    expect(result).toMatchObject({
+      general: expect.objectContaining({
+        projectName: DEFAULT_CONFIG.general.projectName,
+        logLevel: DEFAULT_CONFIG.general.logLevel,
+      }),
+    });
+  });
+
+  it("should return a deep clone (not the same reference)", () => {
+    const source = new ManagedSource();
+    const result1 = source.load();
+    const result2 = source.load();
+    expect(result1).not.toBe(result2);
+    // Mutating result1 should not affect result2
+    (result1 as Record<string, unknown>).general = { mutated: true };
+    const result3 = source.load();
+    expect((result3 as Record<string, unknown>).general).not.toEqual({ mutated: true });
+  });
+
+  it("should include all top-level config sections", () => {
+    const source = new ManagedSource();
+    const result = source.load();
+    expect(result).toHaveProperty("general");
+    expect(result).toHaveProperty("git");
+    expect(result).toHaveProperty("worktree");
+    expect(result).toHaveProperty("commands");
+    expect(result).toHaveProperty("safety");
+  });
+
+  it("should return a synchronous result (not a Promise)", () => {
+    const source = new ManagedSource();
+    const result = source.load();
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+});

--- a/tests/config/sources/merge-sources.test.ts
+++ b/tests/config/sources/merge-sources.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mergeSources } from "../../../src/config/sources/index.js";
+import { ManagedSource } from "../../../src/config/sources/managed-source.js";
+import { UserSource } from "../../../src/config/sources/user-source.js";
+import { ProjectSource } from "../../../src/config/sources/project-source.js";
+import { CliSource } from "../../../src/config/sources/cli-source.js";
+import { EnvSource } from "../../../src/config/sources/env-source.js";
+
+describe("mergeSources — 5단계 병합 통합 테스트", () => {
+  let testDir: string;
+  let userDir: string;
+
+  beforeEach(() => {
+    const ts = Date.now();
+    testDir = join(tmpdir(), `aq-merge-test-${ts}`);
+    userDir = join(tmpdir(), `aq-merge-user-${ts}`);
+    mkdirSync(testDir, { recursive: true });
+    mkdirSync(userDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    rmSync(userDir, { recursive: true, force: true });
+  });
+
+  function writeProjectConfig(content: string): void {
+    writeFileSync(join(testDir, "config.yml"), content);
+  }
+
+  it("should merge Managed source only and return validated config", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "test-project"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      project: new ProjectSource(testDir),
+    });
+
+    expect(result.config.general.projectName).toBe("test-project");
+    // defaults from managed
+    expect(result.config.general.logLevel).toBe("info");
+    expect(result.sources).toContain("managed");
+    expect(result.sources).toContain("project");
+  });
+
+  it("should apply User source on top of Managed", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    const userConfigPath = join(userDir, "config.yml");
+    writeFileSync(userConfigPath, `
+general:
+  logLevel: "warn"
+  concurrency: 4
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      user: new UserSource(userConfigPath),
+      project: new ProjectSource(testDir),
+    });
+
+    expect(result.config.general.logLevel).toBe("warn");
+    expect(result.config.general.concurrency).toBe(4);
+    expect(result.sources).toEqual(expect.arrayContaining(["managed", "user", "project"]));
+  });
+
+  it("should apply CLI overrides above Project", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+  logLevel: "info"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      project: new ProjectSource(testDir),
+      cli: new CliSource({ general: { logLevel: "debug" } }),
+    });
+
+    expect(result.config.general.logLevel).toBe("debug");
+    expect(result.sources).toContain("cli");
+  });
+
+  it("should apply Env overrides at highest priority", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+  logLevel: "info"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      project: new ProjectSource(testDir),
+      cli: new CliSource({ general: { logLevel: "debug" } }),
+      env: new EnvSource({ AQM_GENERAL_LOG_LEVEL: "warn" }),
+    });
+
+    // env beats cli
+    expect(result.config.general.logLevel).toBe("warn");
+    expect(result.sources).toContain("env");
+  });
+
+  it("should apply all 5 sources in priority order: Managed→User→Project→CLI→Env", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+  logLevel: "info"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    const userConfigPath = join(userDir, "config.yml");
+    writeFileSync(userConfigPath, `
+general:
+  logLevel: "debug"
+  concurrency: 2
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      user: new UserSource(userConfigPath),
+      project: new ProjectSource(testDir),
+      cli: new CliSource({ general: { concurrency: 3 } }),
+      env: new EnvSource({ AQM_GENERAL_LOG_LEVEL: "error" }),
+    });
+
+    // env wins for logLevel
+    expect(result.config.general.logLevel).toBe("error");
+    // cli wins for concurrency over user
+    expect(result.config.general.concurrency).toBe(3);
+    // project's value is preserved where not overridden
+    expect(result.config.general.projectName).toBe("project-name");
+    // all 5 sources listed
+    expect(result.sources).toEqual(["managed", "user", "project", "cli", "env"]);
+  });
+
+  it("should skip sources not provided and exclude them from sources list", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      project: new ProjectSource(testDir),
+      // no user, cli, env
+    });
+
+    expect(result.sources).not.toContain("user");
+    expect(result.sources).not.toContain("cli");
+    expect(result.sources).not.toContain("env");
+  });
+
+  it("should use Managed defaults when User source file does not exist", async () => {
+    writeProjectConfig(`
+general:
+  projectName: "project-name"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+
+    const result = await mergeSources({
+      managed: new ManagedSource(),
+      user: new UserSource(join(userDir, "nonexistent.yml")), // file absent → {}
+      project: new ProjectSource(testDir),
+    });
+
+    // managed default survives since user returned {}
+    expect(result.config.general.logLevel).toBe("info");
+    // user source still counted (it ran, returned {})
+    expect(result.sources).toContain("user");
+  });
+});

--- a/tests/config/sources/project-source.test.ts
+++ b/tests/config/sources/project-source.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { ProjectSource } from "../../../src/config/sources/project-source.js";
+
+describe("ProjectSource", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `aq-project-source-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("should have name 'project'", () => {
+    const source = new ProjectSource(testDir);
+    expect(source.name).toBe("project");
+  });
+
+  it("should throw if config.yml is not found", () => {
+    const source = new ProjectSource(testDir);
+    expect(() => source.load()).toThrow("config.yml not found");
+  });
+
+  it("should load and parse config.yml", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+general:
+  projectName: "project-test"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    const source = new ProjectSource(testDir);
+    const result = source.load();
+    expect(result).toHaveProperty("general.projectName", "project-test");
+    expect((result as { git: { allowedRepos: string[] } }).git.allowedRepos).toContain("owner/repo");
+  });
+
+  it("should merge config.local.yml on top of config.yml", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+general:
+  projectName: "project-test"
+  logLevel: "info"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    writeFileSync(join(testDir, "config.local.yml"), `
+general:
+  logLevel: "debug"
+`);
+    const source = new ProjectSource(testDir);
+    const result = source.load();
+    expect(result).toHaveProperty("general.projectName", "project-test");
+    expect(result).toHaveProperty("general.logLevel", "debug");
+  });
+
+  it("should not throw if config.local.yml is absent", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+general:
+  projectName: "project-test"
+git:
+  allowedRepos:
+    - "owner/repo"
+`);
+    const source = new ProjectSource(testDir);
+    expect(() => source.load()).not.toThrow();
+  });
+
+  it("should throw on YAML syntax error in config.yml", () => {
+    writeFileSync(join(testDir, "config.yml"), "key:\n\tbad_indent: value");
+    const source = new ProjectSource(testDir);
+    expect(() => source.load()).toThrow();
+  });
+
+  it("should throw on YAML syntax error in config.local.yml", () => {
+    writeFileSync(join(testDir, "config.yml"), `
+general:
+  projectName: "project-test"
+`);
+    writeFileSync(join(testDir, "config.local.yml"), "key:\n\tbad_indent: value");
+    const source = new ProjectSource(testDir);
+    expect(() => source.load()).toThrow();
+  });
+
+  it("should return empty object for non-object config.yml content", () => {
+    // null YAML gets normalized to {}
+    writeFileSync(join(testDir, "config.yml"), "null");
+    const source = new ProjectSource(testDir);
+    const result = source.load();
+    expect(result).toEqual({});
+  });
+});

--- a/tests/config/sources/user-source.test.ts
+++ b/tests/config/sources/user-source.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { UserSource } from "../../../src/config/sources/user-source.js";
+
+describe("UserSource", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `aq-user-source-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("should have name 'user'", () => {
+    const source = new UserSource(join(testDir, "nonexistent.yml"));
+    expect(source.name).toBe("user");
+  });
+
+  it("should return empty object if config file does not exist", () => {
+    const source = new UserSource(join(testDir, "nonexistent.yml"));
+    expect(source.load()).toEqual({});
+  });
+
+  it("should load and parse valid YAML config", () => {
+    const configPath = join(testDir, "config.yml");
+    writeFileSync(configPath, `
+general:
+  logLevel: "debug"
+  concurrency: 2
+`);
+    const source = new UserSource(configPath);
+    const result = source.load();
+    expect(result).toHaveProperty("general.logLevel", "debug");
+    expect(result).toHaveProperty("general.concurrency", 2);
+  });
+
+  it("should return empty object for empty YAML file", () => {
+    const configPath = join(testDir, "config.yml");
+    writeFileSync(configPath, "");
+    const source = new UserSource(configPath);
+    expect(source.load()).toEqual({});
+  });
+
+  it("should return empty object for null YAML content", () => {
+    const configPath = join(testDir, "config.yml");
+    writeFileSync(configPath, "null");
+    const source = new UserSource(configPath);
+    expect(source.load()).toEqual({});
+  });
+
+  it("should return empty object for non-object YAML (array)", () => {
+    const configPath = join(testDir, "config.yml");
+    writeFileSync(configPath, "- item1\n- item2\n");
+    const source = new UserSource(configPath);
+    // Should log a warning and return {}
+    expect(source.load()).toEqual({});
+  });
+
+  it("should return empty object on YAML parse error (logs warning)", () => {
+    const configPath = join(testDir, "config.yml");
+    // Write invalid YAML with tab indentation
+    writeFileSync(configPath, "key:\n\tbad_indent: value");
+    const source = new UserSource(configPath);
+    // Should catch the error, log warning, return {}
+    expect(source.load()).toEqual({});
+  });
+
+  it("should load nested config sections", () => {
+    const configPath = join(testDir, "config.yml");
+    writeFileSync(configPath, `
+git:
+  defaultBaseBranch: "develop"
+  allowedRepos:
+    - "owner/repo"
+safety:
+  maxPhases: 5
+`);
+    const source = new UserSource(configPath);
+    const result = source.load();
+    expect(result).toHaveProperty("git.defaultBaseBranch", "develop");
+    expect((result as Record<string, unknown> & { git: { allowedRepos: string[] } }).git.allowedRepos).toContain("owner/repo");
+    expect(result).toHaveProperty("safety.maxPhases", 5);
+  });
+
+  it("should use ~/.aqm/config.yml as default path when no path specified", () => {
+    // Just verify it constructs without throwing
+    const source = new UserSource();
+    expect(source.name).toBe("user");
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #386 — refactor: config loader 5단계 병합 — Managed→User→Project→CLI→Env 우선순위

현재 config loader는 4단계(DEFAULT→Project→CLI→Env) 병합만 지원하며, 각 소스 로직이 loader.ts에 인라인으로 구현되어 있다. 5단계 우선순위(Managed→User→Project→CLI→Env)를 지원하고, 각 소스를 독립 모듈로 분리하여 테스트 용이성과 확장성을 개선해야 한다.

## Requirements

- src/config/sources/ 디렉토리에 각 config 소스를 독립 모듈로 분리
- 5단계 우선순위 병합 구현: Managed(DEFAULT_CONFIG) → User(~/.aqm/config.yml) → Project(config.yml, config.local.yml) → CLI(configOverrides) → Env(AQM_*)
- 각 단계에서 존재하는 값만 deep merge로 덮어쓰기
- 기존 loadConfig, tryLoadConfig API 시그니처 유지 (하위 호환성)
- 기존 테스트 통과 + 새 소스 구조에 대한 테스트 추가

## Implementation Phases

- Phase 0: sources 인터페이스 및 기반 구조 — SUCCESS (0e74ec8f)
- Phase 1: Managed/User/Project 소스 구현 — SUCCESS (266eb3b4)
- Phase 2: CLI/Env 소스 구현 — SUCCESS (266eb3b4)
- Phase 3: loader.ts 리팩터링 — SUCCESS (3c7f5486)
- Phase 4: 테스트 추가 및 검증 — SUCCESS (939f9110)

## Risks

- 기존 loadConfig API 시그니처 변경 시 호출부 수정 필요
- User 소스(~/.aqm/config.yml) 추가로 기존 동작과 다른 결과 발생 가능
- deep merge 로직 변경 시 기존 config 병합 결과 달라질 수 있음

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/386-refactor-config-loader-5-managed-user-project-cli-` → `develop`
- **Tokens**: 253 input, 48405 output{{#stats.cacheCreationTokens}}, 320101 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3686556 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #386