### PR TITLE
[AQ-#436] feat: automation rule-engine 신규 생성 — 규칙 평가 엔진

### DIFF
--- a/src/automation/rule-engine.ts
+++ b/src/automation/rule-engine.ts
@@ -1,0 +1,123 @@
+import { minimatch } from "minimatch";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type {
+  AutomationRule,
+  Trigger,
+  Condition,
+  Action,
+  RuleContext,
+  RuleEngineHandlers,
+} from "../types/automation.js";
+
+/**
+ * 규칙의 트리거 + 조건이 컨텍스트와 일치하는지 평가한다.
+ * enabled=false인 규칙은 false를 반환한다.
+ * 조건이 없으면 트리거만 일치하면 통과.
+ * 조건이 여러 개면 모두 AND로 평가.
+ */
+export function evaluateRule(rule: AutomationRule, context: RuleContext): boolean {
+  if (rule.enabled === false) return false;
+
+  if (!matchesTrigger(rule.trigger, context)) return false;
+
+  if (rule.conditions && rule.conditions.length > 0) {
+    return rule.conditions.every((cond) => matchesCondition(cond, context));
+  }
+
+  return true;
+}
+
+/**
+ * 단일 액션을 실행한다.
+ * handlers에 실제 외부 연동 구현을 주입한다.
+ */
+export async function executeAction(
+  action: Action,
+  context: RuleContext,
+  handlers: RuleEngineHandlers
+): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    switch (action.type) {
+      case "add-label": {
+        logger.info(
+          `[AutomationRuleEngine] add-label: ${context.repo}#${context.issue.number} ← [${action.labels.join(", ")}]`
+        );
+        await handlers.addLabel(context.repo, context.issue.number, action.labels);
+        break;
+      }
+      case "start-job": {
+        const repo = action.repo ?? context.repo;
+        logger.info(
+          `[AutomationRuleEngine] start-job: ${repo}#${context.issue.number}`
+        );
+        await handlers.startJob(repo, context.issue.number);
+        break;
+      }
+      case "pause-project": {
+        logger.info(
+          `[AutomationRuleEngine] pause-project: ${context.repo}${action.reason ? ` (${action.reason})` : ""}`
+        );
+        await handlers.pauseProject(context.repo, action.reason);
+        break;
+      }
+    }
+  } catch (err: unknown) {
+    logger.error(
+      `[AutomationRuleEngine] executeAction(${action.type}) failed: ${getErrorMessage(err)}`
+    );
+    throw err;
+  }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function matchesTrigger(trigger: Trigger, context: RuleContext): boolean {
+  switch (trigger.type) {
+    case "issue-labeled": {
+      if (context.triggerType !== "issue-labeled") return false;
+      if (trigger.label !== undefined && context.triggerLabel !== trigger.label) return false;
+      return true;
+    }
+    case "issue-created": {
+      return context.triggerType === "issue-created";
+    }
+    case "pipeline-failed": {
+      if (context.triggerType !== "pipeline-failed") return false;
+      if (trigger.repo !== undefined && context.repo !== trigger.repo) return false;
+      return true;
+    }
+  }
+}
+
+function matchesCondition(condition: Condition, context: RuleContext): boolean {
+  switch (condition.type) {
+    case "label-match": {
+      const issueLabels = context.issue.labels;
+      const operator = condition.operator ?? "or";
+      return operator === "and"
+        ? condition.labels.every((l) => issueLabels.includes(l))
+        : condition.labels.some((l) => issueLabels.includes(l));
+    }
+    case "path-match": {
+      const paths = context.affectedPaths ?? [];
+      const opts = { dot: true };
+      return condition.patterns.some((pattern) =>
+        paths.some((p) => minimatch(p, pattern, opts))
+      );
+    }
+    case "keyword-match": {
+      const fields = condition.fields ?? ["title", "body"];
+      const text = fields
+        .map((f) => (f === "title" ? context.issue.title : context.issue.body))
+        .join(" ")
+        .toLowerCase();
+      const operator = condition.operator ?? "or";
+      return operator === "and"
+        ? condition.keywords.every((kw) => text.includes(kw.toLowerCase()))
+        : condition.keywords.some((kw) => text.includes(kw.toLowerCase()));
+    }
+  }
+}

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -1,0 +1,113 @@
+import type { GitHubIssue } from "../github/issue-fetcher.js";
+
+// ─── Trigger Types ───────────────────────────────────────────────────────────
+
+export interface IssueLabeledTrigger {
+  type: "issue-labeled";
+  /** 특정 라벨에만 반응 (생략 시 모든 라벨에 반응) */
+  label?: string;
+}
+
+export interface IssueCreatedTrigger {
+  type: "issue-created";
+}
+
+export interface PipelineFailedTrigger {
+  type: "pipeline-failed";
+  /** 특정 repo에만 반응 (생략 시 모든 repo) */
+  repo?: string;
+}
+
+export type Trigger =
+  | IssueLabeledTrigger
+  | IssueCreatedTrigger
+  | PipelineFailedTrigger;
+
+export type TriggerType = Trigger["type"];
+
+// ─── Condition Types ──────────────────────────────────────────────────────────
+
+export interface LabelMatchCondition {
+  type: "label-match";
+  labels: string[];
+  /** 기본값: "or" */
+  operator?: "and" | "or";
+}
+
+export interface PathMatchCondition {
+  type: "path-match";
+  /** minimatch glob 패턴 목록 (하나라도 매칭되면 통과) */
+  patterns: string[];
+}
+
+export interface KeywordMatchCondition {
+  type: "keyword-match";
+  keywords: string[];
+  /** 검사할 필드 (기본값: ["title", "body"]) */
+  fields?: Array<"title" | "body">;
+  /** 기본값: "or" */
+  operator?: "and" | "or";
+}
+
+export type Condition =
+  | LabelMatchCondition
+  | PathMatchCondition
+  | KeywordMatchCondition;
+
+// ─── Action Types ─────────────────────────────────────────────────────────────
+
+export interface AddLabelAction {
+  type: "add-label";
+  labels: string[];
+}
+
+export interface StartJobAction {
+  type: "start-job";
+  /** 기본값: context.repo */
+  repo?: string;
+}
+
+export interface PauseProjectAction {
+  type: "pause-project";
+  reason?: string;
+}
+
+export type Action =
+  | AddLabelAction
+  | StartJobAction
+  | PauseProjectAction;
+
+export type ActionType = Action["type"];
+
+// ─── AutomationRule ───────────────────────────────────────────────────────────
+
+export interface AutomationRule {
+  id: string;
+  name: string;
+  /** 기본값: true */
+  enabled?: boolean;
+  trigger: Trigger;
+  /** 모든 조건이 AND로 평가됨 */
+  conditions?: Condition[];
+  actions: Action[];
+}
+
+// ─── Rule Engine Context ──────────────────────────────────────────────────────
+
+export interface RuleContext {
+  triggerType: TriggerType;
+  issue: GitHubIssue;
+  repo: string;
+  /** issue-labeled 트리거 시 추가된 라벨 */
+  triggerLabel?: string;
+  /** pipeline 영향을 받은 파일 경로 목록 (path-match 조건에 사용) */
+  affectedPaths?: string[];
+}
+
+// ─── Rule Engine Handlers ─────────────────────────────────────────────────────
+
+export interface RuleEngineHandlers {
+  addLabel: (repo: string, issueNumber: number, labels: string[]) => Promise<void>;
+  startJob: (repo: string, issueNumber: number) => Promise<void>;
+  pauseProject: (repo: string, reason?: string) => Promise<void>;
+}

--- a/tests/automation/rule-engine.test.ts
+++ b/tests/automation/rule-engine.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi } from "vitest";
+import { evaluateRule, executeAction } from "../../src/automation/rule-engine.js";
+import type {
+  AutomationRule,
+  RuleContext,
+  RuleEngineHandlers,
+} from "../../src/types/automation.js";
+import type { GitHubIssue } from "../../src/github/issue-fetcher.js";
+
+const baseIssue: GitHubIssue = {
+  number: 1,
+  title: "Fix login bug",
+  body: "Users cannot log in with SSO",
+  labels: ["bug"],
+};
+
+const baseContext: RuleContext = {
+  triggerType: "issue-created",
+  issue: baseIssue,
+  repo: "org/repo",
+};
+
+const noopHandlers: RuleEngineHandlers = {
+  addLabel: vi.fn().mockResolvedValue(undefined),
+  startJob: vi.fn().mockResolvedValue(undefined),
+  pauseProject: vi.fn().mockResolvedValue(undefined),
+};
+
+// ─── evaluateRule ─────────────────────────────────────────────────────────────
+
+describe("evaluateRule", () => {
+  describe("enabled flag", () => {
+    it("returns false when enabled=false", () => {
+      const rule: AutomationRule = {
+        id: "r1",
+        name: "disabled",
+        enabled: false,
+        trigger: { type: "issue-created" },
+        actions: [{ type: "add-label", labels: ["auto"] }],
+      };
+      expect(evaluateRule(rule, baseContext)).toBe(false);
+    });
+
+    it("returns true when enabled is omitted (default=true)", () => {
+      const rule: AutomationRule = {
+        id: "r2",
+        name: "default-enabled",
+        trigger: { type: "issue-created" },
+        actions: [{ type: "add-label", labels: ["auto"] }],
+      };
+      expect(evaluateRule(rule, baseContext)).toBe(true);
+    });
+  });
+
+  describe("trigger matching", () => {
+    it("issue-created matches issue-created context", () => {
+      const rule: AutomationRule = {
+        id: "r3",
+        name: "on-create",
+        trigger: { type: "issue-created" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "issue-created" })).toBe(true);
+    });
+
+    it("issue-created does not match issue-labeled context", () => {
+      const rule: AutomationRule = {
+        id: "r4",
+        name: "on-create",
+        trigger: { type: "issue-created" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "issue-labeled" })).toBe(false);
+    });
+
+    it("issue-labeled matches with any label when trigger.label is omitted", () => {
+      const rule: AutomationRule = {
+        id: "r5",
+        name: "on-any-label",
+        trigger: { type: "issue-labeled" },
+        actions: [],
+      };
+      expect(
+        evaluateRule(rule, { ...baseContext, triggerType: "issue-labeled", triggerLabel: "bug" })
+      ).toBe(true);
+    });
+
+    it("issue-labeled only matches specified label", () => {
+      const rule: AutomationRule = {
+        id: "r6",
+        name: "on-bug-label",
+        trigger: { type: "issue-labeled", label: "bug" },
+        actions: [],
+      };
+      const ctx: RuleContext = { ...baseContext, triggerType: "issue-labeled", triggerLabel: "bug" };
+      expect(evaluateRule(rule, ctx)).toBe(true);
+
+      const ctxOther: RuleContext = { ...baseContext, triggerType: "issue-labeled", triggerLabel: "feature" };
+      expect(evaluateRule(rule, ctxOther)).toBe(false);
+    });
+
+    it("pipeline-failed matches with any repo when trigger.repo is omitted", () => {
+      const rule: AutomationRule = {
+        id: "r7",
+        name: "on-fail",
+        trigger: { type: "pipeline-failed" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed" })).toBe(true);
+    });
+
+    it("pipeline-failed only matches specified repo", () => {
+      const rule: AutomationRule = {
+        id: "r8",
+        name: "on-fail-specific",
+        trigger: { type: "pipeline-failed", repo: "org/repo" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed" })).toBe(true);
+      expect(
+        evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed", repo: "org/other" })
+      ).toBe(false);
+    });
+  });
+
+  describe("label-match condition", () => {
+    const rule = (operator?: "and" | "or"): AutomationRule => ({
+      id: "r9",
+      name: "label-check",
+      trigger: { type: "issue-created" },
+      conditions: [{ type: "label-match", labels: ["bug", "urgent"], operator }],
+      actions: [],
+    });
+
+    it("or: matches when at least one label is present (default)", () => {
+      const ctx: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug"] } };
+      expect(evaluateRule(rule(), ctx)).toBe(true);
+    });
+
+    it("or: does not match when no label is present", () => {
+      const ctx: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["feature"] } };
+      expect(evaluateRule(rule("or"), ctx)).toBe(false);
+    });
+
+    it("and: requires all labels to be present", () => {
+      const ctxBoth: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug", "urgent"] } };
+      expect(evaluateRule(rule("and"), ctxBoth)).toBe(true);
+
+      const ctxOne: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug"] } };
+      expect(evaluateRule(rule("and"), ctxOne)).toBe(false);
+    });
+  });
+
+  describe("path-match condition", () => {
+    const rule: AutomationRule = {
+      id: "r10",
+      name: "path-check",
+      trigger: { type: "pipeline-failed" },
+      conditions: [{ type: "path-match", patterns: ["src/**/*.ts"] }],
+      actions: [],
+    };
+
+    it("matches when an affected path matches the pattern", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        triggerType: "pipeline-failed",
+        affectedPaths: ["src/utils/helper.ts"],
+      };
+      expect(evaluateRule(rule, ctx)).toBe(true);
+    });
+
+    it("does not match when no affected path matches", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        triggerType: "pipeline-failed",
+        affectedPaths: ["docs/readme.md"],
+      };
+      expect(evaluateRule(rule, ctx)).toBe(false);
+    });
+
+    it("returns false when affectedPaths is empty", () => {
+      const ctx: RuleContext = { ...baseContext, triggerType: "pipeline-failed", affectedPaths: [] };
+      expect(evaluateRule(rule, ctx)).toBe(false);
+    });
+  });
+
+  describe("keyword-match condition", () => {
+    const rule = (operator?: "and" | "or", fields?: Array<"title" | "body">): AutomationRule => ({
+      id: "r11",
+      name: "keyword-check",
+      trigger: { type: "issue-created" },
+      conditions: [{ type: "keyword-match", keywords: ["login", "sso"], operator, fields }],
+      actions: [],
+    });
+
+    it("or: matches when any keyword found in title or body", () => {
+      expect(evaluateRule(rule(), baseContext)).toBe(true); // "login" in title, "SSO" in body
+    });
+
+    it("and: requires all keywords to be present", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login issue", body: "sso broken" },
+      };
+      expect(evaluateRule(rule("and"), ctx)).toBe(true);
+
+      const ctxMissing: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login issue", body: "no relevant info" },
+      };
+      expect(evaluateRule(rule("and"), ctxMissing)).toBe(false);
+    });
+
+    it("only checks title when fields=['title']", () => {
+      const ctxTitleOnly: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login problem", body: "no keywords here" },
+      };
+      expect(evaluateRule(rule(undefined, ["title"]), ctxTitleOnly)).toBe(true);
+
+      const ctxBodyOnly: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "generic issue", body: "login problem" },
+      };
+      expect(evaluateRule(rule(undefined, ["title"]), ctxBodyOnly)).toBe(false);
+    });
+  });
+
+  describe("multiple conditions (AND)", () => {
+    it("all conditions must pass", () => {
+      const rule: AutomationRule = {
+        id: "r12",
+        name: "multi-cond",
+        trigger: { type: "issue-created" },
+        conditions: [
+          { type: "label-match", labels: ["bug"] },
+          { type: "keyword-match", keywords: ["login"] },
+        ],
+        actions: [],
+      };
+
+      const ctxPass: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, labels: ["bug"], title: "login bug", body: "" },
+      };
+      expect(evaluateRule(rule, ctxPass)).toBe(true);
+
+      const ctxFail: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, labels: ["feature"], title: "login issue", body: "" },
+      };
+      expect(evaluateRule(rule, ctxFail)).toBe(false);
+    });
+  });
+});
+
+// ─── executeAction ────────────────────────────────────────────────────────────
+
+describe("executeAction", () => {
+  it("add-label calls handlers.addLabel with correct args", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn().mockResolvedValue(undefined),
+      startJob: vi.fn(),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "add-label", labels: ["auto", "triaged"] }, baseContext, handlers);
+    expect(handlers.addLabel).toHaveBeenCalledWith("org/repo", 1, ["auto", "triaged"]);
+  });
+
+  it("start-job uses action.repo when provided", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn().mockResolvedValue(undefined),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "start-job", repo: "org/other" }, baseContext, handlers);
+    expect(handlers.startJob).toHaveBeenCalledWith("org/other", 1);
+  });
+
+  it("start-job falls back to context.repo when action.repo is omitted", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn().mockResolvedValue(undefined),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "start-job" }, baseContext, handlers);
+    expect(handlers.startJob).toHaveBeenCalledWith("org/repo", 1);
+  });
+
+  it("pause-project calls handlers.pauseProject with reason", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn(),
+      pauseProject: vi.fn().mockResolvedValue(undefined),
+    };
+    await executeAction({ type: "pause-project", reason: "rate limit" }, baseContext, handlers);
+    expect(handlers.pauseProject).toHaveBeenCalledWith("org/repo", "rate limit");
+  });
+
+  it("pause-project works without reason", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn(),
+      pauseProject: vi.fn().mockResolvedValue(undefined),
+    };
+    await executeAction({ type: "pause-project" }, baseContext, handlers);
+    expect(handlers.pauseProject).toHaveBeenCalledWith("org/repo", undefined);
+  });
+
+  it("re-throws handler errors", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn().mockRejectedValue(new Error("GitHub API error")),
+      startJob: vi.fn(),
+      pauseProject: vi.fn(),
+    };
+    await expect(
+      executeAction({ type: "add-label", labels: ["fail"] }, baseContext, handlers)
+    ).rejects.toThrow("GitHub API error");
+  });
+
+  it("unused handlers are not called", async () => {
+    await executeAction({ type: "add-label", labels: ["x"] }, baseContext, noopHandlers);
+    expect(noopHandlers.startJob).not.toHaveBeenCalled();
+    expect(noopHandlers.pauseProject).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #436 — feat: automation rule-engine 신규 생성 — 규칙 평가 엔진

자동화 규칙 엔진을 신규 구현하여 트리거/조건/액션 기반의 자동화를 지원한다. evaluateRule()로 조건 평가, executeAction()으로 액션 실행(이슈 라벨, 잡 시작, 프로젝트 정지 등)을 처리한다.

## Requirements

- AutomationRule 타입 정의 (trigger, condition, action)
- evaluateRule() — 조건 평가 함수
- executeAction() — 액션 실행 함수 (이슈 라벨, 잡 시작, 프로젝트 정지 등)
- 테스트 작성

## Implementation Phases

- Phase 0: 타입 정의 및 rule-engine 구현 — SUCCESS (44296d21)
- Phase 1: 테스트 작성 — SUCCESS (44296d21)

## Risks

- config automations 필드 이슈 미완료 시 통합 불가 — 해당 이슈 완료 후 통합 필요
- 액션 실행 시 외부 의존성(GitHub API, JobQueue 등) 모킹 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/436-feat-automation-rule-engine` → `develop`
- **Tokens**: 122 input, 18026 output{{#stats.cacheCreationTokens}}, 135541 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1397878 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #436