### PR TITLE
[AQ-#424] refactor: GitTask 구현 — branch/commit/PR 래핑

### DIFF
--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -23,7 +23,7 @@ export enum TaskStatus {
  * 지원하는 태스크 타입
  * 향후 CodexTask, GeminiTask 등 확장 가능
  */
-export type AQMTaskType = "claude" | "codex" | "gemini";
+export type AQMTaskType = "claude" | "codex" | "gemini" | "git";
 
 /**
  * 태스크 JSON 직렬화를 위한 요약 정보

--- a/src/tasks/git-task.ts
+++ b/src/tasks/git-task.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "crypto";
+import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
+import type { GitConfig } from "../types/config.js";
+
+/**
+ * Git 작업 실행을 위한 옵션
+ */
+export interface GitTaskOptions extends BaseTaskOptions {
+  /** Git 설정 */
+  gitConfig: GitConfig;
+  /** 이슈 번호 */
+  issueNumber: number;
+  /** 이슈 제목 (브랜치명 생성에 사용) */
+  issueTitle: string;
+  /** 작업 디렉토리 */
+  cwd: string;
+}
+
+/**
+ * Git 작업 실행 결과
+ */
+export interface GitTaskResult {
+  /** 작업 성공 여부 */
+  success: boolean;
+  /** 생성된 브랜치명 */
+  branchName?: string;
+  /** 커밋 해시 */
+  commitHash?: string;
+  /** PR URL */
+  prUrl?: string;
+  /** 에러 메시지 */
+  error?: string;
+  /** 실행 소요 시간 (밀리초) */
+  durationMs: number;
+}
+
+/**
+ * Git branch/commit/PR 작업을 래핑하는 AQMTask 구현체
+ */
+export class GitTask implements AQMTask {
+  public readonly id: string;
+  public readonly type = "git" as const;
+
+  private _status: TaskStatus = TaskStatus.PENDING;
+  private _startedAt?: Date;
+  private _completedAt?: Date;
+  private _result?: GitTaskResult;
+  private _abortController: AbortController = new AbortController();
+  private readonly _options: GitTaskOptions;
+
+  constructor(options: GitTaskOptions) {
+    this.id = options.id ?? randomUUID();
+    this._options = { ...options, id: this.id };
+  }
+
+  get status(): TaskStatus {
+    return this._status;
+  }
+
+  async kill(): Promise<void> {
+    if (this._status !== TaskStatus.RUNNING) {
+      return;
+    }
+
+    this._abortController.abort();
+    this._status = TaskStatus.KILLED;
+    this._completedAt = new Date();
+  }
+
+  toJSON(): AQMTaskSummary {
+    const durationMs = this._completedAt && this._startedAt
+      ? this._completedAt.getTime() - this._startedAt.getTime()
+      : undefined;
+
+    return {
+      id: this.id,
+      type: this.type,
+      status: this.status,
+      startedAt: this._startedAt?.toISOString(),
+      completedAt: this._completedAt?.toISOString(),
+      durationMs,
+      metadata: {
+        ...this._options.metadata,
+        issueNumber: this._options.issueNumber,
+        issueTitle: this._options.issueTitle,
+        branchName: this._result?.branchName,
+        commitHash: this._result?.commitHash,
+        prUrl: this._result?.prUrl,
+        success: this._result?.success,
+      },
+    };
+  }
+
+  getResult(): GitTaskResult | undefined {
+    return this._result;
+  }
+
+  protected setRunning(): void {
+    this._status = TaskStatus.RUNNING;
+    this._startedAt = new Date();
+  }
+
+  protected setCompleted(result: GitTaskResult): void {
+    this._result = result;
+    this._completedAt = new Date();
+    this._status = result.success ? TaskStatus.SUCCESS : TaskStatus.FAILED;
+  }
+
+  protected setFailed(error: string): void {
+    const durationMs = this._startedAt
+      ? Date.now() - this._startedAt.getTime()
+      : 0;
+    this._result = { success: false, error, durationMs };
+    this._completedAt = new Date();
+    this._status = TaskStatus.FAILED;
+  }
+
+  protected get options(): GitTaskOptions {
+    return this._options;
+  }
+
+  protected get abortSignal(): AbortSignal {
+    return this._abortController.signal;
+  }
+}

--- a/src/tasks/git-task.ts
+++ b/src/tasks/git-task.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "crypto";
 import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
 import type { GitConfig } from "../types/config.js";
+import { syncBaseBranch, createWorkBranch, pushBranch } from "../git/branch-manager.js";
+import { autoCommitIfDirty } from "../git/commit-helper.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
 
 /**
  * Git 작업 실행을 위한 옵션
@@ -55,6 +59,67 @@ export class GitTask implements AQMTask {
 
   get status(): TaskStatus {
     return this._status;
+  }
+
+  async run(): Promise<GitTaskResult> {
+    if (this._status !== TaskStatus.PENDING) {
+      throw new Error(`Task ${this.id} is already in ${this._status} state`);
+    }
+
+    this.setRunning();
+    const logger = getLogger();
+    const { gitConfig, issueNumber, issueTitle, cwd } = this._options;
+
+    try {
+      // Step 1: Sync base branch
+      if (this._abortController.signal.aborted) {
+        this.setFailed("Task was killed before sync");
+        return this._result!;
+      }
+      logger.info(`[GitTask] Syncing base branch for issue #${issueNumber}`);
+      await syncBaseBranch(gitConfig, { cwd });
+
+      // Step 2: Create work branch
+      if (this._abortController.signal.aborted) {
+        this.setFailed("Task was killed before branch creation");
+        return this._result!;
+      }
+      logger.info(`[GitTask] Creating work branch for issue #${issueNumber}`);
+      const { workBranch } = await createWorkBranch(gitConfig, issueNumber, issueTitle, { cwd });
+
+      // Step 3: Auto-commit if dirty
+      if (this._abortController.signal.aborted) {
+        this.setFailed("Task was killed before commit");
+        return this._result!;
+      }
+      logger.info(`[GitTask] Auto-committing changes for issue #${issueNumber}`);
+      const commitMsg = `[#${issueNumber}] ${issueTitle}`;
+      const commitHash = await autoCommitIfDirty(gitConfig.gitPath, cwd, commitMsg);
+
+      // Step 4: Push branch
+      if (this._abortController.signal.aborted) {
+        this.setFailed("Task was killed before push");
+        return this._result!;
+      }
+      logger.info(`[GitTask] Pushing branch ${workBranch}`);
+      await pushBranch(gitConfig, workBranch, { cwd });
+
+      const durationMs = Date.now() - this._startedAt!.getTime();
+      const result: GitTaskResult = {
+        success: true,
+        branchName: workBranch,
+        commitHash,
+        durationMs,
+      };
+      this.setCompleted(result);
+      logger.info(`[GitTask] Completed for issue #${issueNumber}: branch=${workBranch}`);
+      return result;
+    } catch (err: unknown) {
+      const error = getErrorMessage(err);
+      logger.error(`[GitTask] Failed for issue #${issueNumber}: ${error}`);
+      this.setFailed(error);
+      return this._result!;
+    }
   }
 
   async kill(): Promise<void> {

--- a/src/tasks/git-task.ts
+++ b/src/tasks/git-task.ts
@@ -1,10 +1,32 @@
 import { randomUUID } from "crypto";
 import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
-import type { GitConfig } from "../types/config.js";
+import type { GitConfig, PrConfig, GhCliConfig } from "../types/config.js";
+import type { Plan, PhaseResult } from "../types/pipeline.js";
 import { syncBaseBranch, createWorkBranch, pushBranch } from "../git/branch-manager.js";
 import { autoCommitIfDirty } from "../git/commit-helper.js";
+import { createDraftPR } from "../github/pr-creator.js";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
+
+/**
+ * PR 생성을 위한 옵션 (선택적)
+ */
+export interface GitTaskPrOptions {
+  /** PR 설정 */
+  prConfig: PrConfig;
+  /** gh CLI 설정 */
+  ghConfig: GhCliConfig;
+  /** GitHub 레포지토리 (owner/repo) */
+  repo: string;
+  /** 구현 계획 */
+  plan: Plan;
+  /** 페이즈별 실행 결과 */
+  phaseResults: PhaseResult[];
+  /** 프롬프트 디렉토리 경로 */
+  promptsDir: string;
+  /** 드라이런 여부 */
+  dryRun?: boolean;
+}
 
 /**
  * Git 작업 실행을 위한 옵션
@@ -18,6 +40,8 @@ export interface GitTaskOptions extends BaseTaskOptions {
   issueTitle: string;
   /** 작업 디렉토리 */
   cwd: string;
+  /** PR 생성 옵션 (제공 시 PR 생성 수행) */
+  prOptions?: GitTaskPrOptions;
 }
 
 /**
@@ -104,11 +128,47 @@ export class GitTask implements AQMTask {
       logger.info(`[GitTask] Pushing branch ${workBranch}`);
       await pushBranch(gitConfig, workBranch, { cwd });
 
+      // Step 5: Create PR (optional)
+      let prUrl: string | undefined;
+      const { prOptions } = this._options;
+      if (prOptions) {
+        if (this._abortController.signal.aborted) {
+          this.setFailed("Task was killed before PR creation");
+          return this._result!;
+        }
+        logger.info(`[GitTask] Creating PR for issue #${issueNumber}`);
+        const prResult = await createDraftPR(
+          prOptions.prConfig,
+          prOptions.ghConfig,
+          {
+            issueNumber,
+            issueTitle,
+            repo: prOptions.repo,
+            plan: prOptions.plan,
+            phaseResults: prOptions.phaseResults,
+            branchName: workBranch,
+            baseBranch: gitConfig.defaultBaseBranch,
+          },
+          {
+            cwd,
+            promptsDir: prOptions.promptsDir,
+            dryRun: prOptions.dryRun,
+          }
+        );
+        if (prResult) {
+          prUrl = prResult.url;
+          logger.info(`[GitTask] PR created: ${prUrl}`);
+        } else {
+          logger.warn(`[GitTask] PR creation returned null for issue #${issueNumber}`);
+        }
+      }
+
       const durationMs = Date.now() - this._startedAt!.getTime();
       const result: GitTaskResult = {
         success: true,
         branchName: workBranch,
         commitHash,
+        prUrl,
         durationMs,
       };
       this.setCompleted(result);

--- a/src/tasks/git-task.ts
+++ b/src/tasks/git-task.ts
@@ -5,6 +5,7 @@ import type { Plan, PhaseResult } from "../types/pipeline.js";
 import { syncBaseBranch, createWorkBranch, pushBranch } from "../git/branch-manager.js";
 import { autoCommitIfDirty } from "../git/commit-helper.js";
 import { createDraftPR } from "../github/pr-creator.js";
+import { createCheckpoint, rollbackToCheckpoint } from "../safety/rollback-manager.js";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 
@@ -42,6 +43,8 @@ export interface GitTaskOptions extends BaseTaskOptions {
   cwd: string;
   /** PR 생성 옵션 (제공 시 PR 생성 수행) */
   prOptions?: GitTaskPrOptions;
+  /** 실패 시 자동 롤백 여부 (기본값: false) */
+  autoRollback?: boolean;
 }
 
 /**
@@ -58,6 +61,8 @@ export interface GitTaskResult {
   prUrl?: string;
   /** 에러 메시지 */
   error?: string;
+  /** 롤백된 체크포인트 해시 */
+  rolledBackTo?: string;
   /** 실행 소요 시간 (밀리초) */
   durationMs: number;
 }
@@ -92,7 +97,16 @@ export class GitTask implements AQMTask {
 
     this.setRunning();
     const logger = getLogger();
-    const { gitConfig, issueNumber, issueTitle, cwd } = this._options;
+    const { gitConfig, issueNumber, issueTitle, cwd, autoRollback } = this._options;
+
+    // Create checkpoint before any git operations
+    let checkpointHash: string | undefined;
+    try {
+      checkpointHash = await createCheckpoint({ cwd, gitPath: gitConfig.gitPath });
+      logger.info(`[GitTask] Checkpoint created: ${checkpointHash.slice(0, 8)} for issue #${issueNumber}`);
+    } catch (err: unknown) {
+      logger.warn(`[GitTask] Could not create checkpoint: ${getErrorMessage(err)}`);
+    }
 
     try {
       // Step 1: Sync base branch
@@ -177,7 +191,19 @@ export class GitTask implements AQMTask {
     } catch (err: unknown) {
       const error = getErrorMessage(err);
       logger.error(`[GitTask] Failed for issue #${issueNumber}: ${error}`);
-      this.setFailed(error);
+
+      let rolledBackTo: string | undefined;
+      if (autoRollback && checkpointHash) {
+        try {
+          await rollbackToCheckpoint(checkpointHash, { cwd, gitPath: gitConfig.gitPath });
+          rolledBackTo = checkpointHash;
+          logger.info(`[GitTask] Rolled back to checkpoint ${checkpointHash.slice(0, 8)}`);
+        } catch (rollbackErr: unknown) {
+          logger.error(`[GitTask] Rollback failed: ${getErrorMessage(rollbackErr)}`);
+        }
+      }
+
+      this.setFailed(error, rolledBackTo);
       return this._result!;
     }
   }
@@ -231,11 +257,11 @@ export class GitTask implements AQMTask {
     this._status = result.success ? TaskStatus.SUCCESS : TaskStatus.FAILED;
   }
 
-  protected setFailed(error: string): void {
+  protected setFailed(error: string, rolledBackTo?: string): void {
     const durationMs = this._startedAt
       ? Date.now() - this._startedAt.getTime()
       : 0;
-    this._result = { success: false, error, durationMs };
+    this._result = { success: false, error, rolledBackTo, durationMs };
     this._completedAt = new Date();
     this._status = TaskStatus.FAILED;
   }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -16,3 +16,10 @@ export {
   ClaudeTask,
   ClaudeTaskOptions
 } from "./claude-task.js";
+
+// Git 태스크 구현체
+export {
+  GitTask,
+  GitTaskOptions,
+  GitTaskResult
+} from "./git-task.js";

--- a/tests/tasks/git-task.test.ts
+++ b/tests/tasks/git-task.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GitTask, GitTaskOptions, GitTaskPrOptions } from "../../src/tasks/git-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+import type { GitConfig, PrConfig, GhCliConfig } from "../../src/types/config.js";
+
+vi.mock("../../src/git/branch-manager.js", () => ({
+  syncBaseBranch: vi.fn(),
+  createWorkBranch: vi.fn(),
+  pushBranch: vi.fn(),
+}));
+vi.mock("../../src/git/commit-helper.js", () => ({
+  autoCommitIfDirty: vi.fn(),
+}));
+vi.mock("../../src/github/pr-creator.js", () => ({
+  createDraftPR: vi.fn(),
+}));
+vi.mock("../../src/safety/rollback-manager.js", () => ({
+  createCheckpoint: vi.fn(),
+  rollbackToCheckpoint: vi.fn(),
+}));
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { syncBaseBranch, createWorkBranch, pushBranch } from "../../src/git/branch-manager.js";
+import { autoCommitIfDirty } from "../../src/git/commit-helper.js";
+import { createDraftPR } from "../../src/github/pr-creator.js";
+import { createCheckpoint, rollbackToCheckpoint } from "../../src/safety/rollback-manager.js";
+
+const mockSyncBaseBranch = vi.mocked(syncBaseBranch);
+const mockCreateWorkBranch = vi.mocked(createWorkBranch);
+const mockPushBranch = vi.mocked(pushBranch);
+const mockAutoCommitIfDirty = vi.mocked(autoCommitIfDirty);
+const mockCreateDraftPR = vi.mocked(createDraftPR);
+const mockCreateCheckpoint = vi.mocked(createCheckpoint);
+const mockRollbackToCheckpoint = vi.mocked(rollbackToCheckpoint);
+
+const baseGitConfig: GitConfig = {
+  defaultBaseBranch: "main",
+  branchTemplate: "aq/{issueNumber}-{slug}",
+  commitMessageTemplate: "[#{issueNumber}] {title}",
+  remoteAlias: "origin",
+  allowedRepos: ["test/repo"],
+  gitPath: "git",
+  fetchDepth: 50,
+  signCommits: false,
+};
+
+function makeOptions(overrides: Partial<GitTaskOptions> = {}): GitTaskOptions {
+  return {
+    gitConfig: baseGitConfig,
+    issueNumber: 42,
+    issueTitle: "feat: add widget",
+    cwd: "/tmp/test-repo",
+    ...overrides,
+  };
+}
+
+describe("GitTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCheckpoint.mockResolvedValue("checkpoint-abc123");
+    mockSyncBaseBranch.mockResolvedValue(undefined);
+    mockCreateWorkBranch.mockResolvedValue({ baseBranch: "main", workBranch: "aq/42-feat-add-widget" });
+    mockAutoCommitIfDirty.mockResolvedValue("commitabc");
+    mockPushBranch.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("생성 및 기본 속성", () => {
+    it("should create task with auto-generated UUID", () => {
+      const task = new GitTask(makeOptions());
+
+      expect(task.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(task.type).toBe("git");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should use custom ID when provided", () => {
+      const task = new GitTask(makeOptions({ id: "my-custom-id" }));
+
+      expect(task.id).toBe("my-custom-id");
+    });
+
+    it("should start with PENDING status", () => {
+      const task = new GitTask(makeOptions());
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+      expect(task.getResult()).toBeUndefined();
+    });
+  });
+
+  describe("run() — 정상 실행", () => {
+    it("should execute all git steps and return success result", async () => {
+      const task = new GitTask(makeOptions());
+      const result = await task.run();
+
+      expect(result.success).toBe(true);
+      expect(result.branchName).toBe("aq/42-feat-add-widget");
+      expect(result.commitHash).toBe("commitabc");
+      expect(result.prUrl).toBeUndefined();
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should call syncBaseBranch with correct args", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockSyncBaseBranch).toHaveBeenCalledWith(baseGitConfig, { cwd: "/tmp/test-repo" });
+    });
+
+    it("should call createWorkBranch with issue info", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockCreateWorkBranch).toHaveBeenCalledWith(
+        baseGitConfig,
+        42,
+        "feat: add widget",
+        { cwd: "/tmp/test-repo" }
+      );
+    });
+
+    it("should call autoCommitIfDirty with formatted message", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockAutoCommitIfDirty).toHaveBeenCalledWith(
+        "git",
+        "/tmp/test-repo",
+        "[#42] feat: add widget"
+      );
+    });
+
+    it("should call pushBranch with work branch name", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockPushBranch).toHaveBeenCalledWith(
+        baseGitConfig,
+        "aq/42-feat-add-widget",
+        { cwd: "/tmp/test-repo" }
+      );
+    });
+
+    it("should create checkpoint before git operations", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockCreateCheckpoint).toHaveBeenCalledWith({ cwd: "/tmp/test-repo", gitPath: "git" });
+    });
+
+    it("should skip PR creation when prOptions is not provided", async () => {
+      await new GitTask(makeOptions()).run();
+
+      expect(mockCreateDraftPR).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("run() — PR 생성 포함", () => {
+    const prConfig: PrConfig = {
+      draft: true,
+      labelPrefix: "aq/",
+      autoMerge: false,
+    };
+    const ghConfig: GhCliConfig = {
+      path: "gh",
+      timeout: 30000,
+    };
+    const prOptions: GitTaskPrOptions = {
+      prConfig,
+      ghConfig,
+      repo: "test/repo",
+      plan: { phases: [], summary: "test plan" } as never,
+      phaseResults: [],
+      promptsDir: "/tmp/prompts",
+      dryRun: false,
+    };
+
+    it("should create PR and include URL in result", async () => {
+      mockCreateDraftPR.mockResolvedValue({ url: "https://github.com/test/repo/pull/99", number: 99 });
+
+      const task = new GitTask(makeOptions({ prOptions }));
+      const result = await task.run();
+
+      expect(result.success).toBe(true);
+      expect(result.prUrl).toBe("https://github.com/test/repo/pull/99");
+      expect(mockCreateDraftPR).toHaveBeenCalledOnce();
+    });
+
+    it("should pass correct args to createDraftPR", async () => {
+      mockCreateDraftPR.mockResolvedValue({ url: "https://github.com/test/repo/pull/1", number: 1 });
+
+      await new GitTask(makeOptions({ prOptions })).run();
+
+      expect(mockCreateDraftPR).toHaveBeenCalledWith(
+        prConfig,
+        ghConfig,
+        expect.objectContaining({
+          issueNumber: 42,
+          issueTitle: "feat: add widget",
+          repo: "test/repo",
+          branchName: "aq/42-feat-add-widget",
+          baseBranch: "main",
+        }),
+        expect.objectContaining({
+          cwd: "/tmp/test-repo",
+          promptsDir: "/tmp/prompts",
+          dryRun: false,
+        })
+      );
+    });
+
+    it("should handle null PR result without failing", async () => {
+      mockCreateDraftPR.mockResolvedValue(null);
+
+      const task = new GitTask(makeOptions({ prOptions }));
+      const result = await task.run();
+
+      expect(result.success).toBe(true);
+      expect(result.prUrl).toBeUndefined();
+    });
+  });
+
+  describe("run() — 실패 처리", () => {
+    it("should return failed result when syncBaseBranch throws", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("fetch failed"));
+
+      const task = new GitTask(makeOptions());
+      const result = await task.run();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("fetch failed");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+
+    it("should return failed result when createWorkBranch throws", async () => {
+      mockCreateWorkBranch.mockRejectedValue(new Error("branch create failed"));
+
+      const task = new GitTask(makeOptions());
+      const result = await task.run();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("branch create failed");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+
+    it("should return failed result when pushBranch throws", async () => {
+      mockPushBranch.mockRejectedValue(new Error("push rejected"));
+
+      const task = new GitTask(makeOptions());
+      const result = await task.run();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("push rejected");
+    });
+
+    it("should not rollback when autoRollback is false (default)", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("sync failed"));
+
+      await new GitTask(makeOptions()).run();
+
+      expect(mockRollbackToCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it("should rollback when autoRollback is true and checkpoint exists", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("sync failed"));
+
+      const task = new GitTask(makeOptions({ autoRollback: true }));
+      const result = await task.run();
+
+      expect(result.success).toBe(false);
+      expect(result.rolledBackTo).toBe("checkpoint-abc123");
+      expect(mockRollbackToCheckpoint).toHaveBeenCalledWith(
+        "checkpoint-abc123",
+        { cwd: "/tmp/test-repo", gitPath: "git" }
+      );
+    });
+
+    it("should not rollback when autoRollback is true but checkpoint creation failed", async () => {
+      mockCreateCheckpoint.mockRejectedValue(new Error("checkpoint failed"));
+      mockSyncBaseBranch.mockRejectedValue(new Error("sync failed"));
+
+      const task = new GitTask(makeOptions({ autoRollback: true }));
+      const result = await task.run();
+
+      expect(result.success).toBe(false);
+      expect(result.rolledBackTo).toBeUndefined();
+      expect(mockRollbackToCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it("should include durationMs in failed result", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("failed"));
+
+      const result = await new GitTask(makeOptions()).run();
+
+      expect(typeof result.durationMs).toBe("number");
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should throw when run() is called again after completion", async () => {
+      const task = new GitTask(makeOptions());
+      await task.run();
+
+      await expect(task.run()).rejects.toThrow(/already in SUCCESS state/);
+    });
+
+    it("should throw when run() is called again after failure", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("fail"));
+
+      const task = new GitTask(makeOptions());
+      await task.run();
+
+      await expect(task.run()).rejects.toThrow(/already in FAILED state/);
+    });
+  });
+
+  describe("kill()", () => {
+    it("should kill a running task", async () => {
+      let resolveRun!: () => void;
+      mockSyncBaseBranch.mockImplementation(
+        () => new Promise<void>((resolve) => { resolveRun = resolve; })
+      );
+
+      const task = new GitTask(makeOptions());
+      const runPromise = task.run();
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      await task.kill();
+      resolveRun();
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+      await runPromise;
+    });
+
+    it("should do nothing when killing a PENDING task", async () => {
+      const task = new GitTask(makeOptions());
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should do nothing when killing an already completed task", async () => {
+      const task = new GitTask(makeOptions());
+      await task.run();
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+  });
+
+  describe("toJSON()", () => {
+    it("should serialize PENDING task correctly", () => {
+      const task = new GitTask(makeOptions({ id: "test-id-123" }));
+      const json = task.toJSON();
+
+      expect(json).toMatchObject({
+        id: "test-id-123",
+        type: "git",
+        status: TaskStatus.PENDING,
+        startedAt: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      });
+      expect(json.metadata?.issueNumber).toBe(42);
+      expect(json.metadata?.issueTitle).toBe("feat: add widget");
+    });
+
+    it("should include result metadata after successful run", async () => {
+      const task = new GitTask(makeOptions({ id: "run-id" }));
+      await task.run();
+
+      const json = task.toJSON();
+
+      expect(json.status).toBe(TaskStatus.SUCCESS);
+      expect(json.metadata?.branchName).toBe("aq/42-feat-add-widget");
+      expect(json.metadata?.commitHash).toBe("commitabc");
+      expect(json.metadata?.success).toBe(true);
+      expect(json.startedAt).toBeDefined();
+      expect(json.completedAt).toBeDefined();
+      expect(json.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should include extra metadata from options", () => {
+      const task = new GitTask(makeOptions({
+        id: "meta-id",
+        metadata: { customKey: "customVal" },
+      }));
+      const json = task.toJSON();
+
+      expect(json.metadata?.customKey).toBe("customVal");
+    });
+  });
+
+  describe("getResult()", () => {
+    it("should return undefined before run", () => {
+      expect(new GitTask(makeOptions()).getResult()).toBeUndefined();
+    });
+
+    it("should return result after successful run", async () => {
+      const task = new GitTask(makeOptions());
+      await task.run();
+
+      const result = task.getResult();
+
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(true);
+      expect(result!.branchName).toBe("aq/42-feat-add-widget");
+    });
+
+    it("should return error result after failed run", async () => {
+      mockSyncBaseBranch.mockRejectedValue(new Error("boom"));
+
+      const task = new GitTask(makeOptions());
+      await task.run();
+
+      const result = task.getResult();
+
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(false);
+      expect(result!.error).toContain("boom");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #424 — refactor: GitTask 구현 — branch/commit/PR 래핑

기존 src/git/ 모듈의 기능들(branch-manager, commit-helper, pr-creator)이 분산되어 있어 파이프라인에서 일관된 방식으로 사용하기 어렵다. AQMTask 인터페이스를 구현하는 GitTask를 만들어 Git 작업을 통합 관리하고, 실패 시 롤백을 지원해야 한다.

## Requirements

- AQMTask 인터페이스 구현 (id, type, status, kill, toJSON)
- Git operations 지원: sync-branch, create-branch, commit, push, create-pr
- 기존 git/ 모듈 함수들을 내부적으로 활용 (재구현 아님)
- 실패 시 checkpoint 기반 롤백 지원 (rollback-manager 활용)
- operation별 결과 타입 정의
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: GitTask 타입 및 기본 구조 — SUCCESS (412c57c5)
- Phase 1: Branch/Commit/Push operations — SUCCESS (8b948bf4)
- Phase 2: PR 생성 operation — SUCCESS (bdb30c9f)
- Phase 3: 롤백 지원 — SUCCESS (5b97d101)
- Phase 4: 단위 테스트 — SUCCESS (3ce97beb)
- Phase 5: Export 및 정리 — SUCCESS (3ce97beb)

## Risks

- 기존 git/ 모듈 함수들의 시그니처 변경 시 GitTask도 수정 필요
- 롤백 시 worktree 상태 불일치 가능성
- PR 생성 시 gh CLI 의존성

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 6/6 completed
- **Branch**: `aq/424-refactor-gittask-branch-commit-pr` → `develop`
- **Tokens**: 286 input, 33721 output{{#stats.cacheCreationTokens}}, 322568 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3391457 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #424