### PR TITLE
[AQ-#413] fix: 타임라인 Gantt 차트 실제 시간 기준 렌더링 — 순차 누적 → 타임스탬프 기반

### DIFF
--- a/src/pipeline/phase-executor.ts
+++ b/src/pipeline/phase-executor.ts
@@ -39,6 +39,7 @@ export interface PhaseExecutorContext {
 
 export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResult> {
   const startTime = Date.now();
+  const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
   let claudeResult: ClaudeRunResult | undefined;
 
@@ -192,6 +193,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
             warnings,
             commitHash,
             durationMs: Date.now() - startTime,
+            startedAt,
+            completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
           };
@@ -215,6 +218,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
             errors,
             commitHash,
             durationMs: Date.now() - startTime,
+            startedAt,
+            completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
           };
@@ -233,6 +238,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       success: true,
       commitHash,
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult.costUsd,
       usage: claudeResult.usage,
     };
@@ -246,6 +253,8 @@ const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi
       errorCategory: classifyError(errMsg),
       lastOutput: errMsg.slice(-2000),
       durationMs: Date.now() - startTime,
+      startedAt,
+      completedAt: new Date().toISOString(),
       costUsd: claudeResult?.costUsd,
       usage: claudeResult?.usage,
     };

--- a/src/server/public/js/timeline.js
+++ b/src/server/public/js/timeline.js
@@ -62,7 +62,7 @@ function renderTimelineModal(job) {
 
     // Gantt body
     '<div class="p-6">' +
-      renderGanttChart(phases, totalDurationMs) +
+      renderGanttChart(phases, totalDurationMs, job.startedAt) +
     '</div>' +
 
     '</div>' +
@@ -73,7 +73,7 @@ function renderTimelineModal(job) {
    Gantt Chart
    ══════════════════════════════════════════════════════════════ */
 
-function renderGanttChart(phases, totalDurationMs) {
+function renderGanttChart(phases, totalDurationMs, jobStartedAt) {
   if (!phases || phases.length === 0) {
     return '<div class="flex items-center justify-center py-16 text-outline text-sm">' +
       '<span class="material-symbols-outlined text-lg mr-2">hourglass_empty</span>No phase data available</div>';
@@ -97,9 +97,10 @@ function renderGanttChart(phases, totalDurationMs) {
     'background-image:linear-gradient(to right,rgba(65,71,82,0.4) 1px,transparent 1px);background-size:16.66% 100%"></div>';
 
   html += '<div class="space-y-4">';
+  // cumulativeMs is kept for legacy fallback (phases without timestamps)
   var cumulativeMs = 0;
   phases.forEach(function(phase) {
-    html += renderGanttPhaseRow(phase, cumulativeMs, totalDurationMs);
+    html += renderGanttPhaseRow(phase, cumulativeMs, totalDurationMs, jobStartedAt);
     cumulativeMs += (phase.durationMs || 0);
   });
   html += '</div>';
@@ -133,7 +134,7 @@ function buildXAxis(totalDurationMs) {
    Phase Row
    ══════════════════════════════════════════════════════════════ */
 
-function renderGanttPhaseRow(phase, startMs, totalDurationMs) {
+function renderGanttPhaseRow(phase, cumulativeFallbackMs, totalDurationMs, jobStartedAt) {
   var phaseName = phase.name || 'Phase';
   var isSuccess = phase.success === true;
   var isFailed = phase.success === false;
@@ -143,8 +144,21 @@ function renderGanttPhaseRow(phase, startMs, totalDurationMs) {
   var cost = fmtCost(phase.costUsd);
 
   // Bar position (percentage of total)
-  var leftPct = (totalDurationMs > 0 && startMs > 0) ? (startMs / totalDurationMs * 100) : 0;
-  var widthPct = (totalDurationMs > 0 && hasDuration) ? (durationMs / totalDurationMs * 100) : 0;
+  // Prefer timestamp-based calculation; fall back to cumulative durationMs for legacy data
+  var leftPct, widthPct;
+  if (jobStartedAt && phase.startedAt) {
+    var jobStartMs = new Date(jobStartedAt).getTime();
+    var phaseStartMs = new Date(phase.startedAt).getTime();
+    var phaseOffsetMs = phaseStartMs - jobStartMs;
+    var phaseDurationMs = phase.completedAt
+      ? new Date(phase.completedAt).getTime() - phaseStartMs
+      : durationMs;
+    leftPct = totalDurationMs > 0 ? (phaseOffsetMs / totalDurationMs * 100) : 0;
+    widthPct = totalDurationMs > 0 && phaseDurationMs > 0 ? (phaseDurationMs / totalDurationMs * 100) : 0;
+  } else {
+    leftPct = (totalDurationMs > 0 && cumulativeFallbackMs > 0) ? (cumulativeFallbackMs / totalDurationMs * 100) : 0;
+    widthPct = (totalDurationMs > 0 && hasDuration) ? (durationMs / totalDurationMs * 100) : 0;
+  }
 
   // Clamp: always show at least 0.5% width for visible phases
   leftPct = Math.min(Math.max(leftPct, 0), 100);

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -100,6 +100,10 @@ export interface PhaseResult {
   errorCategory?: ErrorCategory;
   lastOutput?: string;
   durationMs: number;
+  /** Phase 시작 시각 (ISO 8601) */
+  startedAt?: string;
+  /** Phase 완료 시각 (ISO 8601) */
+  completedAt?: string;
   costUsd?: number;
   usage?: UsageInfo;
   /** 재시도가 필요한 실패 파일 목록 (partial=true일 때 유효) */
@@ -387,6 +391,10 @@ export interface PhaseResultInfo {
   success: boolean;
   commit?: string;
   durationMs: number;
+  /** Phase 시작 시각 (ISO 8601) */
+  startedAt?: string;
+  /** Phase 완료 시각 (ISO 8601) */
+  completedAt?: string;
   error?: string;
   costUsd?: number;
   usage?: UsageStats;


### PR DESCRIPTION
## Summary

Resolves #413 — fix: 타임라인 Gantt 차트 실제 시간 기준 렌더링 — 순차 누적 → 타임스탬프 기반

현재 타임라인 Gantt 차트는 cumulativeMs를 순차적으로 누적하여 bar 위치를 계산하므로, 병렬 실행된 Phase가 겹쳐 보이지 않고 순차적으로 표시된다. 또한 Phase 간 대기 시간(retry, 검증)이 빈 공간으로 표현되지 않아 실제 파이프라인 실행 타임라인을 정확히 반영하지 못한다.

## Requirements

- PhaseResult 및 PhaseResultInfo 타입에 startedAt/completedAt 타임스탬프 필드 추가
- phase-executor.ts에서 Phase 시작/완료 시점 타임스탬프 기록
- timeline.js에서 cumulativeMs 순차 누적 제거하고 타임스탬프 기반 bar 위치 계산
- 병렬 Phase는 같은 시간대에 겹쳐서 표시
- Phase 간 대기 시간이 빈 공간으로 표시

## Implementation Phases

- Phase 0: PhaseResult 타임스탬프 타입 추가 — SUCCESS (5c886b03)
- Phase 1: phase-executor 타임스탬프 기록 — SUCCESS (a84c291b)
- Phase 2: timeline.js 타임스탬프 기반 렌더링 — SUCCESS (a84c291b)

## Risks

- 기존 PhaseResult 데이터와의 하위 호환성 (optional 필드로 처리)
- 타임스탬프가 없는 레거시 데이터에서 fallback 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/413-fix-gantt` → `develop`
- **Tokens**: 94 input, 11341 output{{#stats.cacheCreationTokens}}, 137908 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 792540 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #413