### PR TITLE
[AQ-#419] refactor: 프롬프트 레이어 구조 정의 — Base/Project/Issue/Phase/Learning 분리

### DIFF
--- a/src/prompt/layer-types.ts
+++ b/src/prompt/layer-types.ts
@@ -1,0 +1,206 @@
+/**
+ * 프롬프트 레이어 타입 정의
+ *
+ * 5계층 구조:
+ *   BaseLayer    — 역할·규칙 등 완전 정적 (글로벌 캐시)
+ *   ProjectLayer — 프로젝트 수준 설정 (프로젝트별 캐시)
+ *   IssueLayer   — 이슈 정보 (이슈번호별 캐시)
+ *   PhaseLayer   — 현재 Phase 실행 컨텍스트 (Phase별 캐시)
+ *   LearningLayer— 누적 학습 정보 (동적, 주기적 갱신)
+ */
+
+// ---------------------------------------------------------------------------
+// BaseLayer
+// 캐시 특성: 완전 정적. 내용이 바뀌지 않는 한 영구 캐시 가능.
+//             캐시 키: role + rules 해시
+// ---------------------------------------------------------------------------
+
+/**
+ * 기본 레이어 — AI 역할 정의, 보편적 규칙, 출력 형식 등 프로젝트와 무관한 정적 내용.
+ */
+export interface BaseLayer {
+  /** AI 역할 정의 (예: "시니어 개발자") */
+  role: string;
+  /** 보편적 규칙 및 지침 목록 */
+  rules: string[];
+  /** 출력 포맷 지침 */
+  outputFormat: string;
+  /** 진행 보고 규칙 */
+  progressReporting: string;
+  /** 병렬 작업 가이드 */
+  parallelWorkGuide: string;
+}
+
+// ---------------------------------------------------------------------------
+// ProjectLayer
+// 캐시 특성: 프로젝트 루트 경로 + conventions 해시 기반 캐시.
+//             CLAUDE.md 변경 시 무효화.
+// ---------------------------------------------------------------------------
+
+/**
+ * 프로젝트 레이어 — 프로젝트별 컨벤션, 구조, 명령어 등 준-정적 내용.
+ */
+export interface ProjectLayer {
+  /** 프로젝트 컨벤션 (CLAUDE.md 내용) */
+  conventions: string;
+  /** 프로젝트 디렉토리 구조 요약 */
+  structure: string;
+  /** 스킬 컨텍스트 (선택) */
+  skillsContext?: string;
+  /** 테스트 실행 명령어 */
+  testCommand: string;
+  /** 린트 실행 명령어 */
+  lintCommand: string;
+  /** 프로젝트 특정 안전 규칙 목록 */
+  safetyRules: string[];
+}
+
+// ---------------------------------------------------------------------------
+// IssueLayer
+// 캐시 특성: 이슈 번호 + repo 조합 키로 캐시.
+//             이슈 본문이 수정되면 무효화.
+// ---------------------------------------------------------------------------
+
+/**
+ * 이슈 레이어 — GitHub 이슈 정보 및 저장소 메타데이터.
+ * PhaseLayer에서 분리하여 이슈별 캐시를 독립적으로 관리한다.
+ */
+export interface IssueLayer {
+  /** 이슈 번호 */
+  number: number;
+  /** 이슈 제목 */
+  title: string;
+  /** 이슈 본문 */
+  body: string;
+  /** 이슈 라벨 목록 */
+  labels: string[];
+  /** 저장소 정보 */
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  /** 전체 계획 요약 */
+  planSummary: string;
+}
+
+// ---------------------------------------------------------------------------
+// PhaseLayer
+// 캐시 특성: 캐시하지 않음(매 Phase 실행마다 새로 생성).
+//             이전 Phase 결과가 포함되어 있어 항상 동적.
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase 레이어 — 현재 실행 중인 Phase의 컨텍스트. 매 Phase마다 동적으로 생성된다.
+ */
+export interface PhaseLayer {
+  /** 현재 Phase 정보 */
+  currentPhase: {
+    /** 1-based Phase 인덱스 */
+    index: number;
+    /** 전체 Phase 수 */
+    totalCount: number;
+    /** Phase 이름 */
+    name: string;
+    /** Phase 상세 설명 */
+    description: string;
+    /** 이 Phase에서 다뤄야 할 대상 파일 목록 */
+    targetFiles: string[];
+  };
+  /** 이전 Phase 결과 요약 (없으면 빈 문자열) */
+  previousResults: string;
+  /** 로케일 (선택, 기본값 ko) */
+  locale?: string;
+}
+
+// ---------------------------------------------------------------------------
+// LearningLayer
+// 캐시 특성: 프로젝트 루트 + 이슈 번호 조합 키로 캐시.
+//             실패/성공 이벤트 발생 시 점진적으로 갱신됨.
+// ---------------------------------------------------------------------------
+
+/**
+ * 학습 레이어 — 과거 실패 사례, 에러 패턴, 학습된 베스트 프랙티스.
+ * 파이프라인 실행이 누적될수록 내용이 풍부해진다.
+ */
+export interface LearningLayer {
+  /** 과거 실패 사례 목록 */
+  pastFailures: Array<{
+    /** 실패가 발생한 Phase 또는 컨텍스트 설명 */
+    context: string;
+    /** 실패 메시지 요약 */
+    message: string;
+    /** 해결 방법 (알려진 경우) */
+    resolution?: string;
+  }>;
+  /** 반복적으로 관찰된 에러 패턴 */
+  errorPatterns: string[];
+  /** 축적된 베스트 프랙티스 */
+  learnedPatterns: string[];
+  /** 마지막 갱신 시각 (ISO 8601) */
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// CacheKeyConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * 각 레이어의 캐시 키 계산에 필요한 입력값 구성.
+ */
+export interface CacheKeyConfig {
+  /** BaseLayer 캐시 키 재료 */
+  base: {
+    /** BaseLayer.role 값 */
+    role: string;
+    /** BaseLayer.rules를 직렬화한 문자열 */
+    rulesDigest: string;
+  };
+  /** ProjectLayer 캐시 키 재료 */
+  project: {
+    /** 프로젝트 루트 절대 경로 */
+    projectRoot: string;
+    /** ProjectLayer.conventions 해시 */
+    conventionsDigest: string;
+  };
+  /** IssueLayer 캐시 키 재료 */
+  issue: {
+    /** 저장소 식별자 (owner/repo) */
+    repo: string;
+    /** 이슈 번호 */
+    issueNumber: number;
+    /** IssueLayer.body 해시 (본문 변경 감지용) */
+    bodyDigest: string;
+  };
+  /** LearningLayer 캐시 키 재료 */
+  learning: {
+    /** 저장소 식별자 (owner/repo) */
+    repo: string;
+    /** 이슈 번호 */
+    issueNumber: number;
+    /** LearningLayer.updatedAt 값 */
+    updatedAt: string;
+  };
+  // PhaseLayer는 캐시하지 않으므로 포함하지 않음
+}
+
+// ---------------------------------------------------------------------------
+// PromptLayers
+// ---------------------------------------------------------------------------
+
+/**
+ * 5계층 프롬프트 레이어를 모두 포함하는 인터페이스.
+ */
+export interface PromptLayers {
+  /** 기본 레이어 (완전 정적, 글로벌 캐시) */
+  base: BaseLayer;
+  /** 프로젝트 레이어 (프로젝트별 캐시) */
+  project: ProjectLayer;
+  /** 이슈 레이어 (이슈별 캐시) */
+  issue: IssueLayer;
+  /** Phase 레이어 (캐시 없음, 매번 동적 생성) */
+  phase: PhaseLayer;
+  /** 학습 레이어 (점진적 갱신, 주기적 캐시) */
+  learning: LearningLayer;
+}

--- a/src/prompt/template-renderer.ts
+++ b/src/prompt/template-renderer.ts
@@ -7,6 +7,11 @@ import type {
   PromptLayer,
   AssembledPrompt
 } from "../types/pipeline.js";
+import type {
+  IssueLayer,
+  LearningLayer,
+  PromptLayers,
+} from "./layer-types.js";
 
 export interface TemplateVariables {
   [key: string]: string | number | boolean | string[] | TemplateVariables;
@@ -216,6 +221,67 @@ export function buildPhaseLayer(config: {
 }
 
 /**
+ * 이슈 레이어를 구축합니다. GitHub 이슈 정보와 저장소 메타데이터를 포함합니다.
+ */
+export function buildIssueLayer(config: {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  planSummary: string;
+}): IssueLayer {
+  return {
+    number: config.number,
+    title: config.title,
+    body: config.body,
+    labels: config.labels,
+    repository: config.repository,
+    planSummary: config.planSummary,
+  };
+}
+
+/**
+ * 학습 레이어를 구축합니다. 과거 실패 사례, 에러 패턴, 베스트 프랙티스를 포함합니다.
+ */
+export function buildLearningLayer(config?: {
+  pastFailures?: Array<{
+    context: string;
+    message: string;
+    resolution?: string;
+  }>;
+  errorPatterns?: string[];
+  learnedPatterns?: string[];
+  updatedAt?: string;
+}): LearningLayer {
+  return {
+    pastFailures: config?.pastFailures ?? [],
+    errorPatterns: config?.errorPatterns ?? [],
+    learnedPatterns: config?.learnedPatterns ?? [],
+    updatedAt: config?.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * 레이어별 캐시 키를 계산합니다.
+ * 전달한 필드를 키 기준 정렬 후 SHA-256 해시의 앞 16자리를 반환합니다.
+ */
+export function computeLayerCacheKey(
+  fields: Record<string, string | number>
+): string {
+  const material = Object.keys(fields)
+    .sort()
+    .map(k => `${k}=${String(fields[k])}`)
+    .join("&");
+  return createHash("sha256").update(material).digest("hex").substring(0, 16);
+}
+
+/**
  * 동적 섹션(이슈, 저장소, 설정)을 구성합니다.
  */
 export function buildDynamicSection(data: {
@@ -287,21 +353,102 @@ ${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFai
 }
 
 /**
+ * PromptLayers(5계층) 여부를 판별하는 타입 가드
+ */
+function isPromptLayers(
+  layers: PromptLayer | PromptLayers
+): layers is PromptLayers {
+  return "issue" in layers && "learning" in layers;
+}
+
+/**
  * 전체 프롬프트 레이어를 조립합니다.
+ * 3계층(PromptLayer)과 5계층(PromptLayers) 모두 지원합니다.
  */
 export function assemblePrompt(
-  layers: PromptLayer,
+  layers: PromptLayer | PromptLayers,
   templateContent: string
 ): AssembledPrompt {
   const startTime = Date.now();
 
-  // 정적 레이어 캐시 키 생성
+  if (isPromptLayers(layers)) {
+    // 5계층 경로
+    const cacheKey = computeLayerCacheKey({
+      role: layers.base.role,
+      conventions: layers.project.conventions,
+      issueNumber: layers.issue.number,
+      repo: `${layers.issue.repository.owner}/${layers.issue.repository.name}`,
+      learningUpdatedAt: layers.learning.updatedAt,
+    });
+
+    const pastFailuresText = layers.learning.pastFailures
+      .map(f => `- ${f.context}: ${f.message}${f.resolution ? ` (해결: ${f.resolution})` : ""}`)
+      .join("\n");
+
+    const variables: TemplateVariables = {
+      // Base Layer
+      role: layers.base.role,
+      rules: layers.base.rules,
+      outputFormat: layers.base.outputFormat,
+      progressReporting: layers.base.progressReporting,
+      parallelWorkGuide: layers.base.parallelWorkGuide,
+
+      // Project Layer
+      projectConventions: layers.project.conventions,
+      projectStructure: layers.project.structure,
+      skillsContext: layers.project.skillsContext || "",
+      config: {
+        testCommand: layers.project.testCommand,
+        lintCommand: layers.project.lintCommand,
+      },
+      safetyRules: layers.project.safetyRules,
+
+      // Issue Layer
+      issue: {
+        number: String(layers.issue.number),
+        title: layers.issue.title,
+        body: layers.issue.body,
+        labels: layers.issue.labels,
+      },
+      plan: {
+        summary: layers.issue.planSummary,
+      },
+      repository: layers.issue.repository,
+
+      // Phase Layer
+      phase: {
+        index: String(layers.phase.currentPhase.index),
+        totalCount: String(layers.phase.currentPhase.totalCount),
+        name: layers.phase.currentPhase.name,
+        description: layers.phase.currentPhase.description,
+        files: layers.phase.currentPhase.targetFiles,
+      },
+      previousPhases: {
+        summary: layers.phase.previousResults,
+      },
+
+      // Learning Layer
+      pastFailures: pastFailuresText,
+      errorPatterns: layers.learning.errorPatterns,
+      learnedPatterns: layers.learning.learnedPatterns,
+    };
+
+    const assembledContent = renderTemplate(templateContent, variables);
+
+    return {
+      content: assembledContent,
+      cacheKey,
+      cacheHit: false,
+      assemblyTimeMs: Date.now() - startTime,
+    };
+  }
+
+  // 3계층 경로 (하위호환)
   const cacheKey = createHash("sha256")
     .update(layers.base.role + JSON.stringify(layers.base.rules) + layers.project.conventions)
     .digest("hex")
     .substring(0, 16);
 
-  // 템플릿 변수 준비
   const variables: TemplateVariables = {
     // Base Layer
     role: layers.base.role,
@@ -345,12 +492,11 @@ export function assemblePrompt(
   };
 
   const assembledContent = renderTemplate(templateContent, variables);
-  const assemblyTime = Date.now() - startTime;
 
   return {
     content: assembledContent,
     cacheKey,
     cacheHit: false,
-    assemblyTimeMs: assemblyTime,
+    assemblyTimeMs: Date.now() - startTime,
   };
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -263,24 +263,22 @@ export interface PlanRetryContext {
 
 // 프롬프트 레이어 분리를 위한 타입 정의
 
-/**
- * 기본 레이어 - 역할과 규칙 등 정적 내용
- */
-export interface BaseLayer {
-  /** AI 역할 정의 (예: "시니어 개발자", "소프트웨어 아키텍트") */
-  role: string;
-  /** 기본 규칙과 지침 */
-  rules: string[];
-  /** 출력 포맷 지침 */
-  outputFormat: string;
-  /** 진행 보고 규칙 */
-  progressReporting: string;
-  /** 병렬 작업 가이드 */
-  parallelWorkGuide: string;
-}
+// BaseLayer는 layer-types.ts와 동일 — import 후 re-export로 중복 제거
+import type { BaseLayer } from "../prompt/layer-types.js";
+export type { BaseLayer };
+
+// IssueLayer, LearningLayer, CacheKeyConfig, PromptLayers는 새 5계층 타입 — 호환성을 위해 re-export
+export type {
+  IssueLayer,
+  LearningLayer,
+  CacheKeyConfig,
+  PromptLayers,
+} from "../prompt/layer-types.js";
 
 /**
  * 프로젝트 레이어 - 프로젝트 수준 설정 (정적)
+ * @note layer-types.ts의 ProjectLayer보다 pastFailures? 필드가 추가됨.
+ *       template-renderer.ts에서 사용 중이므로 별도 유지.
  */
 export interface ProjectLayer {
   /** 프로젝트 컨벤션 (CLAUDE.md 내용) */

--- a/tests/prompt/layer-types.test.ts
+++ b/tests/prompt/layer-types.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildIssueLayer,
+  buildLearningLayer,
+  computeLayerCacheKey,
+  buildBaseLayer,
+  buildProjectLayer,
+} from "../../src/prompt/template-renderer.js";
+import type {
+  IssueLayer,
+  LearningLayer,
+  PhaseLayer,
+  PromptLayers,
+  CacheKeyConfig,
+} from "../../src/prompt/layer-types.js";
+
+// ---------------------------------------------------------------------------
+// IssueLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("IssueLayer 구조", () => {
+  it("buildIssueLayer 결과가 IssueLayer 인터페이스를 충족한다", () => {
+    const layer: IssueLayer = buildIssueLayer({
+      number: 42,
+      title: "Fix critical bug",
+      body: "Detailed description",
+      labels: ["bug", "priority"],
+      repository: {
+        owner: "my-org",
+        name: "my-repo",
+        baseBranch: "main",
+        workBranch: "fix/42-bug",
+      },
+      planSummary: "Fix the bug in 2 phases",
+    });
+
+    expect(layer.number).toBe(42);
+    expect(layer.title).toBe("Fix critical bug");
+    expect(layer.body).toBe("Detailed description");
+    expect(layer.labels).toEqual(["bug", "priority"]);
+    expect(layer.repository.owner).toBe("my-org");
+    expect(layer.repository.name).toBe("my-repo");
+    expect(layer.repository.baseBranch).toBe("main");
+    expect(layer.repository.workBranch).toBe("fix/42-bug");
+    expect(layer.planSummary).toBe("Fix the bug in 2 phases");
+  });
+
+  it("repository 중첩 구조가 모든 필수 필드를 포함한다", () => {
+    const layer = buildIssueLayer({
+      number: 1,
+      title: "T",
+      body: "B",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+
+    expect(layer.repository).toHaveProperty("owner");
+    expect(layer.repository).toHaveProperty("name");
+    expect(layer.repository).toHaveProperty("baseBranch");
+    expect(layer.repository).toHaveProperty("workBranch");
+  });
+
+  it("빈 labels와 빈 body를 허용한다", () => {
+    const layer = buildIssueLayer({
+      number: 0,
+      title: "Empty",
+      body: "",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "",
+    });
+
+    expect(layer.labels).toEqual([]);
+    expect(layer.body).toBe("");
+    expect(layer.planSummary).toBe("");
+  });
+
+  it("다수의 labels를 배열로 유지한다", () => {
+    const layer = buildIssueLayer({
+      number: 1,
+      title: "T",
+      body: "B",
+      labels: ["bug", "feature", "help-wanted", "good-first-issue"],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+
+    expect(layer.labels).toHaveLength(4);
+    expect(layer.labels).toContain("good-first-issue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LearningLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("LearningLayer 구조", () => {
+  it("buildLearningLayer() 결과가 LearningLayer 인터페이스를 충족한다", () => {
+    const layer: LearningLayer = buildLearningLayer();
+
+    expect(layer).toHaveProperty("pastFailures");
+    expect(layer).toHaveProperty("errorPatterns");
+    expect(layer).toHaveProperty("learnedPatterns");
+    expect(layer).toHaveProperty("updatedAt");
+    expect(Array.isArray(layer.pastFailures)).toBe(true);
+    expect(Array.isArray(layer.errorPatterns)).toBe(true);
+    expect(Array.isArray(layer.learnedPatterns)).toBe(true);
+  });
+
+  it("인자 없이 호출하면 모든 배열이 비어 있고 updatedAt이 ISO 8601 형식이다", () => {
+    const layer = buildLearningLayer();
+
+    expect(layer.pastFailures).toEqual([]);
+    expect(layer.errorPatterns).toEqual([]);
+    expect(layer.learnedPatterns).toEqual([]);
+    expect(layer.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("pastFailures 각 항목이 context, message를 가지며 resolution은 선택이다", () => {
+    const layer = buildLearningLayer({
+      pastFailures: [
+        { context: "Phase 1", message: "Login error", resolution: "Run /login" },
+        { context: "Phase 2", message: "Type error" },
+      ],
+    });
+
+    expect(layer.pastFailures[0].context).toBe("Phase 1");
+    expect(layer.pastFailures[0].message).toBe("Login error");
+    expect(layer.pastFailures[0].resolution).toBe("Run /login");
+    expect(layer.pastFailures[1].resolution).toBeUndefined();
+  });
+
+  it("updatedAt을 명시하면 그 값을 그대로 보존한다", () => {
+    const ts = "2026-04-10T12:34:56.789Z";
+    const layer = buildLearningLayer({ updatedAt: ts });
+    expect(layer.updatedAt).toBe(ts);
+  });
+
+  it("일부 필드만 제공하면 나머지는 빈 배열로 기본값 처리된다", () => {
+    const layer = buildLearningLayer({ learnedPatterns: ["Always check auth"] });
+    expect(layer.pastFailures).toEqual([]);
+    expect(layer.errorPatterns).toEqual([]);
+    expect(layer.learnedPatterns).toEqual(["Always check auth"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhaseLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("PhaseLayer 구조", () => {
+  it("PhaseLayer 인터페이스에 맞는 객체를 직접 생성할 수 있다", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 1,
+        totalCount: 3,
+        name: "Implementation",
+        description: "Implement the feature",
+        targetFiles: ["src/feature.ts", "tests/feature.test.ts"],
+      },
+      previousResults: "Phase 0: SUCCESS",
+    };
+
+    expect(layer.currentPhase.index).toBe(1);
+    expect(layer.currentPhase.totalCount).toBe(3);
+    expect(layer.currentPhase.targetFiles).toHaveLength(2);
+    expect(layer.previousResults).toBe("Phase 0: SUCCESS");
+    expect(layer.locale).toBeUndefined();
+  });
+
+  it("locale 필드는 선택적으로 지정 가능하다", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 2,
+        totalCount: 2,
+        name: "Test",
+        description: "Write tests",
+        targetFiles: [],
+      },
+      previousResults: "",
+      locale: "en",
+    };
+
+    expect(layer.locale).toBe("en");
+  });
+
+  it("previousResults가 빈 문자열인 경우를 허용한다 (첫 Phase)", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 1,
+        totalCount: 1,
+        name: "Only Phase",
+        description: "Do everything",
+        targetFiles: [],
+      },
+      previousResults: "",
+    };
+
+    expect(layer.previousResults).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PromptLayers 5계층 조합
+// ---------------------------------------------------------------------------
+
+describe("PromptLayers 5계층 구조", () => {
+  function makePromptLayers(): PromptLayers {
+    return {
+      base: buildBaseLayer({ role: "시니어 개발자" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM + Vitest",
+        testCommand: "npx vitest run",
+        lintCommand: "npx eslint src/ tests/",
+      }),
+      issue: buildIssueLayer({
+        number: 419,
+        title: "refactor: 5-layer prompt",
+        body: "Issue body",
+        labels: ["refactor"],
+        repository: {
+          owner: "test-org",
+          name: "ai-quartermaster",
+          baseBranch: "main",
+          workBranch: "aq/419-refactor",
+        },
+        planSummary: "5계층 레이어 분리",
+      }),
+      phase: {
+        currentPhase: {
+          index: 4,
+          totalCount: 4,
+          name: "테스트 추가",
+          description: "레이어 타입 테스트 작성",
+          targetFiles: ["tests/prompt/layer-types.test.ts"],
+        },
+        previousResults: "Phase 3: SUCCESS",
+      },
+      learning: buildLearningLayer({
+        pastFailures: [{ context: "UNKNOWN", message: "Not logged in", resolution: "Run /login" }],
+        errorPatterns: ["Not logged in"],
+        learnedPatterns: ["Check auth before start"],
+        updatedAt: "2026-04-10T00:00:00.000Z",
+      }),
+    };
+  }
+
+  it("모든 5개 레이어를 포함하는 PromptLayers를 생성할 수 있다", () => {
+    const layers = makePromptLayers();
+
+    expect(layers).toHaveProperty("base");
+    expect(layers).toHaveProperty("project");
+    expect(layers).toHaveProperty("issue");
+    expect(layers).toHaveProperty("phase");
+    expect(layers).toHaveProperty("learning");
+  });
+
+  it("각 레이어는 독립적인 타입 구조를 가진다", () => {
+    const layers = makePromptLayers();
+
+    // base
+    expect(typeof layers.base.role).toBe("string");
+    expect(Array.isArray(layers.base.rules)).toBe(true);
+
+    // project
+    expect(typeof layers.project.conventions).toBe("string");
+    expect(typeof layers.project.testCommand).toBe("string");
+
+    // issue
+    expect(typeof layers.issue.number).toBe("number");
+    expect(typeof layers.issue.repository.owner).toBe("string");
+
+    // phase
+    expect(typeof layers.phase.currentPhase.index).toBe("number");
+    expect(Array.isArray(layers.phase.currentPhase.targetFiles)).toBe(true);
+
+    // learning
+    expect(Array.isArray(layers.learning.pastFailures)).toBe(true);
+    expect(typeof layers.learning.updatedAt).toBe("string");
+  });
+
+  it("issue와 phase는 서로 독립적이다 (이슈 정보는 issue 레이어에만 있다)", () => {
+    const layers = makePromptLayers();
+
+    expect(layers.issue.number).toBe(419);
+    expect(layers.issue.planSummary).toBe("5계층 레이어 분리");
+    // phase는 currentPhase와 previousResults만 가진다
+    expect(layers.phase).not.toHaveProperty("issue");
+    expect(layers.phase).not.toHaveProperty("planSummary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CacheKeyConfig 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("CacheKeyConfig 구조", () => {
+  it("CacheKeyConfig 인터페이스에 맞는 객체를 생성할 수 있다", () => {
+    const config: CacheKeyConfig = {
+      base: { role: "Developer", rulesDigest: "abc123" },
+      project: { projectRoot: "/home/user/repo", conventionsDigest: "def456" },
+      issue: { repo: "owner/repo", issueNumber: 42, bodyDigest: "ghi789" },
+      learning: { repo: "owner/repo", issueNumber: 42, updatedAt: "2026-04-10T00:00:00.000Z" },
+    };
+
+    expect(config.base.role).toBe("Developer");
+    expect(config.project.projectRoot).toBe("/home/user/repo");
+    expect(config.issue.issueNumber).toBe(42);
+    expect(config.learning.updatedAt).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("PhaseLayer 캐시 키 재료는 CacheKeyConfig에 포함되지 않는다", () => {
+    const config: CacheKeyConfig = {
+      base: { role: "Developer", rulesDigest: "abc" },
+      project: { projectRoot: "/repo", conventionsDigest: "def" },
+      issue: { repo: "o/r", issueNumber: 1, bodyDigest: "ghi" },
+      learning: { repo: "o/r", issueNumber: 1, updatedAt: "2026-01-01T00:00:00.000Z" },
+    };
+
+    // phase는 키 없음 — 타입이 강제하는 계약 확인
+    expect(Object.keys(config)).not.toContain("phase");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLayerCacheKey 함수
+// ---------------------------------------------------------------------------
+
+describe("computeLayerCacheKey", () => {
+  it("16자리 소문자 16진수 문자열을 반환한다", () => {
+    const key = computeLayerCacheKey({ role: "Developer", rulesDigest: "abc123" });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("동일한 입력에 대해 항상 같은 키를 반환한다 (결정론적)", () => {
+    const fields = { role: "Developer", issueNumber: 42 };
+    expect(computeLayerCacheKey(fields)).toBe(computeLayerCacheKey(fields));
+  });
+
+  it("다른 입력에 대해 다른 키를 반환한다", () => {
+    expect(computeLayerCacheKey({ role: "Developer" }))
+      .not.toBe(computeLayerCacheKey({ role: "Architect" }));
+  });
+
+  it("키 순서에 무관하게 같은 결과를 반환한다 (순서 독립)", () => {
+    const key1 = computeLayerCacheKey({ a: "1", b: "2", c: "3" });
+    const key2 = computeLayerCacheKey({ c: "3", a: "1", b: "2" });
+    expect(key1).toBe(key2);
+  });
+
+  it("숫자 값을 처리할 수 있다", () => {
+    const key = computeLayerCacheKey({ issueNumber: 419, version: 1 });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("빈 객체에 대해서도 유효한 키를 반환한다", () => {
+    const key = computeLayerCacheKey({});
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("BaseLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const base = buildBaseLayer({ role: "시니어 개발자" });
+    const key = computeLayerCacheKey({
+      role: base.role,
+      rulesDigest: base.rules.join("|"),
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("IssueLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const issue = buildIssueLayer({
+      number: 42,
+      title: "Test",
+      body: "Body",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+    const key = computeLayerCacheKey({
+      repo: `${issue.repository.owner}/${issue.repository.name}`,
+      issueNumber: issue.number,
+      bodyDigest: issue.body,
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("LearningLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const learning = buildLearningLayer({ updatedAt: "2026-04-10T00:00:00.000Z" });
+    const key = computeLayerCacheKey({
+      repo: "owner/repo",
+      issueNumber: 42,
+      updatedAt: learning.updatedAt,
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+});

--- a/tests/prompt/template-renderer.test.ts
+++ b/tests/prompt/template-renderer.test.ts
@@ -4,9 +4,13 @@ import {
   buildBaseLayer,
   buildProjectLayer,
   buildPhaseLayer,
+  buildIssueLayer,
+  buildLearningLayer,
+  computeLayerCacheKey,
   assemblePrompt
 } from "../../src/prompt/template-renderer.js";
 import type { PromptLayer } from "../../src/types/pipeline.js";
+import type { PromptLayers } from "../../src/prompt/layer-types.js";
 
 describe("renderTemplate", () => {
   it("should replace simple variables", () => {
@@ -315,5 +319,224 @@ Target Files: {{phase.files}}
     expect(typeof result.assemblyTimeMs).toBe("number");
     expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
     expect(result.assemblyTimeMs).toBeLessThan(1000); // Should be fast
+  });
+});
+
+describe("buildIssueLayer", () => {
+  it("should create issue layer with all required fields", () => {
+    const result = buildIssueLayer({
+      number: 42,
+      title: "Fix critical bug",
+      body: "Detailed description",
+      labels: ["bug", "priority"],
+      repository: {
+        owner: "my-org",
+        name: "my-repo",
+        baseBranch: "main",
+        workBranch: "fix/42-bug",
+      },
+      planSummary: "Fix the bug in 2 phases",
+    });
+
+    expect(result.number).toBe(42);
+    expect(result.title).toBe("Fix critical bug");
+    expect(result.body).toBe("Detailed description");
+    expect(result.labels).toEqual(["bug", "priority"]);
+    expect(result.repository.owner).toBe("my-org");
+    expect(result.repository.name).toBe("my-repo");
+    expect(result.repository.baseBranch).toBe("main");
+    expect(result.repository.workBranch).toBe("fix/42-bug");
+    expect(result.planSummary).toBe("Fix the bug in 2 phases");
+  });
+
+  it("should handle empty labels", () => {
+    const result = buildIssueLayer({
+      number: 1,
+      title: "Test",
+      body: "",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "",
+    });
+    expect(result.labels).toEqual([]);
+  });
+});
+
+describe("buildLearningLayer", () => {
+  it("should create empty learning layer when no config provided", () => {
+    const result = buildLearningLayer();
+
+    expect(result.pastFailures).toEqual([]);
+    expect(result.errorPatterns).toEqual([]);
+    expect(result.learnedPatterns).toEqual([]);
+    expect(result.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("should create learning layer with provided data", () => {
+    const result = buildLearningLayer({
+      pastFailures: [
+        { context: "Phase 1", message: "Login error", resolution: "Run /login" },
+        { context: "Phase 2", message: "Type error" },
+      ],
+      errorPatterns: ["Not logged in", "TS error"],
+      learnedPatterns: ["Always check auth first"],
+      updatedAt: "2026-04-10T00:00:00.000Z",
+    });
+
+    expect(result.pastFailures).toHaveLength(2);
+    expect(result.pastFailures[0].context).toBe("Phase 1");
+    expect(result.pastFailures[0].resolution).toBe("Run /login");
+    expect(result.pastFailures[1].resolution).toBeUndefined();
+    expect(result.errorPatterns).toEqual(["Not logged in", "TS error"]);
+    expect(result.learnedPatterns).toEqual(["Always check auth first"]);
+    expect(result.updatedAt).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("should use defaults for missing optional fields", () => {
+    const result = buildLearningLayer({ updatedAt: "2026-04-10T00:00:00.000Z" });
+    expect(result.pastFailures).toEqual([]);
+    expect(result.errorPatterns).toEqual([]);
+    expect(result.learnedPatterns).toEqual([]);
+  });
+});
+
+describe("computeLayerCacheKey", () => {
+  it("should return 16-char hex string", () => {
+    const key = computeLayerCacheKey({ role: "Developer", rulesDigest: "abc123" });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("should produce consistent keys for same input", () => {
+    const fields = { role: "Developer", rulesDigest: "abc123" };
+    expect(computeLayerCacheKey(fields)).toBe(computeLayerCacheKey(fields));
+  });
+
+  it("should produce different keys for different inputs", () => {
+    const key1 = computeLayerCacheKey({ role: "Developer" });
+    const key2 = computeLayerCacheKey({ role: "Architect" });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("should be order-independent (sorts keys)", () => {
+    const key1 = computeLayerCacheKey({ a: "1", b: "2" });
+    const key2 = computeLayerCacheKey({ b: "2", a: "1" });
+    expect(key1).toBe(key2);
+  });
+
+  it("should handle numeric values", () => {
+    const key = computeLayerCacheKey({ issueNumber: 42, version: 1 });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+describe("assemblePrompt (5계층 PromptLayers)", () => {
+  function createFiveLayerLayers(): PromptLayers {
+    return {
+      base: buildBaseLayer({ role: "Test Developer" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM",
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+      }),
+      issue: buildIssueLayer({
+        number: 99,
+        title: "5-layer Test Issue",
+        body: "Issue body text",
+        labels: ["feature"],
+        repository: {
+          owner: "five-org",
+          name: "five-repo",
+          baseBranch: "main",
+          workBranch: "feat/99",
+        },
+        planSummary: "Five layer plan",
+      }),
+      phase: {
+        currentPhase: {
+          index: 2,
+          totalCount: 3,
+          name: "Implementation",
+          description: "Implement the feature",
+          targetFiles: ["src/feature.ts"],
+        },
+        previousResults: "Phase 1: SUCCESS",
+      },
+      learning: buildLearningLayer({
+        pastFailures: [{ context: "Phase 1", message: "Login required", resolution: "Run /login" }],
+        errorPatterns: ["Not logged in"],
+        learnedPatterns: ["Check auth before start"],
+        updatedAt: "2026-04-10T00:00:00.000Z",
+      }),
+    };
+  }
+
+  it("should assemble 5-layer prompt with all layer variables", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Role: {{role}}\nIssue #{{issue.number}}: {{issue.title}}\nPhase {{phase.index}}/{{phase.totalCount}}\nRepo: {{repository.owner}}/{{repository.name}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Role: Test Developer");
+    expect(result.content).toContain("Issue #99: 5-layer Test Issue");
+    expect(result.content).toContain("Phase 2/3");
+    expect(result.content).toContain("Repo: five-org/five-repo");
+    expect(result.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+    expect(result.cacheHit).toBe(false);
+    expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should include learning layer data in variables", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Patterns: {{errorPatterns}}\nLearned: {{learnedPatterns}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Not logged in");
+    expect(result.content).toContain("Check auth before start");
+  });
+
+  it("should include plan summary from issue layer", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Plan: {{plan.summary}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Plan: Five layer plan");
+  });
+
+  it("should generate consistent cache keys for same 5-layer content", () => {
+    const layers1 = createFiveLayerLayers();
+    const layers2 = createFiveLayerLayers();
+
+    const r1 = assemblePrompt(layers1, "{{role}}");
+    const r2 = assemblePrompt(layers2, "{{role}}");
+
+    expect(r1.cacheKey).toBe(r2.cacheKey);
+  });
+
+  it("should generate different cache key from 3-layer for same role/conventions", () => {
+    const threeLayers = {
+      base: buildBaseLayer({ role: "Test Developer" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM",
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+      }),
+      phase: buildPhaseLayer({
+        issue: { number: 99, title: "Test", body: "", labels: [] },
+        planSummary: "",
+        currentPhase: { index: 1, totalCount: 1, name: "P", description: "", targetFiles: [] },
+        previousResults: "",
+        repository: { owner: "five-org", name: "five-repo", baseBranch: "main", workBranch: "b" },
+      }),
+    };
+    const fiveLayers = createFiveLayerLayers();
+
+    const r3 = assemblePrompt(threeLayers, "{{role}}");
+    const r5 = assemblePrompt(fiveLayers, "{{role}}");
+
+    // Both produce valid 16-char hex keys
+    expect(r3.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+    expect(r5.cacheKey).toMatch(/^[a-f0-9]{16}$/);
   });
 });


### PR DESCRIPTION
## Summary

Resolves #419 — refactor: 프롬프트 레이어 구조 정의 — Base/Project/Issue/Phase/Learning 분리

현재 프롬프트 레이어가 3계층(Base/Project/Phase)으로 구성되어 있으며, Issue 정보가 PhaseLayer에 포함되어 있고 Learning 레이어가 없음. 5-layer 구조로 분리하여 각 레이어의 캐시 전략을 명확히 하고, 레이어별 캐시 키 계산 유틸을 추가해야 함.

## Requirements

- src/prompt/layer-types.ts 신규 생성 — 5개 레이어 타입 정의
- IssueLayer 타입 추가 (이슈 본문, 의존성) — PhaseLayer에서 분리
- LearningLayer 타입 추가 (과거 실패 패턴) — PatternStore 연동
- PromptLayers 타입을 5-layer 구조로 재정의
- 각 레이어별 캐시 키 계산 유틸 함수 추가
- buildIssueLayer() 함수 추가
- buildLearningLayer() 함수 추가
- 기존 타입 import 경로 호환성 유지 (re-export)

## Implementation Phases

- Phase 0: 레이어 타입 정의 — SUCCESS (4827ae81)
- Phase 1: 캐시 키 유틸 및 빌더 함수 추가 — SUCCESS (8991e23a)
- Phase 2: 타입 re-export 및 호환성 — SUCCESS (8991e23a)
- Phase 3: 테스트 추가 — SUCCESS (9f248a7d)

## Risks

- 기존 PhaseLayer에서 Issue 정보 분리 시 호출부 수정 필요할 수 있음
- assemblePrompt() 시그니처 변경 시 기존 호출부 영향

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/419-refactor-base-project-issue-phase-learning` → `develop`
- **Tokens**: 195 input, 47575 output{{#stats.cacheCreationTokens}}, 287399 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2636833 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #419