### PR TITLE
[AQ-#383] feat: Claude coordinator 신규 생성 — 워커 태스크 분배

### DIFF
--- a/src/claude/coordinator.ts
+++ b/src/claude/coordinator.ts
@@ -1,0 +1,179 @@
+import { WorkerPool, WorkerTaskHandler } from "./worker-pool.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+
+const logger = getLogger();
+
+export interface ClaudeTask {
+  id: string;
+  prompt: string;
+  model?: string;
+  maxTurns?: number;
+  additionalArgs?: string[];
+}
+
+export interface ClaudeTaskResult {
+  taskId: string;
+  workerId: string;
+  output: string;
+  success: boolean;
+  error?: string;
+  duration: number;
+}
+
+export interface CoordinatorConfig {
+  maxWorkers: number;
+  claudeCliPath: string;
+  defaultModel: string;
+  timeout: number;
+}
+
+/**
+ * Claude Worker Pool과 통합하여 태스크를 분배하고 결과를 수집하는 Coordinator.
+ * 다중 Claude 인스턴스 간의 작업 분산을 담당한다.
+ */
+export class Coordinator {
+  private pool: WorkerPool<ClaudeTask, ClaudeTaskResult>;
+  private config: CoordinatorConfig;
+
+  constructor(config: CoordinatorConfig) {
+    this.config = config;
+
+    // WorkerPool에 Claude CLI 태스크 핸들러 설정
+    const handler: WorkerTaskHandler<ClaudeTask, ClaudeTaskResult> = async (
+      task: ClaudeTask,
+      workerId: string
+    ) => {
+      return this.executeClaudeTask(task, workerId);
+    };
+
+    this.pool = new WorkerPool(config.maxWorkers, handler);
+    logger.info(`Coordinator initialized with ${config.maxWorkers} max workers`);
+  }
+
+  /**
+   * 개별 Claude 태스크를 실행한다.
+   */
+  private async executeClaudeTask(
+    task: ClaudeTask,
+    workerId: string
+  ): Promise<ClaudeTaskResult> {
+    const startTime = Date.now();
+
+    try {
+      logger.debug(`${workerId}: executing task ${task.id}`);
+
+      // Claude CLI 실행 로직
+      const { runCli } = await import("../utils/cli-runner.js");
+
+      const model = task.model || this.config.defaultModel;
+      const args = [
+        "--model", model,
+        ...(task.maxTurns ? ["--max-turns", task.maxTurns.toString()] : []),
+        ...(task.additionalArgs || []),
+        task.prompt
+      ];
+
+      const result = await runCli(this.config.claudeCliPath, args, {
+        timeout: this.config.timeout,
+      });
+
+      const duration = Date.now() - startTime;
+
+      if (result.exitCode !== 0) {
+        throw new Error(`Claude CLI failed with exit code ${result.exitCode}: ${result.stderr}`);
+      }
+
+      return {
+        taskId: task.id,
+        workerId,
+        output: result.stdout,
+        success: true,
+        duration,
+      };
+    } catch (error: unknown) {
+      const duration = Date.now() - startTime;
+      const errorMessage = getErrorMessage(error);
+
+      logger.error(`${workerId}: task ${task.id} failed: ${errorMessage}`);
+
+      return {
+        taskId: task.id,
+        workerId,
+        output: "",
+        success: false,
+        error: errorMessage,
+        duration,
+      };
+    }
+  }
+
+  /**
+   * 태스크를 워커 풀에 제출한다.
+   */
+  async submitTask(task: ClaudeTask): Promise<ClaudeTaskResult> {
+    logger.debug(`Submitting task ${task.id} to worker pool`);
+    return this.pool.submit(task);
+  }
+
+  /**
+   * 여러 태스크를 병렬로 실행한다.
+   */
+  async submitTasks(tasks: ClaudeTask[]): Promise<ClaudeTaskResult[]> {
+    logger.info(`Submitting ${tasks.length} tasks for parallel execution`);
+
+    const promises = tasks.map(task => this.submitTask(task));
+    const results = await Promise.allSettled(promises);
+
+    return results.map((result, index) => {
+      if (result.status === "fulfilled") {
+        return result.value;
+      } else {
+        const task = tasks[index];
+        const errorMessage = getErrorMessage(result.reason);
+        logger.error(`Task ${task.id} rejected: ${errorMessage}`);
+
+        return {
+          taskId: task.id,
+          workerId: "unknown",
+          output: "",
+          success: false,
+          error: errorMessage,
+          duration: 0,
+        };
+      }
+    });
+  }
+
+  /**
+   * 워커 풀의 현재 상태를 반환한다.
+   */
+  getPoolStatus() {
+    return this.pool.getStatus();
+  }
+
+  /**
+   * 활성 워커 목록을 반환한다.
+   */
+  getWorkers() {
+    return this.pool.getWorkers();
+  }
+
+  /**
+   * 최대 워커 수를 변경한다.
+   */
+  setMaxWorkers(count: number): void {
+    logger.info(`Updating max workers from ${this.config.maxWorkers} to ${count}`);
+    this.config.maxWorkers = count;
+    this.pool.setMaxWorkers(count);
+  }
+
+  /**
+   * Coordinator를 종료한다.
+   */
+  async shutdown(timeoutMs: number = 30000): Promise<void> {
+    logger.info("Shutting down Coordinator");
+    await this.pool.shutdown(timeoutMs);
+    logger.info("Coordinator shutdown complete");
+  }
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -159,6 +159,7 @@ export const DEFAULT_CONFIG: AQConfig = {
   },
   features: {
     parallelPhases: false,  // 안정성을 위해 기본값은 false
+    multiAI: false,        // 기본값은 false
   },
   executionMode: "standard",
 };

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -286,6 +286,7 @@ const safetyConfigSchema = z.object({
 
 const featuresConfigSchema = z.object({
   parallelPhases: z.boolean(),
+  multiAI: z.boolean(),
 });
 
 const projectConfigSchema = z.object({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -167,6 +167,8 @@ export interface SafetyConfig {
 export interface FeaturesConfig {
   /** 병렬 Phase 실행 활성화 여부 (안정성을 위해 기본값은 false) */
   parallelPhases: boolean;
+  /** Claude 다중 AI 워커 풀 활성화 여부 */
+  multiAI: boolean;
 }
 
 export interface ExecutionModePreset {

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -123,6 +123,7 @@ describe("validateConfig", () => {
     },
     features: {
       parallelPhases: false,
+      multiAI: false,
     },
     executionMode: "standard",
   };


### PR DESCRIPTION
## Summary

Resolves #383 — feat: Claude coordinator 신규 생성 — 워커 태스크 분배

현재 Claude CLI 실행은 단일 프로세스로 처리되어 멀티 AI 워커 환경에서 태스크 분배가 불가능합니다. WorkerPool은 이미 구현되어 있으나, 이를 활용하여 태스크를 분배하고 결과를 수집하는 coordinator가 없습니다. features.multiAI 피처 플래그를 통해 이 기능을 선택적으로 활성화할 수 있어야 합니다.

## Requirements

- src/claude/coordinator.ts 신규 생성 — WorkerPool을 활용한 태스크 분배 및 결과 수집
- config features.multiAI 피처 플래그 추가 (기본값 false)
- config 3곳 동시 수정: types/config.ts, defaults.ts, validator.ts
- npx tsc --noEmit 타입 체크 통과
- npx vitest run 전체 테스트 통과

## Implementation Phases

- Phase 0: Config 필드 추가 — SUCCESS (cd42b0ac)
- Phase 1: Coordinator 모듈 구현 — SUCCESS (d9dcea22)
- Phase 2: Coordinator 테스트 작성 — SUCCESS (9c7964f2)

## Risks

- WorkerPool 인터페이스 변경 시 coordinator 영향
- 피처 플래그 기본값 false이므로 기존 동작에 영향 없음
- config 3곳 수정 누락 시 런타임 오류 발생 가능

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/383-feat-claude-coordinator` → `develop`
- **Tokens**: 23 input, 2860 output{{#stats.cacheCreationTokens}}, 37661 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 68073 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #383