### PR TITLE
[AQ-#421] refactor: AQMTask 공통 인터페이스 정의 — tasks 추상화 기반

### DIFF
--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -26,6 +26,26 @@ export enum TaskStatus {
 export type AQMTaskType = "claude" | "codex" | "gemini";
 
 /**
+ * 태스크 라이프사이클 이벤트 타입
+ */
+export type TaskLifecycleEvent = "started" | "completed" | "failed" | "killed";
+
+/**
+ * 태스크 이벤트 리스너 타입
+ */
+export type TaskEventListener = () => void;
+
+/**
+ * 태스크 이벤트 에미터 인터페이스
+ * 라이프사이클 이벤트를 구독/해제하는 메서드 계약
+ */
+export interface TaskEventEmitter {
+  on(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+  off(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+  once(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+}
+
+/**
  * 태스크 JSON 직렬화를 위한 요약 정보
  */
 export interface AQMTaskSummary {
@@ -44,6 +64,12 @@ export interface AQMTaskSummary {
   /** 실행 결과 메타데이터 */
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * 태스크 역직렬화(fromJSON)를 위한 직렬화 형태
+ * AQMTaskSummary와 동일한 구조이나, 역직렬화 목적으로 분리
+ */
+export type SerializedTask = AQMTaskSummary;
 
 /**
  * AQM 태스크 공통 인터페이스
@@ -70,6 +96,21 @@ export interface AQMTask {
    * @returns 직렬화된 태스크 요약 정보
    */
   toJSON(): AQMTaskSummary;
+
+  /**
+   * 라이프사이클 이벤트 리스너 등록
+   */
+  on?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+
+  /**
+   * 라이프사이클 이벤트 리스너 해제
+   */
+  off?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+
+  /**
+   * 라이프사이클 이벤트 리스너 1회 등록 (이벤트 발생 후 자동 해제)
+   */
+  once?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
 }
 
 /**

--- a/src/tasks/claude-task.ts
+++ b/src/tasks/claude-task.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
+import { EventEmitter } from "events";
+import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions, TaskLifecycleEvent, TaskEventListener, SerializedTask } from "./aqm-task.js";
 import { runClaude, getActiveProcessPids, type ClaudeRunResult, type ClaudeRunOptions } from "../claude/claude-runner.js";
 import type { ClaudeCliConfig } from "../types/config.js";
 
@@ -38,6 +39,7 @@ export class ClaudeTask implements AQMTask {
   private _result?: ClaudeRunResult;
   private _processId?: number;
   private readonly _options: ClaudeTaskOptions;
+  private readonly _emitter = new EventEmitter();
 
   constructor(options: ClaudeTaskOptions) {
     this.id = options.id || randomUUID();
@@ -56,6 +58,18 @@ export class ClaudeTask implements AQMTask {
     return this._status;
   }
 
+  on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.on(event, listener);
+  }
+
+  off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.off(event, listener);
+  }
+
+  once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.once(event, listener);
+  }
+
   async run(): Promise<ClaudeRunResult> {
     if (this._status !== "PENDING") {
       throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
@@ -63,6 +77,7 @@ export class ClaudeTask implements AQMTask {
 
     this._status = TaskStatus.RUNNING;
     this._startedAt = new Date();
+    this._emitter.emit("started");
 
     try {
       // Claude 실행 옵션 구성
@@ -92,10 +107,17 @@ export class ClaudeTask implements AQMTask {
       this._completedAt = new Date();
       this._status = this._result.success ? TaskStatus.SUCCESS : TaskStatus.FAILED;
 
+      if (this._result.success) {
+        this._emitter.emit("completed");
+      } else {
+        this._emitter.emit("failed");
+      }
+
       return this._result;
     } catch (error) {
       this._completedAt = new Date();
       this._status = TaskStatus.FAILED;
+      this._emitter.emit("failed");
 
       // 에러를 ClaudeRunResult 형태로 변환
       this._result = {
@@ -135,6 +157,7 @@ export class ClaudeTask implements AQMTask {
     this._status = TaskStatus.KILLED;
     this._completedAt = new Date();
     this._processId = undefined;
+    this._emitter.emit("killed");
   }
 
   toJSON(): AQMTaskSummary {
@@ -168,5 +191,26 @@ export class ClaudeTask implements AQMTask {
 
   getResult(): ClaudeRunResult | undefined {
     return this._result;
+  }
+
+  /**
+   * SerializedTask로부터 ClaudeTask를 복원
+   * 복원된 태스크는 PENDING 상태로 시작
+   */
+  static fromJSON(data: SerializedTask, config: ClaudeCliConfig): ClaudeTask {
+    const metadata = data.metadata ?? {};
+    const prompt = typeof metadata.prompt === "string" ? metadata.prompt : "";
+    const systemPrompt = typeof metadata.systemPrompt === "string" ? metadata.systemPrompt : undefined;
+    const maxTurns = typeof metadata.maxTurns === "number" ? metadata.maxTurns : undefined;
+    const enableAgents = typeof metadata.enableAgents === "boolean" ? metadata.enableAgents : undefined;
+
+    return new ClaudeTask({
+      id: data.id,
+      prompt,
+      config,
+      systemPrompt,
+      maxTurns,
+      enableAgents,
+    });
   }
 }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -8,7 +8,11 @@ export {
   TaskStatus,
   AQMTaskType,
   AQMTaskSummary,
-  BaseTaskOptions
+  BaseTaskOptions,
+  SerializedTask,
+  TaskLifecycleEvent,
+  TaskEventListener,
+  TaskEventEmitter
 } from "./aqm-task.js";
 
 // Claude 태스크 구현체

--- a/tests/tasks/aqm-task.test.ts
+++ b/tests/tasks/aqm-task.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   TaskStatus,
   AQMTaskType,
   AQMTaskSummary,
   AQMTask,
-  BaseTaskOptions
+  BaseTaskOptions,
+  SerializedTask,
+  TaskLifecycleEvent,
+  TaskEventEmitter,
+  TaskEventListener,
 } from "../../src/tasks/aqm-task.js";
 
 describe("AQMTask 인터페이스 및 타입 정의", () => {
@@ -155,6 +159,273 @@ describe("AQMTask 인터페이스 및 타입 정의", () => {
         type: "claude",
         status: TaskStatus.PENDING
       });
+    });
+
+    it("should support optional on/off/once event methods", () => {
+      // AQMTask interface defines on/off/once as optional
+      // A task without event support is valid
+      const task = new TestTask();
+      expect(task.on).toBeUndefined();
+      expect(task.off).toBeUndefined();
+      expect(task.once).toBeUndefined();
+    });
+
+    it("should support implementation with event methods", () => {
+      class EventedTask implements AQMTask {
+        readonly id = "evented-task";
+        readonly type: AQMTaskType = "claude";
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        get status() { return TaskStatus.PENDING; }
+        async kill() {}
+        toJSON(): AQMTaskSummary {
+          return { id: this.id, type: this.type, status: this.status };
+        }
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const task = new EventedTask();
+      const fn = vi.fn();
+      task.on("started", fn);
+      task.emit("started");
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      task.off("started", fn);
+      task.emit("started");
+      expect(fn).toHaveBeenCalledTimes(1); // not called again
+    });
+  });
+
+  describe("SerializedTask 타입", () => {
+    it("should be structurally identical to AQMTaskSummary", () => {
+      // SerializedTask = AQMTaskSummary (type alias)
+      const serialized: SerializedTask = {
+        id: "task-123",
+        type: "claude",
+        status: TaskStatus.SUCCESS
+      };
+
+      expect(serialized.id).toBe("task-123");
+      expect(serialized.type).toBe("claude");
+      expect(serialized.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should accept all optional fields", () => {
+      const serialized: SerializedTask = {
+        id: "task-456",
+        type: "codex",
+        status: TaskStatus.FAILED,
+        startedAt: "2026-04-10T10:00:00.000Z",
+        completedAt: "2026-04-10T10:01:00.000Z",
+        durationMs: 60000,
+        metadata: { prompt: "test", retryCount: 2 }
+      };
+
+      expect(serialized.startedAt).toBe("2026-04-10T10:00:00.000Z");
+      expect(serialized.completedAt).toBe("2026-04-10T10:01:00.000Z");
+      expect(serialized.durationMs).toBe(60000);
+      expect(serialized.metadata?.retryCount).toBe(2);
+    });
+
+    it("should be usable as AQMTaskSummary and vice versa", () => {
+      // SerializedTask and AQMTaskSummary are interchangeable
+      const summary: AQMTaskSummary = {
+        id: "task-789",
+        type: "gemini",
+        status: TaskStatus.PENDING
+      };
+
+      const serialized: SerializedTask = summary;
+      const backToSummary: AQMTaskSummary = serialized;
+
+      expect(backToSummary.id).toBe("task-789");
+    });
+  });
+
+  describe("TaskLifecycleEvent 타입", () => {
+    it("should accept all valid lifecycle event values", () => {
+      const events: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      expect(events).toHaveLength(4);
+      expect(events).toContain("started");
+      expect(events).toContain("completed");
+      expect(events).toContain("failed");
+      expect(events).toContain("killed");
+    });
+
+    it("should be usable as event key in a map", () => {
+      const callCounts = new Map<TaskLifecycleEvent, number>();
+      const allEvents: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      for (const event of allEvents) {
+        callCounts.set(event, 0);
+      }
+
+      callCounts.set("started", 1);
+      expect(callCounts.get("started")).toBe(1);
+    });
+  });
+
+  describe("TaskEventListener 타입", () => {
+    it("should be a callable with no parameters", () => {
+      const listener: TaskEventListener = vi.fn();
+      listener();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support multiple listener instances", () => {
+      const listeners: TaskEventListener[] = [vi.fn(), vi.fn(), vi.fn()];
+      listeners.forEach(l => l());
+
+      listeners.forEach(l => expect(l).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("TaskEventEmitter 인터페이스", () => {
+    it("should be implementable with on/off/once methods", () => {
+      class SimpleEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const emitter = new SimpleEmitter();
+      const fn = vi.fn();
+
+      emitter.on("started", fn);
+      emitter.emit("started");
+      emitter.emit("started");
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      emitter.off("started", fn);
+      emitter.emit("started");
+      expect(fn).toHaveBeenCalledTimes(2); // not called again
+    });
+
+    it("should support once semantics — fires only once", () => {
+      class SimpleEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          [...(this._listeners.get(event) ?? [])].forEach(l => l());
+        }
+      }
+
+      const emitter = new SimpleEmitter();
+      const fn = vi.fn();
+
+      emitter.once("completed", fn);
+      emitter.emit("completed");
+      emitter.emit("completed");
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle all four lifecycle events independently", () => {
+      const calls: TaskLifecycleEvent[] = [];
+
+      class TrackingEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const emitter = new TrackingEmitter();
+      const allEvents: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      for (const event of allEvents) {
+        emitter.on(event, () => calls.push(event));
+      }
+
+      emitter.emit("started");
+      emitter.emit("failed");
+      emitter.emit("killed");
+
+      expect(calls).toEqual(["started", "failed", "killed"]);
+      expect(calls).not.toContain("completed");
     });
   });
 });

--- a/tests/tasks/claude-task.test.ts
+++ b/tests/tasks/claude-task.test.ts
@@ -442,4 +442,96 @@ describe("ClaudeTask", () => {
       expect(json.durationMs).toBeGreaterThanOrEqual(0);
     });
   });
+
+  describe("fromJSON", () => {
+    const baseConfig: ClaudeTaskOptions["config"] = {
+      path: "claude",
+      model: "sonnet",
+      maxTurns: 10,
+      timeout: 30000,
+      additionalArgs: []
+    };
+
+    it("should restore task from SerializedTask in PENDING state", () => {
+      const serialized = {
+        id: "restored-id",
+        type: "claude" as const,
+        status: TaskStatus.SUCCESS,
+        metadata: { prompt: "Restored prompt" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+
+      expect(task.id).toBe("restored-id");
+      expect(task.type).toBe("claude");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should restore prompt from metadata", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.FAILED,
+        metadata: { prompt: "Hello world" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const json = task.toJSON();
+
+      expect(json.metadata?.prompt).toBe("Hello world");
+    });
+
+    it("should restore optional fields from metadata", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.SUCCESS,
+        metadata: {
+          prompt: "Test",
+          systemPrompt: "Be helpful",
+          maxTurns: 5,
+          enableAgents: true
+        }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const json = task.toJSON();
+
+      expect(json.metadata?.systemPrompt).toBe("Be helpful");
+      expect(json.metadata?.maxTurns).toBe(5);
+      expect(json.metadata?.enableAgents).toBe(true);
+    });
+
+    it("should handle missing metadata gracefully", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.PENDING,
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+
+      expect(task.id).toBe("test-id");
+      expect(task.status).toBe(TaskStatus.PENDING);
+      const json = task.toJSON();
+      expect(json.metadata?.prompt).toBe("");
+    });
+
+    it("should be runnable after restoration", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const serialized = {
+        id: "runnable-id",
+        type: "claude" as const,
+        status: TaskStatus.FAILED,
+        metadata: { prompt: "Run me again" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const result = await task.run();
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+  });
 });

--- a/tests/tasks/claude-task.test.ts
+++ b/tests/tasks/claude-task.test.ts
@@ -276,6 +276,99 @@ describe("ClaudeTask", () => {
     });
   });
 
+  describe("라이프사이클 이벤트", () => {
+    it("should emit started event when run begins", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit completed event on success", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await task.run();
+
+      expect(completedFn).toHaveBeenCalledTimes(1);
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it("should emit failed event on unsuccessful result", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: false, output: "err", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await task.run();
+
+      expect(failedFn).toHaveBeenCalledTimes(1);
+      expect(completedFn).not.toHaveBeenCalled();
+    });
+
+    it("should emit failed event on thrown error", async () => {
+      mockRunClaude.mockRejectedValueOnce(new Error("crash"));
+
+      const task = new ClaudeTask(testOptions);
+      const failedFn = vi.fn();
+      task.on("failed", failedFn);
+
+      await expect(task.run()).rejects.toThrow("crash");
+
+      expect(failedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit killed event when kill is called", async () => {
+      const task = new ClaudeTask(testOptions);
+      const killedFn = vi.fn();
+      task.on("killed", killedFn);
+
+      (task as any)._status = TaskStatus.RUNNING;
+      await task.kill();
+
+      expect(killedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support once listener (fires only once)", async () => {
+      mockRunClaude
+        .mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const onceFn = vi.fn();
+      task.once("started", onceFn);
+
+      await task.run();
+
+      expect(onceFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support off (remove listener)", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+      task.off("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).not.toHaveBeenCalled();
+    });
+  });
+
   describe("직렬화", () => {
     it("should serialize task to JSON summary", () => {
       const task = new ClaudeTask({


### PR DESCRIPTION
## Summary

Resolves #421 — refactor: AQMTask 공통 인터페이스 정의 — tasks 추상화 기반

현재 src/tasks/에 AQMTask 인터페이스와 ClaudeTask 구현체가 존재하나, 요구사항의 fromJSON() 역직렬화, SerializedTask 타입, 라이프사이클 이벤트(started, completed, failed, killed)가 누락되어 있음. 향후 CodexTask, GeminiTask 등 확장을 위한 완전한 태스크 추상화 기반 구축 필요.

## Requirements

- AQMTask 인터페이스에 fromJSON() 정적 팩토리 패턴 추가
- SerializedTask 타입 정의 (AQMTaskSummary 확장, 복원에 필요한 필드 포함)
- TaskLifecycleEvent 타입 및 이벤트 발생 메커니즘 추가
- ClaudeTask에 fromJSON() 구현 및 이벤트 emit 통합
- 기존 테스트 확장 및 신규 기능 테스트 추가
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: 타입 및 인터페이스 확장 — SUCCESS (a60f20a1)
- Phase 1: ClaudeTask 이벤트 통합 — SUCCESS (40a1b5be)
- Phase 2: fromJSON 팩토리 구현 — SUCCESS (40a1b5be)
- Phase 3: index.ts export 업데이트 — SUCCESS (40a1b5be)
- Phase 4: 테스트 확장 — SUCCESS (baa06fd2)

## Risks

- EventEmitter 의존성 추가로 번들 크기 증가 가능 (Node.js 내장 사용으로 최소화)
- fromJSON() 복원 시 비동기 상태(진행 중 태스크) 복원 불가 — 설계상 PENDING으로 제한
- 기존 AQMTaskSummary 사용처와 SerializedTask 호환성 검토 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/421-refactor-aqmtask-tasks` → `develop`
- **Tokens**: 221 input, 30706 output{{#stats.cacheCreationTokens}}, 249413 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2750961 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #421