### PR TITLE
[AQ-#423] refactor: ValidationTask 구현 — test/lint/typecheck 래핑

### DIFF
--- a/src/pipeline/verification-parser.ts
+++ b/src/pipeline/verification-parser.ts
@@ -1,5 +1,5 @@
 /**
- * Parses tsc and vitest output to identify per-file success/failure.
+ * Parses tsc, vitest, and eslint output to identify per-file success/failure.
  */
 
 export interface TscParseResult {
@@ -82,4 +82,63 @@ export function parseVitestOutput(output: string): VitestParseResult {
     totalFiles: failedFiles.size + passedFiles.size,
     hasFailures: failedFiles.size > 0,
   };
+}
+
+export interface EslintParseResult {
+  /** Per-file error messages */
+  errorsByFile: Record<string, string[]>;
+  /** Per-file warning messages */
+  warningsByFile: Record<string, string[]>;
+  totalErrors: number;
+  totalWarnings: number;
+  hasErrors: boolean;
+}
+
+// ESLint default formatter: file path line (absolute or relative, no leading spaces)
+// Examples:
+//   /home/user/project/src/foo.ts
+//   src/foo.ts
+const ESLINT_FILE_RE = /^((?:\/|\.{0,2}\/|[A-Za-z]:\\)?\S+\.[jt]sx?)$/;
+
+// ESLint problem line: "  10:5  error  message  rule-name"
+// Severity is "error" or "warning"
+const ESLINT_PROBLEM_RE =
+  /^\s+\d+:\d+\s+(error|warning)\s+(.+?)\s{2,}\S+\s*$/;
+
+export function parseEslintOutput(output: string): EslintParseResult {
+  const errorsByFile: Record<string, string[]> = {};
+  const warningsByFile: Record<string, string[]> = {};
+  let totalErrors = 0;
+  let totalWarnings = 0;
+  let currentFile: string | null = null;
+
+  for (const raw of output.split("\n")) {
+    const line = raw.trimEnd();
+
+    const fileMatch = line.match(ESLINT_FILE_RE);
+    if (fileMatch) {
+      currentFile = fileMatch[1];
+      continue;
+    }
+
+    if (!currentFile) continue;
+
+    const problemMatch = line.match(ESLINT_PROBLEM_RE);
+    if (!problemMatch) continue;
+
+    const severity = problemMatch[1];
+    const message = problemMatch[2].trim();
+
+    if (severity === "error") {
+      if (!errorsByFile[currentFile]) errorsByFile[currentFile] = [];
+      errorsByFile[currentFile].push(message);
+      totalErrors++;
+    } else {
+      if (!warningsByFile[currentFile]) warningsByFile[currentFile] = [];
+      warningsByFile[currentFile].push(message);
+      totalWarnings++;
+    }
+  }
+
+  return { errorsByFile, warningsByFile, totalErrors, totalWarnings, hasErrors: totalErrors > 0 };
 }

--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -23,7 +23,7 @@ export enum TaskStatus {
  * 지원하는 태스크 타입
  * 향후 CodexTask, GeminiTask 등 확장 가능
  */
-export type AQMTaskType = "claude" | "codex" | "gemini";
+export type AQMTaskType = "claude" | "codex" | "gemini" | "validation";
 
 /**
  * 태스크 JSON 직렬화를 위한 요약 정보

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -16,3 +16,11 @@ export {
   ClaudeTask,
   ClaudeTaskOptions
 } from "./claude-task.js";
+
+// Validation 태스크 구현체 (typecheck/lint/test)
+export {
+  ValidationTask,
+  ValidationTaskOptions,
+  ValidationTaskType,
+  ValidationResult,
+} from "./validation-task.js";

--- a/src/tasks/validation-task.ts
+++ b/src/tasks/validation-task.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "crypto";
+import { spawn, type ChildProcess } from "child_process";
+import { AQMTask, TaskStatus, type AQMTaskSummary, type BaseTaskOptions } from "./aqm-task.js";
+import {
+  parseTscOutput,
+  parseVitestOutput,
+  parseEslintOutput,
+  type TscParseResult,
+  type VitestParseResult,
+  type EslintParseResult,
+} from "../pipeline/verification-parser.js";
+
+export type ValidationTaskType = "typecheck" | "lint" | "test";
+
+export interface ValidationResult {
+  success: boolean;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  parsed: TscParseResult | VitestParseResult | EslintParseResult;
+}
+
+export interface ValidationTaskOptions extends BaseTaskOptions {
+  validationType: ValidationTaskType;
+  command: string;
+  args: string[];
+  timeout?: number;
+}
+
+/**
+ * typecheck/lint/test 명령을 spawn으로 실행하고 결과를 파싱하는 AQMTask 구현체
+ */
+export class ValidationTask implements AQMTask {
+  public readonly id: string;
+  public readonly type = "validation" as const;
+
+  private _status: TaskStatus = TaskStatus.PENDING;
+  private _startedAt?: Date;
+  private _completedAt?: Date;
+  private _result?: ValidationResult;
+  private _child?: ChildProcess;
+  private readonly _options: ValidationTaskOptions;
+
+  constructor(options: ValidationTaskOptions) {
+    this.id = options.id ?? randomUUID();
+    this._options = { ...options, id: this.id };
+  }
+
+  get status(): TaskStatus {
+    return this._status;
+  }
+
+  async run(): Promise<ValidationResult> {
+    if (this._status !== TaskStatus.PENDING) {
+      throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
+    }
+
+    this._status = TaskStatus.RUNNING;
+    this._startedAt = new Date();
+
+    try {
+      const result = await this._spawnCommand();
+      this._completedAt = new Date();
+      this._status = result.exitCode === 0 ? TaskStatus.SUCCESS : TaskStatus.FAILED;
+      this._result = result;
+      return result;
+    } catch (err: unknown) {
+      this._completedAt = new Date();
+      this._status = TaskStatus.FAILED;
+      const durationMs = this._completedAt.getTime() - (this._startedAt?.getTime() ?? 0);
+      this._result = {
+        success: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: err instanceof Error ? err.message : String(err),
+        durationMs,
+        parsed: this._parseOutput("", ""),
+      };
+      throw err;
+    }
+  }
+
+  private _spawnCommand(): Promise<ValidationResult> {
+    return new Promise((resolve, reject) => {
+      const startTime = this._startedAt?.getTime() ?? Date.now();
+      let stdout = "";
+      let stderr = "";
+
+      this._child = spawn(this._options.command, this._options.args, {
+        cwd: this._options.cwd ?? process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      this._child.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+      this._child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+      this._child.on("close", (code) => {
+        this._child = undefined;
+        const exitCode = code ?? 1;
+        const durationMs = Date.now() - startTime;
+        resolve({
+          success: exitCode === 0,
+          exitCode,
+          stdout,
+          stderr,
+          durationMs,
+          parsed: this._parseOutput(stdout, stderr),
+        });
+      });
+
+      this._child.on("error", (err) => {
+        this._child = undefined;
+        reject(err);
+      });
+
+      if (this._options.timeout) {
+        setTimeout(() => {
+          this._child?.kill("SIGTERM");
+        }, this._options.timeout);
+      }
+    });
+  }
+
+  private _parseOutput(
+    stdout: string,
+    stderr: string,
+  ): TscParseResult | VitestParseResult | EslintParseResult {
+    const combined = stdout + "\n" + stderr;
+    switch (this._options.validationType) {
+      case "typecheck":
+        return parseTscOutput(combined);
+      case "test":
+        return parseVitestOutput(combined);
+      case "lint":
+        return parseEslintOutput(combined);
+    }
+  }
+
+  async kill(): Promise<void> {
+    if (this._status !== TaskStatus.RUNNING) {
+      return;
+    }
+
+    if (this._child) {
+      try {
+        this._child.kill("SIGTERM");
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        this._child?.kill("SIGKILL");
+      } catch {
+        // 프로세스가 이미 종료되었거나 권한 없음 — 무시
+      }
+    }
+
+    this._status = TaskStatus.KILLED;
+    this._completedAt = new Date();
+    this._child = undefined;
+  }
+
+  toJSON(): AQMTaskSummary {
+    const durationMs =
+      this._completedAt && this._startedAt
+        ? this._completedAt.getTime() - this._startedAt.getTime()
+        : undefined;
+
+    return {
+      id: this.id,
+      type: this.type,
+      status: this.status,
+      startedAt: this._startedAt?.toISOString(),
+      completedAt: this._completedAt?.toISOString(),
+      durationMs,
+      metadata: {
+        ...this._options.metadata,
+        validationType: this._options.validationType,
+        command: this._options.command,
+        args: this._options.args,
+        success: this._result?.success,
+        exitCode: this._result?.exitCode,
+      },
+    };
+  }
+
+  getResult(): ValidationResult | undefined {
+    return this._result;
+  }
+}

--- a/tests/tasks/validation-task.test.ts
+++ b/tests/tasks/validation-task.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { ValidationTask, ValidationTaskOptions, ValidationTaskType } from "../../src/tasks/validation-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+
+// child_process spawn 모킹
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+import { spawn } from "child_process";
+const mockSpawn = vi.mocked(spawn);
+
+/**
+ * 가짜 ChildProcess를 생성하는 헬퍼
+ * stdout/stderr/process 이벤트를 직접 제어할 수 있다
+ */
+function createMockChild() {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+function makeOptions(
+  validationType: ValidationTaskType,
+  overrides: Partial<ValidationTaskOptions> = {}
+): ValidationTaskOptions {
+  return {
+    validationType,
+    command: "npx",
+    args: validationType === "typecheck"
+      ? ["tsc", "--noEmit"]
+      : validationType === "test"
+      ? ["vitest", "run"]
+      : ["eslint", "src/"],
+    cwd: "/fake/cwd",
+    ...overrides,
+  };
+}
+
+describe("ValidationTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 생성 및 기본 속성
+  // ---------------------------------------------------------------------------
+  describe("생성 및 기본 속성", () => {
+    it("should auto-generate UUID when id is not provided", () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      expect(task.id).toBeDefined();
+      expect(task.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("should use provided id", () => {
+      const task = new ValidationTask(makeOptions("typecheck", { id: "my-task" }));
+      expect(task.id).toBe("my-task");
+    });
+
+    it("should have type = 'validation'", () => {
+      const task = new ValidationTask(makeOptions("lint"));
+      expect(task.type).toBe("validation");
+    });
+
+    it("should start with PENDING status", () => {
+      const task = new ValidationTask(makeOptions("test"));
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should return undefined result before run", () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+      expect(task.getResult()).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // typecheck 성공 케이스
+  // ---------------------------------------------------------------------------
+  describe("typecheck 성공 케이스", () => {
+    it("should return SUCCESS status and parsed TscParseResult on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      // stdout 없이 종료
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+      expect(result.parsed).toMatchObject({ totalErrors: 0, hasErrors: false });
+    });
+
+    it("should collect stdout and stderr before close", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from("some output"));
+      child.stderr.emit("data", Buffer.from("some stderr"));
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.stdout).toBe("some output");
+      expect(result.stderr).toBe("some stderr");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // typecheck 실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("typecheck 실패 케이스", () => {
+    it("should return FAILED status and parsed errors on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const tscOutput =
+        "src/foo.ts(10,5): error TS2345: Argument of type 'string' is not assignable to type 'number'.\n";
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(tscOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number; errorsByFile: Record<string, string[]> };
+      expect(parsed.hasErrors).toBe(true);
+      expect(parsed.totalErrors).toBe(1);
+      expect(parsed.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // test 성공/실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("test 성공/실패 케이스", () => {
+    it("should parse vitest PASS output on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const vitestOutput = " PASS  tests/foo.test.ts\n";
+
+      const task = new ValidationTask(makeOptions("test"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(vitestOutput));
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+
+      const parsed = result.parsed as { hasFailures: boolean; passedFiles: string[]; failedFiles: string[] };
+      expect(parsed.hasFailures).toBe(false);
+      expect(parsed.passedFiles).toContain("tests/foo.test.ts");
+    });
+
+    it("should parse vitest FAIL output on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const vitestOutput = " FAIL  tests/bar.test.ts\n     × should work\n";
+
+      const task = new ValidationTask(makeOptions("test"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(vitestOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasFailures: boolean; failedFiles: string[]; failedTests: string[] };
+      expect(parsed.hasFailures).toBe(true);
+      expect(parsed.failedFiles).toContain("tests/bar.test.ts");
+      expect(parsed.failedTests).toContain("should work");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // lint 성공/실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("lint 성공/실패 케이스", () => {
+    it("should parse eslint output on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("lint"));
+      const runPromise = task.run();
+
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number };
+      expect(parsed.hasErrors).toBe(false);
+      expect(parsed.totalErrors).toBe(0);
+    });
+
+    it("should parse eslint errors on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const eslintOutput =
+        "src/foo.ts\n  10:5  error  no-unused-vars  no-unused-vars\n\n";
+
+      const task = new ValidationTask(makeOptions("lint"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(eslintOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number; errorsByFile: Record<string, string[]> };
+      expect(parsed.hasErrors).toBe(true);
+      expect(parsed.totalErrors).toBe(1);
+      expect(parsed.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 중복 실행 방지
+  // ---------------------------------------------------------------------------
+  describe("중복 실행 방지", () => {
+    it("should throw when run() is called on already-running task", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      // 첫 번째 run은 닫히지 않은 채로 대기
+      const runPromise = task.run();
+
+      // 즉시 두 번째 run 시도
+      await expect(task.run()).rejects.toThrow(/already RUNNING/);
+
+      // 정리
+      child.emit("close", 0);
+      await runPromise;
+    });
+
+    it("should throw when run() is called on completed task", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      await expect(task.run()).rejects.toThrow(/already SUCCESS/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 프로세스 오류 이벤트
+  // ---------------------------------------------------------------------------
+  describe("프로세스 오류 이벤트", () => {
+    it("should reject run() and set FAILED status on spawn error event", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.emit("error", new Error("ENOENT: command not found"));
+
+      await expect(runPromise).rejects.toThrow("ENOENT: command not found");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+
+    it("should store error info in result on spawn error", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.emit("error", new Error("spawn failed"));
+
+      await expect(runPromise).rejects.toThrow();
+      expect(task.getResult()).toMatchObject({
+        success: false,
+        exitCode: 1,
+        stderr: "spawn failed",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // durationMs
+  // ---------------------------------------------------------------------------
+  describe("실행 시간 측정", () => {
+    it("should report non-negative durationMs", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // kill()
+  // ---------------------------------------------------------------------------
+  describe("kill()", () => {
+    it("should set status to KILLED when task is running", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      // 실행 중인 상태에서 kill
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+
+      // runPromise가 resolve될 수 있도록 close 이벤트 발생
+      child.emit("close", 0);
+      // kill 후에는 resolve되지 않을 수도 있으므로 race
+      await Promise.race([runPromise, Promise.resolve()]);
+    });
+
+    it("should be no-op when task is PENDING", async () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should be no-op when task is already SUCCESS", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should call kill on child process", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      task.run(); // 대기하지 않음 — 비동기 실행 중
+
+      // 잠깐 대기하여 spawn이 호출된 상태가 되도록
+      await new Promise((r) => setTimeout(r, 0));
+
+      await task.kill();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toJSON()
+  // ---------------------------------------------------------------------------
+  describe("toJSON()", () => {
+    it("should include id, type, status in JSON", () => {
+      const task = new ValidationTask(makeOptions("typecheck", { id: "t-001" }));
+      const json = task.toJSON();
+
+      expect(json.id).toBe("t-001");
+      expect(json.type).toBe("validation");
+      expect(json.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should include validationType and command in metadata", () => {
+      const task = new ValidationTask(makeOptions("lint", { id: "t-002" }));
+      const json = task.toJSON();
+
+      expect(json.metadata?.validationType).toBe("lint");
+      expect(json.metadata?.command).toBe("npx");
+      expect(json.metadata?.args).toEqual(["eslint", "src/"]);
+    });
+
+    it("should include execution result in metadata after run", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck", { id: "t-003" }));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      const json = task.toJSON();
+
+      expect(json.metadata?.success).toBe(true);
+      expect(json.metadata?.exitCode).toBe(0);
+      expect(json.durationMs).toBeGreaterThanOrEqual(0);
+      expect(json.startedAt).toBeDefined();
+      expect(json.completedAt).toBeDefined();
+    });
+
+    it("should include custom metadata", () => {
+      const task = new ValidationTask(
+        makeOptions("test", { id: "t-004", metadata: { issueId: 42 } })
+      );
+      const json = task.toJSON();
+
+      expect(json.metadata?.issueId).toBe(42);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // spawn 호출 검증
+  // ---------------------------------------------------------------------------
+  describe("spawn 호출 검증", () => {
+    it("should call spawn with correct command and args", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck", { cwd: "/my/project" }));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npx",
+        ["tsc", "--noEmit"],
+        expect.objectContaining({ cwd: "/my/project" })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #423 — refactor: ValidationTask 구현 — test/lint/typecheck 래핑

AQMTask 인터페이스를 구현하여 test/lint/typecheck 명령을 통합 관리하는 ValidationTask 클래스 구현. 현재 verification-parser.ts에 tsc/vitest 파서가 있으나 태스크 추상화가 없고, eslint 파서도 없음.

## Requirements

- ValidationTask가 AQMTask 인터페이스를 구현
- typecheck (npx tsc --noEmit), lint (npx eslint src/ tests/), test (npx vitest run) 지원
- 각 검증 타입별 결과 파싱 (성공/실패 파일 목록)
- 실행 중 프로세스 kill() 지원
- 단위 테스트 작성

## Implementation Phases

- Phase 0: AQMTaskType 확장 — SUCCESS (4a948067)
- Phase 1: ESLint 파서 추가 — SUCCESS (4a948067)
- Phase 2: ValidationTask 구현 — SUCCESS (e62179de)
- Phase 3: index.ts export 추가 — SUCCESS (e62179de)
- Phase 4: 단위 테스트 작성 — SUCCESS (0bc8aa65)
- Phase 5: 검증 — SUCCESS (0bc8aa65)

## Risks

- spawn 프로세스 종료 시 좀비 프로세스 가능성 — SIGKILL 폴백으로 대응
- ESLint 출력 형식이 버전에 따라 다를 수 있음 — 기본 포맷 기준으로 파싱

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 6/6 completed
- **Branch**: `aq/423-refactor-validationtask-test-lint-typecheck` → `develop`
- **Tokens**: 174 input, 19738 output{{#stats.cacheCreationTokens}}, 255287 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1692211 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #423