### PR TITLE
[AQ-#433] feat: job-queue 우선순위 기반 정렬 — priority 높은 잡 먼저 처리

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
-import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob } from "../types/pipeline.js";
+import { Job, JobPriority, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob } from "../types/pipeline.js";
 import { areDependenciesMet } from "./dependency-resolver.js";
 import { removeCheckpoint, loadCheckpoint } from "../pipeline/checkpoint.js";
 import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
@@ -297,7 +297,7 @@ export class JobQueue {
   /**
    * Enqueues a new job. Returns the job or undefined if duplicate.
    */
-  enqueue(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean): Job | undefined {
+  enqueue(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, priority?: JobPriority): Job | undefined {
     if (this.shuttingDown) {
       logger.warn(`Job for issue #${issueNumber} (${repo}) rejected — queue is shutting down`);
       return undefined;
@@ -326,7 +326,7 @@ export class JobQueue {
       }
     }
 
-    const job = this.store.create(issueNumber, repo, dependencies, isRetry);
+    const job = this.store.create(issueNumber, repo, dependencies, isRetry, undefined, priority);
     // Convert StoreJob to discriminated union Job type
     const snapshot = convertStoreJobToJob(job);
     this.pending.push(job.id);
@@ -583,6 +583,28 @@ export class JobQueue {
     }
   }
 
+  private static readonly PRIORITY_ORDER: Record<JobPriority, number> = { high: 0, normal: 1, low: 2 };
+
+  /**
+   * Sorts pending job IDs by priority (high > normal > low), then by createdAt ascending.
+   * Jobs without a priority are treated as normal.
+   */
+  private sortPendingByPriority(): void {
+    this.pending.sort((a, b) => {
+      const jobA = this.store.get(a);
+      const jobB = this.store.get(b);
+
+      const priorityA = JobQueue.PRIORITY_ORDER[jobA?.priority ?? "normal"] ?? 1;
+      const priorityB = JobQueue.PRIORITY_ORDER[jobB?.priority ?? "normal"] ?? 1;
+
+      if (priorityA !== priorityB) return priorityA - priorityB;
+
+      const createdAtA = jobA?.createdAt ? new Date(jobA.createdAt).getTime() : 0;
+      const createdAtB = jobB?.createdAt ? new Date(jobB.createdAt).getTime() : 0;
+      return createdAtA - createdAtB;
+    });
+  }
+
   private async processNext(): Promise<void> {
     // Prevent re-entrancy
     if (this.isProcessing) {
@@ -594,6 +616,9 @@ export class JobQueue {
     this.needsReprocess = false;
 
     try {
+      // Sort pending jobs by priority before processing
+      this.sortPendingByPriority();
+
       // Collect job IDs that are skipped due to unmet dependencies (put back at end)
       const deferred: string[] = [];
 

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -7,6 +7,7 @@ import { JsonMigrator } from "./json-migrator.js";
 import type {
   Job,
   JobStatus,
+  JobPriority,
   QueuedJob,
   RunningJob,
   SuccessJob,
@@ -159,6 +160,7 @@ export class JobStore extends EventEmitter {
       id: dbJob.id,
       issueNumber: dbJob.issueNumber,
       repo: dbJob.repo,
+      priority: dbJob.priority,
       createdAt: dbJob.createdAt,
       lastUpdatedAt: dbJob.lastUpdatedAt,
       currentStep: dbJob.currentStep,
@@ -274,6 +276,7 @@ export class JobStore extends EventEmitter {
       issueNumber: job.issueNumber,
       repo: job.repo,
       status: job.status,
+      priority: job.priority,
       createdAt: job.createdAt,
       startedAt: job.startedAt,
       completedAt: job.completedAt,
@@ -290,7 +293,7 @@ export class JobStore extends EventEmitter {
     };
   }
 
-  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, initialPhaseResults?: PhaseResultInfo[]): QueuedJob {
+  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, initialPhaseResults?: PhaseResultInfo[], priority?: JobPriority): QueuedJob {
     const id = `aq-${issueNumber}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const job: QueuedJob = {
       id,
@@ -298,6 +301,7 @@ export class JobStore extends EventEmitter {
       repo,
       status: "queued",
       createdAt: new Date().toISOString(),
+      ...(priority ? { priority } : {}),
       ...(dependencies && dependencies.length > 0 ? { dependencies } : {}),
       ...(isRetry ? { isRetry } : {}),
       ...(initialPhaseResults && initialPhaseResults.length > 0 ? { phaseResults: initialPhaseResults } : {}),
@@ -382,6 +386,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "queued",
+          priority: baseFields.priority,
           createdAt: baseFields.createdAt,
           lastUpdatedAt: baseFields.lastUpdatedAt,
           logs: baseFields.logs,
@@ -402,6 +407,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "running",
+          priority: baseFields.priority,
           startedAt: baseFields.startedAt || new Date().toISOString(),
           createdAt: baseFields.createdAt,
           lastUpdatedAt: baseFields.lastUpdatedAt,
@@ -424,6 +430,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "success",
+          priority: baseFields.priority,
           startedAt: baseFields.startedAt!,
           completedAt: baseFields.completedAt || new Date().toISOString(),
           prUrl: baseFields.prUrl!,
@@ -447,6 +454,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "failure",
+          priority: baseFields.priority,
           startedAt: baseFields.startedAt!,
           completedAt: baseFields.completedAt || new Date().toISOString(),
           error: baseFields.error!,
@@ -471,6 +479,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "cancelled",
+          priority: baseFields.priority,
           completedAt: baseFields.completedAt || new Date().toISOString(),
           startedAt: baseFields.startedAt,
           error: baseFields.error,
@@ -494,6 +503,7 @@ export class JobStore extends EventEmitter {
           issueNumber: baseFields.issueNumber,
           repo: baseFields.repo,
           status: "archived",
+          priority: baseFields.priority,
           startedAt: baseFields.startedAt,
           completedAt: baseFields.completedAt,
           prUrl: baseFields.prUrl,

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -12,6 +12,7 @@ interface JobRow {
   issue_number: number;
   repo: string;
   status: string;
+  priority: string;
   created_at: string;
   started_at: string | null;
   completed_at: string | null;
@@ -58,6 +59,7 @@ export interface DatabaseJob {
   issueNumber: number;
   repo: string;
   status: "queued" | "running" | "success" | "failure" | "cancelled" | "archived";
+  priority?: "high" | "normal" | "low";
   createdAt: string;
   startedAt?: string;
   completedAt?: string;
@@ -126,6 +128,7 @@ export class AQDatabase {
         issue_number INTEGER NOT NULL,
         repo TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'success', 'failure', 'cancelled', 'archived')),
+        priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('high', 'normal', 'low')),
         created_at TEXT NOT NULL,
         started_at TEXT,
         completed_at TEXT,
@@ -191,7 +194,19 @@ export class AQDatabase {
     // Foreign key 제약조건 활성화
     this.db.exec("PRAGMA foreign_keys = ON;");
 
+    // priority 컬럼 마이그레이션 (기존 DB에 컬럼이 없을 경우 추가)
+    this.migrateAddPriorityColumn();
+
     logger.info("Database schema initialized successfully");
+  }
+
+  private migrateAddPriorityColumn(): void {
+    const tableInfo = this.db.prepare("PRAGMA table_info(jobs)").all() as Array<{ name: string }>;
+    const hasPriority = tableInfo.some(col => col.name === "priority");
+    if (!hasPriority) {
+      logger.info("Migrating: adding priority column to jobs table");
+      this.db.exec("ALTER TABLE jobs ADD COLUMN priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('high', 'normal', 'low'))");
+    }
   }
 
   // === Job CRUD ===
@@ -199,19 +214,15 @@ export class AQDatabase {
   createJob(job: DatabaseJob): void {
     const stmt = this.db.prepare(`
       INSERT INTO jobs (
-        id, issue_number, repo, status, created_at, started_at, completed_at,
+        id, issue_number, repo, status, priority, created_at, started_at, completed_at,
         pr_url, error, last_updated_at, current_step, dependencies, progress,
         is_retry, cost_usd, total_cost_usd, total_input_tokens, total_output_tokens,
         total_cache_creation_input_tokens, total_cache_read_input_tokens
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const params = this.jobToParams(job);
-    stmt.run(
-      params[0], params[1], params[2], params[3], params[4], params[5], params[6],
-      params[7], params[8], params[9], params[10], params[11], params[12], params[13],
-      params[14], params[15], params[16], params[17], params[18], params[19]
-    );
+    stmt.run(...params);
 
     logger.debug(`Job created: ${job.id}`);
   }
@@ -230,7 +241,7 @@ export class AQDatabase {
 
     const stmt = this.db.prepare(`
       UPDATE jobs SET
-        issue_number = ?, repo = ?, status = ?, created_at = ?,
+        issue_number = ?, repo = ?, status = ?, priority = ?, created_at = ?,
         started_at = ?, completed_at = ?, pr_url = ?, error = ?,
         last_updated_at = ?, current_step = ?, dependencies = ?,
         progress = ?, is_retry = ?, cost_usd = ?, total_cost_usd = ?,
@@ -240,11 +251,8 @@ export class AQDatabase {
     `);
 
     const params = this.jobToParams(merged);
-    const changes = stmt.run(
-      params[1], params[2], params[3], params[4], params[5], params[6], params[7],
-      params[8], params[9], params[10], params[11], params[12], params[13], params[14],
-      params[15], params[16], params[17], params[18], params[19], id
-    ).changes;
+    // params[0] = id, params[1..] = fields; skip id (params[0]), append id at end
+    const changes = stmt.run(...params.slice(1), id).changes;
 
     if (changes > 0) {
       logger.debug(`Job updated: ${id}`);
@@ -388,6 +396,7 @@ export class AQDatabase {
       job.issueNumber,
       job.repo,
       job.status,
+      job.priority ?? "normal",
       job.createdAt,
       job.startedAt || null,
       job.completedAt || null,
@@ -413,6 +422,7 @@ export class AQDatabase {
       issueNumber: row.issue_number,
       repo: row.repo,
       status: row.status as DatabaseJob["status"],
+      priority: (row.priority ?? "normal") as DatabaseJob["priority"],
       createdAt: row.created_at,
       startedAt: row.started_at ?? undefined,
       completedAt: row.completed_at ?? undefined,

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -375,6 +375,8 @@ export interface AssembledPrompt {
 
 // Job Discriminated Union Types
 
+export type JobPriority = "high" | "normal" | "low";
+
 export type JobStatus = "queued" | "running" | "success" | "failure" | "cancelled" | "archived";
 
 export interface UsageStats {
@@ -401,6 +403,7 @@ export interface JobBase {
   id: string;
   issueNumber: number;
   repo: string;
+  priority?: JobPriority;
   createdAt: string;
   lastUpdatedAt?: string;
   logs?: string[];

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1572,4 +1572,151 @@ describe("JobQueue", () => {
       expect(handler).toHaveBeenCalledTimes(5);
     });
   });
+
+  describe("Priority-based sorting", () => {
+    it("should process high priority jobs before normal and low", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      // concurrency=0 holds all jobs until setConcurrency is called
+      const queue = new JobQueue(store, 0, handler);
+
+      queue.enqueue(1, "test/repo", undefined, undefined, "low");
+      queue.enqueue(2, "test/repo", undefined, undefined, "normal");
+      queue.enqueue(3, "test/repo", undefined, undefined, "high");
+
+      // Release all at once
+      queue.setConcurrency(3);
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(executionOrder[0]).toBe(3); // high first
+    });
+
+    it("should process normal priority before low", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      const queue = new JobQueue(store, 0, handler);
+
+      queue.enqueue(1, "test/repo", undefined, undefined, "low");
+      queue.enqueue(2, "test/repo", undefined, undefined, "normal");
+
+      queue.setConcurrency(2);
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(executionOrder[0]).toBe(2); // normal before low
+    });
+
+    it("should treat missing priority as normal", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      const queue = new JobQueue(store, 0, handler);
+
+      queue.enqueue(1, "test/repo"); // no priority → treated as normal
+      queue.enqueue(2, "test/repo", undefined, undefined, "high");
+
+      queue.setConcurrency(2);
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(executionOrder[0]).toBe(2); // high before no-priority (normal)
+      expect(executionOrder[1]).toBe(1);
+    });
+
+    it("should maintain FIFO order within the same priority", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      const queue = new JobQueue(store, 0, handler);
+
+      // Add delays to ensure distinct createdAt timestamps
+      queue.enqueue(10, "test/repo", undefined, undefined, "normal");
+      await new Promise(r => setTimeout(r, 5));
+      queue.enqueue(20, "test/repo", undefined, undefined, "normal");
+      await new Promise(r => setTimeout(r, 5));
+      queue.enqueue(30, "test/repo", undefined, undefined, "normal");
+
+      queue.setConcurrency(3);
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(executionOrder).toEqual([10, 20, 30]); // FIFO within same priority
+    });
+
+    it("should sort all priority levels correctly: high > normal > low", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      const queue = new JobQueue(store, 0, handler);
+
+      queue.enqueue(1, "test/repo", undefined, undefined, "low");
+      queue.enqueue(2, "test/repo", undefined, undefined, "normal");
+      queue.enqueue(3, "test/repo", undefined, undefined, "high");
+      queue.enqueue(4, "test/repo", undefined, undefined, "low");
+      queue.enqueue(5, "test/repo", undefined, undefined, "normal");
+      queue.enqueue(6, "test/repo", undefined, undefined, "high");
+
+      queue.setConcurrency(6);
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(handler).toHaveBeenCalledTimes(6);
+      // high jobs (3, 6) come before normal and low
+      expect(executionOrder.slice(0, 2)).toContain(3);
+      expect(executionOrder.slice(0, 2)).toContain(6);
+      // normal jobs (2, 5) come before low
+      expect(executionOrder.slice(2, 4)).toContain(2);
+      expect(executionOrder.slice(2, 4)).toContain(5);
+      // low jobs (1, 4) come last
+      expect(executionOrder.slice(4, 6)).toContain(1);
+      expect(executionOrder.slice(4, 6)).toContain(4);
+    });
+
+    it("should re-sort when a high priority job is enqueued after lower priority jobs", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        await new Promise(r => setTimeout(r, 30));
+        return { prUrl: `https://pr/${job.issueNumber}` };
+      });
+
+      // concurrency=1 so only one job runs at a time
+      const queue = new JobQueue(store, 1, handler);
+
+      // Enqueue low and normal jobs first; they go into pending while first job runs
+      queue.enqueue(1, "test/repo", undefined, undefined, "low");
+      queue.enqueue(2, "test/repo", undefined, undefined, "normal");
+
+      // Wait briefly so issue 1 starts running
+      await new Promise(r => setTimeout(r, 10));
+
+      // Enqueue a high priority job while issue 1 is running
+      queue.enqueue(3, "test/repo", undefined, undefined, "high");
+
+      // Wait for all to complete
+      await new Promise(r => setTimeout(r, 200));
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(executionOrder[0]).toBe(1); // already started
+      expect(executionOrder[1]).toBe(3); // high priority wins over pending normal
+      expect(executionOrder[2]).toBe(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #433 — feat: job-queue 우선순위 기반 정렬 — priority 높은 잡 먼저 처리

현재 JobQueue의 processNext()는 pending 큐에서 FIFO 순서로 잡을 처리한다. priority 필드를 추가하여 high > normal > low 순으로 처리하고, 같은 priority면 createdAt 순으로 정렬해야 한다. priority가 없는 기존 잡은 normal로 취급한다.

## Requirements

- JobBase 타입에 priority?: 'high' | 'normal' | 'low' 필드 추가
- database.ts jobs 테이블에 priority 컬럼 추가 (기본값 'normal')
- JobStore에서 priority 필드 처리 (create, update, dbJobToJob 등)
- JobQueue.processNext()에서 priority 기반 정렬 로직 구현
- priority 없는 잡은 'normal'로 취급 (하위 호환성)
- 테스트 케이스 추가

## Implementation Phases

- Phase 0: 타입 정의 추가 — SUCCESS (7d425059)
- Phase 1: DB 스키마 수정 — SUCCESS (3173a7e3)
- Phase 2: JobStore 수정 — SUCCESS (628c92ef)
- Phase 3: JobQueue 정렬 로직 — SUCCESS (954cb881)
- Phase 4: 테스트 추가 — SUCCESS (47abb506)

## Risks

- 기존 DB 마이그레이션 시 priority 컬럼 기본값 처리 필요
- enqueue API 변경 시 호출부 수정 필요 여부 검토

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/433-feat-job-queue-priority` → `develop`
- **Tokens**: 296 input, 37887 output{{#stats.cacheCreationTokens}}, 343386 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 4201217 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #433