### PR TITLE
[AQ-#434] feat: 칸반 드래그 앤 드롭 UI — Queued 잡 우선순위 변경

### DIFF
--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -37,6 +37,8 @@ export class JobStore extends EventEmitter {
   private maxJobs: number;
   // 메모리 캐시: running/queued 상태의 job만 캐싱
   private cache: Map<string, Job> = new Map();
+  // 우선순위 맵: jobId → priority (낮을수록 먼저). in-memory only.
+  private priorityMap: Map<string, number> = new Map();
 
   constructor(dataDir: string, maxJobs: number = 1000) {
     super();
@@ -584,7 +586,19 @@ export class JobStore extends EventEmitter {
     }
 
     return Array.from(jobMap.values())
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      .map(job => {
+        const p = this.priorityMap.get(job.id);
+        return p !== undefined ? { ...job, priority: p } : job;
+      })
+      .sort((a, b) => {
+        // queued 잡: priority 오름차순 (낮을수록 먼저), 그 다음 createdAt 내림차순
+        if (a.status === "queued" && b.status === "queued") {
+          const pa = a.priority ?? Infinity;
+          const pb = b.priority ?? Infinity;
+          if (pa !== pb) return pa - pb;
+        }
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      });
   }
 
   findByIssue(issueNumber: number, repo: string): Job | undefined {
@@ -770,6 +784,22 @@ export class JobStore extends EventEmitter {
     // SQLite 기반으로 전환하면서 파일시스템 감시는 불필요
     // 호환성을 위해 메서드는 유지하지만 실제 동작은 하지 않음
     logger.debug("stopWatching called but no-op in SQLite mode");
+  }
+
+  /**
+   * queued 잡의 우선순위를 변경한다. (낮을수록 먼저 실행)
+   * running 이상의 잡에는 적용되지 않는다.
+   */
+  updateJobPriority(id: string, priority: number): boolean {
+    const job = this.get(id);
+    if (!job) return false;
+    if (job.status !== "queued") return false;
+
+    this.priorityMap.set(id, priority);
+    const updatedJob = { ...job, priority };
+    this.updateCache(updatedJob);
+    this.emit('jobUpdated', updatedJob, job);
+    return true;
   }
 
   /**

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -10,7 +10,7 @@ import { maskSensitiveConfig } from "../utils/config-masker.js";
 import type { ProjectConfig, AQConfig } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, type HealthCheckResponse } from "../types/api.js";
+import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, UpdateJobPriorityRequestSchema, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary } from "../store/queries.js";
 import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
@@ -903,6 +903,37 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
       return c.json({ error: "Failed to retry job" }, 500);
     }
     return c.json({ status: "queued", id: newJob.id });
+  });
+
+  // Update priority of a queued job
+  api.put("/api/jobs/:id/priority", async (c) => {
+    const id = c.req.param("id");
+    const job = store.get(id);
+    if (!job) return c.json({ error: "Job not found" }, 404);
+    if (job.status !== "queued") {
+      return c.json({ error: "Priority can only be changed for queued jobs" }, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parseResult = UpdateJobPriorityRequestSchema.safeParse(body);
+    if (!parseResult.success) {
+      return c.json({ error: "Invalid request body", details: parseResult.error }, 400);
+    }
+
+    const { priority } = parseResult.data;
+    const updated = store.updateJobPriority(id, priority);
+    if (!updated) {
+      return c.json({ error: "Failed to update priority" }, 500);
+    }
+
+    broadcastToAllClients("jobUpdated", { ...job, priority });
+    return c.json({ status: "updated", id, priority });
   });
 
   // SSE endpoint for real-time updates

--- a/src/server/public/js/kanban.js
+++ b/src/server/public/js/kanban.js
@@ -298,6 +298,10 @@ function kanbanDrop(e) {
 
   var fromIdx = ids.indexOf(dragId);
   if (fromIdx === -1) return;
+
+  // 롤백용 원본 순서 스냅샷
+  var originalNodes = cards.slice();
+
   ids.splice(fromIdx, 1);
 
   var insertIdx = ids.length; // default: end
@@ -309,12 +313,25 @@ function kanbanDrop(e) {
   }
   ids.splice(insertIdx, 0, dragId);
 
-  ids.forEach(function(id, idx) {
-    apiFetch('/api/jobs/' + encodeURIComponent(id) + '/priority', {
+  // 낙관적 UI: DOM 즉시 재정렬
+  ids.forEach(function(id) {
+    var card = list.querySelector('[data-job-id="' + id + '"]');
+    if (card) list.appendChild(card);
+  });
+
+  // API 호출 — 실패 시 원본 순서로 롤백
+  var promises = ids.map(function(id, idx) {
+    return apiFetch('/api/jobs/' + encodeURIComponent(id) + '/priority', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ priority: idx })
-    }).catch(function() {});
+    }).then(function(r) {
+      if (!r.ok) return Promise.reject(new Error('HTTP ' + r.status));
+    });
+  });
+
+  Promise.all(promises).catch(function() {
+    originalNodes.forEach(function(card) { list.appendChild(card); });
   });
 }
 

--- a/src/server/public/js/kanban.js
+++ b/src/server/public/js/kanban.js
@@ -96,11 +96,11 @@ function renderKanbanCard(job) {
 
   } else {
     // queued
-    cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/15 hover:border-primary/40 transition-all cursor-pointer group';
+    cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/15 hover:border-primary/40 transition-all cursor-grab group';
     headerHtml =
       '<div class="flex justify-between items-start mb-3">' +
         '<span class="text-[10px] font-mono text-outline-variant font-bold tracking-wider">' + esc(issueRef) + '</span>' +
-        '<span class="material-symbols-outlined text-[16px] text-outline-variant group-hover:text-primary transition-colors">more_horiz</span>' +
+        '<span class="material-symbols-outlined text-[16px] text-outline-variant group-hover:text-primary transition-colors select-none">drag_indicator</span>' +
       '</div>';
     var elapsed = fmtDuration(job) || relativeTime(job.createdAt);
     bodyHtml =
@@ -114,6 +114,14 @@ function renderKanbanCard(job) {
           '<div class="h-full bg-outline-variant rounded-full" style="width:0%"></div>' +
         '</div>' +
       '</div>';
+
+    return '<div class="' + cardClass + '" data-job-id="' + esc(job.id) + '"' +
+      ' draggable="true"' +
+      ' ondragstart="kanbanDragStart(event)"' +
+      ' ondragend="kanbanDragEnd(event)"' +
+      ' onclick="selectJob(\'' + esc(job.id) + '\')">' +
+      headerHtml + bodyHtml +
+    '</div>';
   }
 
   return '<div class="' + cardClass + '" data-job-id="' + esc(job.id) + '" onclick="selectJob(\'' + esc(job.id) + '\')">' +
@@ -132,6 +140,10 @@ function renderKanbanColumn(col, jobs) {
   var listClass = 'flex-1 p-3 space-y-3 overflow-y-auto custom-scrollbar' +
     (col.id === 'done' ? ' opacity-70 hover:opacity-100 transition-opacity' : '');
 
+  var listAttrs = col.id === 'queued'
+    ? ' ondragover="kanbanDragOver(event)" ondrop="kanbanDrop(event)"'
+    : '';
+
   return '<div class="w-[280px] flex-shrink-0 flex flex-col h-full bg-[#181c22] rounded-lg">' +
     '<div class="p-4 flex items-center justify-between border-b border-outline-variant/10">' +
       '<div class="flex items-center gap-2">' +
@@ -140,7 +152,7 @@ function renderKanbanColumn(col, jobs) {
       '</div>' +
       '<span class="text-xs font-mono text-outline-variant">' + jobs.length + '</span>' +
     '</div>' +
-    '<div class="' + listClass + '">' + cardsHtml + '</div>' +
+    '<div class="' + listClass + '"' + listAttrs + '>' + cardsHtml + '</div>' +
   '</div>';
 }
 
@@ -159,4 +171,103 @@ function renderKanban(jobs) {
   return KANBAN_COLUMNS.map(function(col) {
     return renderKanbanColumn(col, columnJobs[col.id]);
   }).join('');
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Drag & Drop — Queued Column Only
+   ══════════════════════════════════════════════════════════════ */
+var _dnd = { draggingId: null };
+
+function kanbanDragStart(e) {
+  var card = e.currentTarget;
+  _dnd.draggingId = card.dataset.jobId;
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/plain', _dnd.draggingId);
+  setTimeout(function() { card.style.opacity = '0.4'; }, 0);
+}
+
+function kanbanDragEnd(e) {
+  e.currentTarget.style.opacity = '';
+  _dnd.draggingId = null;
+  _kanbanRemoveIndicator();
+}
+
+function kanbanDragOver(e) {
+  if (!_dnd.draggingId) return;
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+
+  var target = _kanbanFindCardTarget(e);
+  _kanbanRemoveIndicator();
+
+  var list = e.currentTarget;
+  var indicator = document.createElement('div');
+  indicator.id = 'dnd-indicator';
+  indicator.style.cssText = 'height:2px;background:#6750a4;border-radius:1px;margin:2px 0;pointer-events:none;';
+
+  if (target) {
+    var before = (e.clientY - target.getBoundingClientRect().top) < target.offsetHeight / 2;
+    if (before) {
+      list.insertBefore(indicator, target);
+    } else {
+      list.insertBefore(indicator, target.nextSibling);
+    }
+  } else {
+    list.appendChild(indicator);
+  }
+}
+
+function kanbanDrop(e) {
+  e.preventDefault();
+  _kanbanRemoveIndicator();
+
+  var dragId = _dnd.draggingId;
+  if (!dragId) return;
+
+  var target = _kanbanFindCardTarget(e);
+  var list = e.currentTarget;
+  var cards = Array.from(list.querySelectorAll('[data-job-id]'));
+  var ids = cards.map(function(c) { return c.dataset.jobId; });
+
+  var fromIdx = ids.indexOf(dragId);
+  if (fromIdx === -1) return;
+  ids.splice(fromIdx, 1);
+
+  var insertIdx = ids.length; // default: end
+  if (target) {
+    var targetId = target.dataset.jobId;
+    var targetIdx = ids.indexOf(targetId);
+    var dropBefore = (e.clientY - target.getBoundingClientRect().top) < target.offsetHeight / 2;
+    insertIdx = dropBefore ? targetIdx : targetIdx + 1;
+  }
+  ids.splice(insertIdx, 0, dragId);
+
+  ids.forEach(function(id, idx) {
+    apiFetch('/api/jobs/' + encodeURIComponent(id) + '/priority', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priority: idx })
+    }).catch(function() {});
+  });
+}
+
+function _kanbanFindCardTarget(e) {
+  var list = e.currentTarget;
+  var cards = Array.from(list.querySelectorAll('[data-job-id]'));
+  if (cards.length === 0) return null;
+  var best = null;
+  var bestDist = Infinity;
+  for (var i = 0; i < cards.length; i++) {
+    var card = cards[i];
+    var rect = card.getBoundingClientRect();
+    var midY = rect.top + rect.height / 2;
+    var dist = Math.abs(e.clientY - midY);
+    if (dist < bestDist) { bestDist = dist; best = card; }
+  }
+  return best;
+}
+
+function _kanbanRemoveIndicator() {
+  var el = document.getElementById('dnd-indicator');
+  if (el) el.parentNode.removeChild(el);
 }

--- a/src/server/public/js/kanban.js
+++ b/src/server/public/js/kanban.js
@@ -30,6 +30,20 @@ function getJobKanbanColumn(job) {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   Priority Visual Helpers
+   ══════════════════════════════════════════════════════════════ */
+/**
+ * 숫자 priority → 'high' | 'normal' | 'low'
+ * 낮을수록 먼저 처리: 0=high, 1=normal, ≥2=low, undefined=normal
+ */
+function getPriorityLevel(priority) {
+  if (typeof priority !== 'number') return 'normal';
+  if (priority === 0) return 'high';
+  if (priority === 1) return 'normal';
+  return 'low';
+}
+
+/* ══════════════════════════════════════════════════════════════
    Card Rendering
    ══════════════════════════════════════════════════════════════ */
 function renderKanbanCard(job) {
@@ -41,6 +55,7 @@ function renderKanbanCard(job) {
   var issueRef   = '#' + job.issueNumber;
 
   var cardClass, headerHtml, bodyHtml;
+  var priorityBarHtml = '';
 
   if (isRunning) {
     cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/30 bg-gradient-to-br from-[#262a31] to-[#1c2026] relative overflow-hidden group cursor-pointer';
@@ -95,32 +110,84 @@ function renderKanbanCard(job) {
       '</div>';
 
   } else {
-    // queued
-    cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/15 hover:border-primary/40 transition-all cursor-grab group';
-    headerHtml =
-      '<div class="flex justify-between items-start mb-3">' +
-        '<span class="text-[10px] font-mono text-outline-variant font-bold tracking-wider">' + esc(issueRef) + '</span>' +
-        '<span class="material-symbols-outlined text-[16px] text-outline-variant group-hover:text-primary transition-colors select-none">drag_indicator</span>' +
-      '</div>';
+    // queued — priority에 따라 시각적 처리 분기
+    var pLevel = getPriorityLevel(job.priority);
     var elapsed = fmtDuration(job) || relativeTime(job.createdAt);
-    bodyHtml =
-      '<h4 class="text-sm font-medium text-on-surface mb-4 leading-snug">' + esc(title) + '</h4>' +
-      '<div class="space-y-3">' +
-        '<div class="flex items-center justify-between text-[10px] font-mono text-outline">' +
-          '<span>ELAPSED</span>' +
-          '<span class="text-on-surface-variant">' + elapsed + '</span>' +
-        '</div>' +
-        '<div class="w-full h-1 bg-surface-container-low rounded-full overflow-hidden">' +
-          '<div class="h-full bg-outline-variant rounded-full" style="width:0%"></div>' +
-        '</div>' +
-      '</div>';
+
+    if (pLevel === 'high') {
+      // high: 빨강 좌측 바 + 빨강 우선순위 아이콘
+      cardClass = 'bg-[#262a31] p-4 pl-5 rounded-md border border-error/25 hover:border-error/50 transition-all cursor-grab group relative overflow-hidden';
+      priorityBarHtml = '<div class="absolute left-0 top-0 bottom-0 w-1 rounded-l-md" style="background:rgba(255,180,171,0.7)"></div>';
+      headerHtml =
+        '<div class="flex justify-between items-start mb-3">' +
+          '<span class="text-[10px] font-mono text-error/80 font-bold tracking-wider">' + esc(issueRef) + '</span>' +
+          '<div class="flex items-center gap-1">' +
+            '<span class="material-symbols-outlined text-[14px] text-error/80" style="font-variation-settings:\'FILL\' 1,\'wght\' 600">keyboard_double_arrow_up</span>' +
+            '<span class="material-symbols-outlined text-[16px] text-outline-variant/60 group-hover:text-primary transition-colors select-none">drag_indicator</span>' +
+          '</div>' +
+        '</div>';
+      bodyHtml =
+        '<h4 class="text-sm font-medium text-on-surface mb-4 leading-snug">' + esc(title) + '</h4>' +
+        '<div class="space-y-3">' +
+          '<div class="flex items-center justify-between text-[10px] font-mono text-outline">' +
+            '<span>ELAPSED</span>' +
+            '<span class="text-on-surface-variant">' + elapsed + '</span>' +
+          '</div>' +
+          '<div class="w-full h-1 bg-surface-container-low rounded-full overflow-hidden">' +
+            '<div class="h-full bg-error/40 rounded-full" style="width:0%"></div>' +
+          '</div>' +
+        '</div>';
+
+    } else if (pLevel === 'low') {
+      // low: 회색 처리 (opacity 낮춤) + 하향 아이콘
+      cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/10 hover:border-primary/30 transition-all cursor-grab group opacity-55 hover:opacity-90';
+      headerHtml =
+        '<div class="flex justify-between items-start mb-3">' +
+          '<span class="text-[10px] font-mono text-outline-variant/60 font-bold tracking-wider">' + esc(issueRef) + '</span>' +
+          '<div class="flex items-center gap-1">' +
+            '<span class="material-symbols-outlined text-[14px] text-outline-variant/50">keyboard_double_arrow_down</span>' +
+            '<span class="material-symbols-outlined text-[16px] text-outline-variant/50 group-hover:text-primary transition-colors select-none">drag_indicator</span>' +
+          '</div>' +
+        '</div>';
+      bodyHtml =
+        '<h4 class="text-sm font-medium text-on-surface/60 mb-4 leading-snug">' + esc(title) + '</h4>' +
+        '<div class="space-y-3">' +
+          '<div class="flex items-center justify-between text-[10px] font-mono text-outline/60">' +
+            '<span>ELAPSED</span>' +
+            '<span class="text-on-surface-variant/60">' + elapsed + '</span>' +
+          '</div>' +
+          '<div class="w-full h-1 bg-surface-container-low rounded-full overflow-hidden">' +
+            '<div class="h-full bg-outline-variant/40 rounded-full" style="width:0%"></div>' +
+          '</div>' +
+        '</div>';
+
+    } else {
+      // normal: 기본 스타일
+      cardClass = 'bg-[#262a31] p-4 rounded-md border border-[#414752]/15 hover:border-primary/40 transition-all cursor-grab group';
+      headerHtml =
+        '<div class="flex justify-between items-start mb-3">' +
+          '<span class="text-[10px] font-mono text-outline-variant font-bold tracking-wider">' + esc(issueRef) + '</span>' +
+          '<span class="material-symbols-outlined text-[16px] text-outline-variant group-hover:text-primary transition-colors select-none">drag_indicator</span>' +
+        '</div>';
+      bodyHtml =
+        '<h4 class="text-sm font-medium text-on-surface mb-4 leading-snug">' + esc(title) + '</h4>' +
+        '<div class="space-y-3">' +
+          '<div class="flex items-center justify-between text-[10px] font-mono text-outline">' +
+            '<span>ELAPSED</span>' +
+            '<span class="text-on-surface-variant">' + elapsed + '</span>' +
+          '</div>' +
+          '<div class="w-full h-1 bg-surface-container-low rounded-full overflow-hidden">' +
+            '<div class="h-full bg-outline-variant rounded-full" style="width:0%"></div>' +
+          '</div>' +
+        '</div>';
+    }
 
     return '<div class="' + cardClass + '" data-job-id="' + esc(job.id) + '"' +
       ' draggable="true"' +
       ' ondragstart="kanbanDragStart(event)"' +
       ' ondragend="kanbanDragEnd(event)"' +
       ' onclick="selectJob(\'' + esc(job.id) + '\')">' +
-      headerHtml + bodyHtml +
+      priorityBarHtml + headerHtml + bodyHtml +
     '</div>';
   }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -270,3 +270,10 @@ export const HealthCheckResponseSchema = z.object({
 }).strict();
 
 export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;
+
+// UpdateJobPriority 요청 스키마 (PUT /api/jobs/:id/priority)
+export const UpdateJobPriorityRequestSchema = z.object({
+  priority: z.number().int().min(0),
+}).strict();
+
+export type UpdateJobPriorityRequest = z.infer<typeof UpdateJobPriorityRequestSchema>;

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -412,6 +412,8 @@ export interface JobBase {
   costUsd?: number;
   totalCostUsd?: number;
   totalUsage?: UsageStats;
+  /** 큐 내 우선순위 (낮을수록 먼저 처리). queued 상태에서만 유효 */
+  priority?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves #434 — feat: 칸반 드래그 앤 드롭 UI — Queued 잡 우선순위 변경

Queued 컬럼의 잡 카드를 드래그 앤 드롭으로 순서를 변경하고, 이를 우선순위로 반영하는 UI 기능이 필요함. 현재 kanban.js에는 드래그 앤 드롭 기능이 없고, Job 타입에 priority 필드가 없으며, priority 변경 API도 없음.

## Requirements

- Queued 컬럼에서만 드래그 앤 드롭으로 카드 순서 변경 가능
- 드롭 시 PUT /api/jobs/:id/priority API 호출
- 우선순위 시각적 표시: high=빨강, normal=기본, low=회색
- 낙관적 UI 업데이트 — API 응답 전에 UI 먼저 반영
- API 실패 시 롤백 처리

## Implementation Phases

- Phase 0: Priority 타입 및 API 추가 — SUCCESS (5efdfd02)
- Phase 1: 드래그 앤 드롭 기능 구현 — SUCCESS (72af51f1)
- Phase 3: Priority 시각적 표시 — SUCCESS (72af51f1)
- Phase 2: Priority API 연동 및 낙관적 UI — SUCCESS (95127c42)

## Risks

- depends: Job priority API 이슈가 선행 구현되어야 함 — 미완료 시 Phase 0 포함 필요
- HTML5 Drag and Drop은 모바일에서 제한적 — 터치 이벤트 별도 처리 필요할 수 있음
- SSE 이벤트와 낙관적 UI 충돌 가능성 — jobUpdated 이벤트 처리 시 주의

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/434-feat-ui-queued` → `develop`
- **Tokens**: 272 input, 44635 output{{#stats.cacheCreationTokens}}, 271405 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3698841 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #434