### PR TITLE
[AQ-#327] fix: 웹훅 모드에서도 폴링 보조 실행 — 놓친 이벤트 복구

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -343,12 +343,9 @@ async function startCommand(args: CliArgs): Promise<void> {
     }
   };
 
-  // === Polling mode ===
-  let poller: IssuePoller | undefined;
-  if (isPollingMode) {
-    poller = new IssuePoller(effectiveConfig, store, queue, performGracefulRestart);
-    poller.start();
-  }
+  // === Poller: always start (webhook mode uses it as fallback for missed events) ===
+  const poller = new IssuePoller(effectiveConfig, store, queue, performGracefulRestart);
+  poller.start();
 
   // Mount dashboard and health routes
   const apiKey = process.env.DASHBOARD_API_KEY || undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ export async function checkForUpdates(aqRoot: string): Promise<void> {
   }
 }
 
-async function startCommand(args: CliArgs): Promise<void> {
+export async function startCommand(args: CliArgs): Promise<void> {
   const aqRoot = args.config ? resolve(args.config, "..") : process.cwd();
 
   // Check for updates (non-blocking)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildProjectConcurrency, parseArgs, printHelp, runCommand, checkForUpdates, statusCommand, versionCommand, doctorCommand } from "../src/cli.js";
+import { buildProjectConcurrency, parseArgs, printHelp, runCommand, checkForUpdates, statusCommand, versionCommand, doctorCommand, startCommand } from "../src/cli.js";
 import { loadConfig, tryLoadConfig } from "../src/config/loader.js";
 import { runPipeline } from "../src/pipeline/orchestrator.js";
 import { JobStore } from "../src/queue/job-store.js";
+import { JobQueue } from "../src/queue/job-queue.js";
 import { runDoctor } from "../src/setup/doctor.js";
 import { runCli } from "../src/utils/cli-runner.js";
+import { IssuePoller } from "../src/polling/issue-poller.js";
+import { createWebhookApp, startServer } from "../src/server/webhook-server.js";
+import { createDashboardRoutes } from "../src/server/dashboard-api.js";
+import { createHealthRoutes } from "../src/server/health.js";
+import { cleanupStalePid, writePidFile } from "../src/server/pid-manager.js";
+import { ConfigWatcher } from "../src/config/config-watcher.js";
 
 vi.mock("../src/config/loader.js", () => ({
   loadConfig: vi.fn(),
@@ -25,6 +32,32 @@ vi.mock("../src/setup/doctor.js", () => ({
 }));
 vi.mock("../src/utils/cli-runner.js", () => ({
   runCli: vi.fn(),
+}));
+vi.mock("../src/polling/issue-poller.js", () => ({
+  IssuePoller: vi.fn(),
+}));
+vi.mock("../src/queue/job-queue.js", () => ({
+  JobQueue: vi.fn(),
+}));
+vi.mock("../src/server/webhook-server.js", () => ({
+  createWebhookApp: vi.fn(),
+  startServer: vi.fn(),
+}));
+vi.mock("../src/server/dashboard-api.js", () => ({
+  createDashboardRoutes: vi.fn(),
+  applyConfigChanges: vi.fn(),
+}));
+vi.mock("../src/server/health.js", () => ({
+  createHealthRoutes: vi.fn(),
+}));
+vi.mock("../src/server/pid-manager.js", () => ({
+  writePidFile: vi.fn(),
+  cleanupStalePid: vi.fn(),
+  removePidFile: vi.fn(),
+  readPidFile: vi.fn(),
+}));
+vi.mock("../src/config/config-watcher.js", () => ({
+  ConfigWatcher: vi.fn(),
 }));
 
 describe("buildProjectConcurrency", () => {
@@ -390,5 +423,79 @@ describe("doctorCommand", () => {
     await doctorCommand({});
     expect(tryLoadConfig).toHaveBeenCalled();
     expect(runDoctor).toHaveBeenCalled();
+  });
+});
+
+describe("startCommand — IssuePoller 항상 시작", () => {
+  let mockPollerStart: ReturnType<typeof vi.fn>;
+
+  const mockConfigWithProject = {
+    ...mockBaseConfig,
+    projects: [{ repo: "owner/repo", path: "/tmp", baseBranch: "main" }],
+  } as unknown as ReturnType<typeof loadConfig>;
+
+  beforeEach(() => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+
+    mockPollerStart = vi.fn();
+    vi.mocked(IssuePoller).mockImplementation(() => ({
+      start: mockPollerStart,
+      stop: vi.fn(),
+      isRunning: vi.fn().mockReturnValue(false),
+    } as unknown as IssuePoller));
+
+    vi.mocked(JobStore).mockImplementation(() => ({
+      prune: vi.fn(),
+      list: vi.fn().mockReturnValue([]),
+    } as unknown as JobStore));
+
+    vi.mocked(JobQueue).mockImplementation(() => ({
+      recover: vi.fn(),
+      shutdown: vi.fn(),
+      enqueue: vi.fn(),
+    } as unknown as JobQueue));
+
+    vi.mocked(loadConfig).mockReturnValue(mockConfigWithProject);
+
+    vi.mocked(createWebhookApp).mockReturnValue({
+      route: vi.fn(),
+      get: vi.fn(),
+    } as unknown as ReturnType<typeof createWebhookApp>);
+    vi.mocked(createDashboardRoutes).mockReturnValue({} as unknown as ReturnType<typeof createDashboardRoutes>);
+    vi.mocked(createHealthRoutes).mockReturnValue({} as unknown as ReturnType<typeof createHealthRoutes>);
+    vi.mocked(cleanupStalePid).mockReturnValue(true);
+
+    vi.mocked(ConfigWatcher).mockImplementation(() => ({
+      on: vi.fn(),
+      startWatching: vi.fn(),
+      stopWatching: vi.fn(),
+    } as unknown as ConfigWatcher));
+
+    vi.mocked(runCli).mockResolvedValue({ stdout: "0\n", stderr: "", exitCode: 0 });
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    vi.restoreAllMocks();
+  });
+
+  it("웹훅 모드에서 IssuePoller.start()가 호출됨 (놓친 이벤트 복구 보장)", async () => {
+    await startCommand({});
+    expect(mockPollerStart).toHaveBeenCalledOnce();
+  });
+
+  it("IssuePoller는 웹훅 앱 설정보다 먼저 생성됨", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(IssuePoller).mockImplementation(() => {
+      callOrder.push("IssuePoller");
+      return { start: vi.fn(), stop: vi.fn(), isRunning: vi.fn().mockReturnValue(false) } as unknown as IssuePoller;
+    });
+    vi.mocked(startServer).mockImplementation(() => {
+      callOrder.push("startServer");
+    });
+
+    await startCommand({});
+
+    expect(callOrder.indexOf("IssuePoller")).toBeLessThan(callOrder.indexOf("startServer"));
   });
 });


### PR DESCRIPTION
## Summary

Resolves #327 — fix: 웹훅 모드에서도 폴링 보조 실행 — 놓친 이벤트 복구

현재 웹훅 모드와 폴링 모드가 배타적으로 동작하여(`isPollingMode` 분기), 서버 재시작 후 이미 라벨이 달려있는 이슈는 웹훅 이벤트가 발생하지 않아 놓치게 된다. 웹훅 모드에서도 폴링을 보조로 실행하여 놓친 이벤트를 복구해야 한다.

## Requirements

- 웹훅 모드(`aqm start`)에서도 폴링을 보조로 실행
- 폴링 주기는 기존 `pollingIntervalMs` 설정 사용
- 웹훅이 이미 처리한 이슈는 중복 처리하지 않도록 방어

## Implementation Phases

- Phase 0: 폴러 상시 시작 로직 구현 — SUCCESS (829837b5)
- Phase 1: 테스트 작성 및 검증 — SUCCESS (6ada64e9)

## Risks

- 웹훅과 폴러가 동시에 같은 이슈를 처리하려 할 때 race condition 가능성 (기존 shouldBlockRepickup/enqueue 중복 방지 로직으로 방어됨)
- 폴링 간격이 짧으면 불필요한 GitHub API 호출 증가 (기존 idle 감지 로직으로 5분 무활동 시 5분 간격 폴링으로 완화됨)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/327-fix` → `develop`
- **Tokens**: 58 input, 5485 output{{#stats.cacheCreationTokens}}, 80053 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 343820 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #327