### PR TITLE
[AQ-#412] feat: PhaseResult에 startedAt/completedAt 타임스탬프 추가

### DIFF
--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -39,6 +39,7 @@ export interface PhaseExecutorContext {
 
 export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResult> {
   const startTime = Date.now();
+  const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
   let claudeResult: ClaudeRunResult | undefined;
 
@@ -192,6 +193,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
             warnings,
             commitHash,
             durationMs: Date.now() - startTime,
+            startedAt,
+            completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
           };
@@ -215,6 +218,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
             errors,
             commitHash,
             durationMs: Date.now() - startTime,
+            startedAt,
+            completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
           };
@@ -233,6 +238,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       success: true,
       commitHash,
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult.costUsd,
       usage: claudeResult.usage,
     };
@@ -246,6 +253,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       errorCategory: classifyError(errMsg),
       lastOutput: errMsg.slice(-2000),
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult?.costUsd,
       usage: claudeResult?.usage,
     };

--- a/src/pipeline/phase-retry.ts
+++ b/src/pipeline/phase-retry.ts
@@ -91,6 +91,7 @@ export interface PhaseRetryContext {
 
 export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
   const startTime = Date.now();
+  const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
   let claudeResult: ClaudeRunResult | undefined;
 
@@ -210,6 +211,8 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       success: true,
       commitHash,
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult.costUsd,
     };
   } catch (error: unknown) {
@@ -222,6 +225,8 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       errorCategory: classifyError(errMsg),
       lastOutput: errMsg.slice(-2000),
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult?.costUsd,
     };
   }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -100,6 +100,8 @@ export interface PhaseResult {
   errorCategory?: ErrorCategory;
   lastOutput?: string;
   durationMs: number;
+  startedAt?: string;
+  completedAt?: string;
   costUsd?: number;
   usage?: UsageInfo;
   /** 재시도가 필요한 실패 파일 목록 (partial=true일 때 유효) */

--- a/tests/pipeline/phase-retry.test.ts
+++ b/tests/pipeline/phase-retry.test.ts
@@ -307,6 +307,8 @@ describe("retryPhase", () => {
         success: true,
         commitHash: "abc12345",
         durationMs: expect.any(Number),
+        startedAt: expect.any(String),
+        completedAt: expect.any(String),
         costUsd: undefined,
       });
     });
@@ -352,6 +354,8 @@ describe("retryPhase", () => {
         errorCategory: "CLI_CRASH",
         lastOutput: "Phase retry failed: Claude failed",
         durationMs: expect.any(Number),
+        startedAt: expect.any(String),
+        completedAt: expect.any(String),
         costUsd: undefined,
       });
     });
@@ -376,6 +380,8 @@ describe("retryPhase", () => {
         errorCategory: "VERIFICATION_FAILED",
         lastOutput: expect.stringMatching(/Tests failed after retry/),
         durationMs: expect.any(Number),
+        startedAt: expect.any(String),
+        completedAt: expect.any(String),
         costUsd: undefined,
       });
     });


### PR DESCRIPTION
## Summary

Resolves #412 — feat: PhaseResult에 startedAt/completedAt 타임스탬프 추가

현재 PhaseResult는 durationMs만 기록하여 Phase 실행 소요시간은 알 수 있지만, 실제 시작/종료 시점을 알 수 없다. 파이프라인 모니터링과 디버깅을 위해 각 Phase의 절대 시작/종료 타임스탬프가 필요하다.

## Requirements

- PhaseResult 인터페이스에 startedAt, completedAt optional 필드 추가 (ISO 8601 문자열)
- phase-executor.ts의 모든 return 지점(성공 3곳, 실패 1곳)에 타임스탬프 기록
- phase-retry.ts의 모든 return 지점(성공 1곳, 실패 1곳)에 타임스탬프 기록
- 기존 phaseResults 하위 호환 유지 (optional 필드로 추가)

## Implementation Phases

- Phase 0: PhaseResult 타임스탬프 필드 추가 및 적용 — SUCCESS (e33b44fb)

## Risks

- 타입 변경으로 인한 컴파일 에러 가능성 (optional이므로 낮음)
- return 지점 누락 시 일부 PhaseResult에 타임스탬프 없을 수 있음

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/412-feat-phaseresult-startedat-completedat` → `develop`
- **Tokens**: 114 input, 10920 output{{#stats.cacheCreationTokens}}, 99827 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1292952 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #412