### PR TITLE
[AQ-#437] feat: automation scheduler 신규 생성 — cron 기반 스케줄러

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "better-sqlite3": "^12.8.0",
         "hono": "^4.12.8",
         "minimatch": "^9.0.9",
+        "node-cron": "^3.0.3",
         "tsx": "^4.7.0",
         "yaml": "^2.3.0",
         "zod": "^3.22.0"
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.11.0",
+        "@types/node-cron": "^3.0.11",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitest/coverage-v8": "^1.3.0",
@@ -1164,6 +1166,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -3067,6 +3076,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -4041,6 +4062,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "better-sqlite3": "^12.8.0",
     "hono": "^4.12.8",
     "minimatch": "^9.0.9",
+    "node-cron": "^3.0.3",
     "tsx": "^4.7.0",
     "yaml": "^2.3.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/node-cron": "^3.0.11",
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -1,0 +1,152 @@
+import cron from "node-cron";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { ScheduledTask, ScheduledTaskStatus } from "../types/automation.js";
+
+export type TaskCallback = () => Promise<void> | void;
+
+interface TaskEntry {
+  task: ScheduledTask;
+  cronJob: cron.ScheduledTask;
+  callback: TaskCallback;
+}
+
+const logger = getLogger();
+
+export class AutomationScheduler {
+  private tasks = new Map<string, TaskEntry>();
+  private running = false;
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    logger.info(`AutomationScheduler 시작 — 등록된 태스크: ${this.tasks.size}개`);
+
+    for (const [id, entry] of this.tasks) {
+      if (entry.task.status !== "disabled") {
+        entry.cronJob.start();
+        logger.debug(`태스크 스케줄 시작 — id: ${id}, name: ${entry.task.name}`);
+      }
+    }
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+
+    for (const [id, entry] of this.tasks) {
+      entry.cronJob.stop();
+      logger.debug(`태스크 스케줄 중지 — id: ${id}`);
+    }
+
+    logger.info("AutomationScheduler 중지");
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  addTask(task: ScheduledTask, callback: TaskCallback): void {
+    if (this.tasks.has(task.id)) {
+      logger.warn(`태스크 이미 존재 — id: ${task.id}, 덮어씁니다`);
+      this.removeTask(task.id);
+    }
+
+    const { expression, timezone } = task.schedule;
+
+    if (!cron.validate(expression)) {
+      throw new Error(`유효하지 않은 cron 표현식 — id: ${task.id}, expression: "${expression}"`);
+    }
+
+    const cronJob = cron.schedule(
+      expression,
+      async () => {
+        await this.runTask(task.id);
+      },
+      {
+        scheduled: false,
+        timezone,
+      }
+    );
+
+    this.tasks.set(task.id, { task: { ...task }, cronJob, callback });
+    logger.info(`태스크 등록 — id: ${task.id}, name: ${task.name}, schedule: ${expression}`);
+
+    if (this.running && task.status !== "disabled") {
+      cronJob.start();
+      logger.debug(`스케줄러 실행 중 — 태스크 즉시 시작: ${task.id}`);
+    }
+  }
+
+  removeTask(id: string): void {
+    const entry = this.tasks.get(id);
+    if (!entry) {
+      logger.warn(`태스크 없음 — id: ${id}`);
+      return;
+    }
+
+    entry.cronJob.stop();
+    this.tasks.delete(id);
+    logger.info(`태스크 제거 — id: ${id}, name: ${entry.task.name}`);
+  }
+
+  getTask(id: string): ScheduledTask | undefined {
+    return this.tasks.get(id)?.task;
+  }
+
+  getTasks(): ScheduledTask[] {
+    return Array.from(this.tasks.values()).map(e => ({ ...e.task }));
+  }
+
+  getState(): { tasks: ScheduledTask[]; running: boolean } {
+    return {
+      tasks: this.getTasks(),
+      running: this.running,
+    };
+  }
+
+  private async runTask(id: string): Promise<void> {
+    const entry = this.tasks.get(id);
+    if (!entry) return;
+
+    if (entry.task.status === "running") {
+      logger.warn(`태스크 이미 실행 중 — id: ${id}, 건너뜀`);
+      return;
+    }
+
+    this.updateTaskStatus(id, "running");
+    const startedAt = Date.now();
+    logger.info(`태스크 실행 시작 — id: ${id}, name: ${entry.task.name}`);
+
+    try {
+      await entry.callback();
+      this.updateTaskAfterRun(id, startedAt, undefined);
+      logger.info(`태스크 실행 완료 — id: ${id}, name: ${entry.task.name}`);
+    } catch (err: unknown) {
+      const errorMsg = getErrorMessage(err);
+      this.updateTaskAfterRun(id, startedAt, errorMsg);
+      logger.error(`태스크 실행 실패 — id: ${id}, name: ${entry.task.name}, error: ${errorMsg}`);
+    }
+  }
+
+  private updateTaskStatus(id: string, status: ScheduledTaskStatus): void {
+    const entry = this.tasks.get(id);
+    if (!entry) return;
+    entry.task.status = status;
+  }
+
+  private updateTaskAfterRun(id: string, startedAt: number, error: string | undefined): void {
+    const entry = this.tasks.get(id);
+    if (!entry) return;
+
+    entry.task.lastRunAt = startedAt;
+    entry.task.runCount++;
+    entry.task.status = error ? "failed" : "idle";
+
+    if (error) {
+      entry.task.lastError = error;
+    } else {
+      entry.task.lastError = undefined;
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { cleanOldWorktrees } from "./git/worktree-cleaner.js";
 import { runDoctor } from "./setup/doctor.js";
 import { JobLogger } from "./queue/job-logger.js";
 import { IssuePoller } from "./polling/issue-poller.js";
+import { AutomationScheduler } from "./automation/scheduler.js";
 import { PatternStore } from "./learning/pattern-store.js";
 import { SelfUpdater } from "./update/self-updater.js";
 import { ConfigWatcher } from "./config/config-watcher.js";
@@ -310,8 +311,9 @@ export async function startCommand(args: CliArgs): Promise<void> {
     logger.info("업데이트 감지됨 — graceful restart 시작...");
 
     try {
-      // Stop poller to prevent new issues from being picked up
+      // Stop poller and scheduler to prevent new issues from being picked up
       poller?.stop();
+      scheduler.stop();
 
       // Wait for running jobs to complete
       logger.info("실행 중인 job 완료 대기...");
@@ -340,12 +342,19 @@ export async function startCommand(args: CliArgs): Promise<void> {
       if (poller && !poller.isRunning()) {
         poller.start();
       }
+      if (!scheduler.isRunning()) {
+        scheduler.start();
+      }
     }
   };
 
   // === Poller: always start (webhook mode uses it as fallback for missed events) ===
   const poller = new IssuePoller(effectiveConfig, store, queue, performGracefulRestart);
   poller.start();
+
+  // === Automation Scheduler: cron-based automation rules ===
+  const scheduler = new AutomationScheduler();
+  scheduler.start();
 
   // Mount dashboard and health routes
   const apiKey = process.env.DASHBOARD_API_KEY || undefined;
@@ -406,6 +415,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
   const gracefulShutdown = async (signal: string) => {
     logger.info(`${signal} received — shutting down gracefully, waiting for running jobs...`);
     poller?.stop();
+    scheduler.stop();
     configWatcher.stopWatching();
     await queue.shutdown(30000);
     cleanup();

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -1,0 +1,58 @@
+export type CronExpression = string; // e.g. "0 9 * * *", "@daily", "@weekly"
+
+export type ScheduledTaskStatus = "idle" | "running" | "failed" | "disabled";
+
+export interface CronSchedule {
+  expression: CronExpression;
+  timezone?: string; // e.g. "Asia/Seoul", defaults to system timezone
+}
+
+export interface ScheduledTask {
+  id: string;
+  name: string;
+  schedule: CronSchedule;
+  status: ScheduledTaskStatus;
+  lastRunAt?: number; // epoch ms
+  nextRunAt?: number; // epoch ms
+  lastError?: string;
+  runCount: number;
+}
+
+export interface AutomationRule {
+  id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  schedule: CronSchedule;
+  conditions: AutomationCondition[];
+  actions: AutomationAction[];
+  createdAt: number; // epoch ms
+  updatedAt: number; // epoch ms
+}
+
+export type AutomationConditionType =
+  | "issue_label"
+  | "issue_age_days"
+  | "issue_has_no_activity_days";
+
+export type AutomationActionType =
+  | "add_label"
+  | "remove_label"
+  | "comment"
+  | "close_issue"
+  | "queue_issue";
+
+export interface AutomationCondition {
+  type: AutomationConditionType;
+  value: string | number;
+}
+
+export interface AutomationAction {
+  type: AutomationActionType;
+  value?: string;
+}
+
+export interface AutomationSchedulerState {
+  tasks: ScheduledTask[];
+  running: boolean;
+}

--- a/tests/automation/scheduler.test.ts
+++ b/tests/automation/scheduler.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// node-cron mock — schedule된 Job 객체를 제어 가능하게 만든다
+const mockCronStart = vi.fn();
+const mockCronStop = vi.fn();
+
+// 등록된 콜백을 테스트에서 직접 트리거하기 위해 보관
+let capturedCallbacks: Array<() => Promise<void>> = [];
+
+vi.mock("node-cron", () => ({
+  default: {
+    validate: vi.fn((expr: string) => expr !== "invalid"),
+    schedule: vi.fn((_expr: string, callback: () => Promise<void>, _opts: unknown) => {
+      capturedCallbacks.push(callback);
+      return { start: mockCronStart, stop: mockCronStop };
+    }),
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import { AutomationScheduler } from "../../src/automation/scheduler.js";
+import type { ScheduledTask } from "../../src/types/automation.js";
+
+function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: "task-1",
+    name: "Test Task",
+    schedule: { expression: "0 9 * * *" },
+    status: "idle",
+    runCount: 0,
+    ...overrides,
+  };
+}
+
+describe("AutomationScheduler", () => {
+  let scheduler: AutomationScheduler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks = [];
+    scheduler = new AutomationScheduler();
+  });
+
+  // ─── start / stop ────────────────────────────────────────────────────────
+
+  describe("start / stop", () => {
+    it("isRunning()은 초기에 false", () => {
+      expect(scheduler.isRunning()).toBe(false);
+    });
+
+    it("start() 후 isRunning()은 true", () => {
+      scheduler.start();
+      expect(scheduler.isRunning()).toBe(true);
+    });
+
+    it("stop() 후 isRunning()은 false", () => {
+      scheduler.start();
+      scheduler.stop();
+      expect(scheduler.isRunning()).toBe(false);
+    });
+
+    it("start()를 두 번 호출해도 cronJob.start()는 한 번만", () => {
+      const task = makeTask();
+      scheduler.addTask(task, vi.fn());
+      scheduler.start();
+      scheduler.start(); // 두 번째 호출 — 무시
+      expect(mockCronStart).toHaveBeenCalledTimes(1);
+    });
+
+    it("stop()을 두 번 호출해도 cronJob.stop()은 한 번만", () => {
+      const task = makeTask();
+      scheduler.addTask(task, vi.fn());
+      scheduler.start();
+      scheduler.stop();
+      const stopCountAfterFirst = mockCronStop.mock.calls.length;
+      scheduler.stop(); // 두 번째 호출 — 무시
+      expect(mockCronStop.mock.calls.length).toBe(stopCountAfterFirst);
+    });
+
+    it("start() 시 등록된 active 태스크의 cronJob.start() 호출", () => {
+      scheduler.addTask(makeTask({ id: "t1" }), vi.fn());
+      scheduler.addTask(makeTask({ id: "t2" }), vi.fn());
+      scheduler.start();
+      expect(mockCronStart).toHaveBeenCalledTimes(2);
+    });
+
+    it("stop() 시 모든 cronJob.stop() 호출", () => {
+      scheduler.addTask(makeTask({ id: "t1" }), vi.fn());
+      scheduler.addTask(makeTask({ id: "t2" }), vi.fn());
+      scheduler.start();
+      mockCronStop.mockClear();
+      scheduler.stop();
+      expect(mockCronStop).toHaveBeenCalledTimes(2);
+    });
+
+    it("start() 시 disabled 태스크는 cronJob.start() 호출 안 함", () => {
+      scheduler.addTask(makeTask({ id: "t1", status: "disabled" }), vi.fn());
+      scheduler.start();
+      expect(mockCronStart).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── addTask ─────────────────────────────────────────────────────────────
+
+  describe("addTask", () => {
+    it("태스크 등록 후 getTask()로 조회 가능", () => {
+      const task = makeTask();
+      scheduler.addTask(task, vi.fn());
+      const stored = scheduler.getTask("task-1");
+      expect(stored).toBeDefined();
+      expect(stored?.id).toBe("task-1");
+      expect(stored?.name).toBe("Test Task");
+    });
+
+    it("동일 id 재등록 시 기존 태스크 덮어쓰기", () => {
+      scheduler.addTask(makeTask({ name: "Old" }), vi.fn());
+      scheduler.addTask(makeTask({ name: "New" }), vi.fn());
+      expect(scheduler.getTask("task-1")?.name).toBe("New");
+      expect(scheduler.getTasks()).toHaveLength(1);
+    });
+
+    it("유효하지 않은 cron 표현식은 에러 throw", () => {
+      const task = makeTask({ schedule: { expression: "invalid" } });
+      expect(() => scheduler.addTask(task, vi.fn())).toThrow(/유효하지 않은 cron 표현식/);
+    });
+
+    it("스케줄러 실행 중 addTask하면 cronJob.start() 즉시 호출", () => {
+      scheduler.start();
+      scheduler.addTask(makeTask(), vi.fn());
+      expect(mockCronStart).toHaveBeenCalled();
+    });
+
+    it("스케줄러 실행 중 disabled 태스크 addTask하면 cronJob.start() 미호출", () => {
+      scheduler.start();
+      scheduler.addTask(makeTask({ status: "disabled" }), vi.fn());
+      expect(mockCronStart).not.toHaveBeenCalled();
+    });
+
+    it("스케줄러 미실행 상태에서 addTask하면 cronJob.start() 미호출", () => {
+      scheduler.addTask(makeTask(), vi.fn());
+      expect(mockCronStart).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── removeTask ──────────────────────────────────────────────────────────
+
+  describe("removeTask", () => {
+    it("등록된 태스크 제거 후 getTask() undefined 반환", () => {
+      scheduler.addTask(makeTask(), vi.fn());
+      scheduler.removeTask("task-1");
+      expect(scheduler.getTask("task-1")).toBeUndefined();
+    });
+
+    it("제거 시 cronJob.stop() 호출", () => {
+      scheduler.addTask(makeTask(), vi.fn());
+      scheduler.removeTask("task-1");
+      expect(mockCronStop).toHaveBeenCalledTimes(1);
+    });
+
+    it("존재하지 않는 id 제거 시 에러 없음", () => {
+      expect(() => scheduler.removeTask("nonexistent")).not.toThrow();
+    });
+  });
+
+  // ─── getTasks / getState ──────────────────────────────────────────────────
+
+  describe("getTasks / getState", () => {
+    it("getTasks()는 등록된 모든 태스크 반환", () => {
+      scheduler.addTask(makeTask({ id: "t1" }), vi.fn());
+      scheduler.addTask(makeTask({ id: "t2" }), vi.fn());
+      expect(scheduler.getTasks()).toHaveLength(2);
+    });
+
+    it("getTasks()는 복사본 반환 — 원본 변경 불가", () => {
+      const task = makeTask();
+      scheduler.addTask(task, vi.fn());
+      const tasks = scheduler.getTasks();
+      tasks[0].name = "mutated";
+      expect(scheduler.getTask("task-1")?.name).toBe("Test Task");
+    });
+
+    it("getState()는 tasks 배열과 running 상태 반환", () => {
+      scheduler.addTask(makeTask(), vi.fn());
+      scheduler.start();
+      const state = scheduler.getState();
+      expect(state.running).toBe(true);
+      expect(state.tasks).toHaveLength(1);
+    });
+  });
+
+  // ─── cron 트리거 (runTask) ────────────────────────────────────────────────
+
+  describe("cron 트리거", () => {
+    it("cron 콜백 실행 시 callback이 호출됨", async () => {
+      const callback = vi.fn().mockResolvedValue(undefined);
+      scheduler.addTask(makeTask(), callback);
+
+      // node-cron이 등록한 콜백을 직접 트리거
+      expect(capturedCallbacks).toHaveLength(1);
+      await capturedCallbacks[0]();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("실행 후 태스크 상태가 idle로 복귀하고 runCount 증가", async () => {
+      scheduler.addTask(makeTask(), vi.fn().mockResolvedValue(undefined));
+      await capturedCallbacks[0]();
+
+      const task = scheduler.getTask("task-1");
+      expect(task?.status).toBe("idle");
+      expect(task?.runCount).toBe(1);
+      expect(task?.lastRunAt).toBeDefined();
+    });
+
+    it("callback 실패 시 태스크 상태가 failed이고 lastError 설정", async () => {
+      const callback = vi.fn().mockRejectedValue(new Error("callback error"));
+      scheduler.addTask(makeTask(), callback);
+      await capturedCallbacks[0]();
+
+      const task = scheduler.getTask("task-1");
+      expect(task?.status).toBe("failed");
+      expect(task?.lastError).toBe("callback error");
+      expect(task?.runCount).toBe(1);
+    });
+
+    it("태스크 이미 running 상태면 중복 실행 건너뜀", async () => {
+      const callback = vi.fn().mockResolvedValue(undefined);
+      scheduler.addTask(makeTask(), callback);
+
+      // 내부 상태를 직접 running으로 변경
+      const entry = (scheduler as unknown as { tasks: Map<string, { task: ScheduledTask }> }).tasks.get("task-1");
+      if (entry) entry.task.status = "running";
+
+      await capturedCallbacks[0]();
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("성공 실행 후 lastError는 undefined로 클리어", async () => {
+      const task = makeTask({ lastError: "previous error", status: "failed" });
+      scheduler.addTask(task, vi.fn().mockResolvedValue(undefined));
+      await capturedCallbacks[0]();
+
+      expect(scheduler.getTask("task-1")?.lastError).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #437 — feat: automation scheduler 신규 생성 — cron 기반 스케줄러

주기적으로 automation rules를 평가하는 cron 기반 스케줄러가 필요함. IssuePoller와 유사한 start/stop 패턴으로 서버 생명주기와 통합되어야 하며, 매일/매주 등 cron 표현식 기반 스케줄링을 지원해야 함.

## Requirements

- src/automation/scheduler.ts 신규 생성 — cron 기반 스케줄러 코어
- node-cron 의존성 추가 (cron 표현식 파싱 지원)
- 주기적 규칙 평가 — 매일/매주 트리거 지원
- 서버 시작/종료 시 스케줄러 관리 (IssuePoller 패턴 참고)
- tests/automation/scheduler.test.ts 테스트 작성

## Implementation Phases

- Phase 0: 타입 정의 — SUCCESS (29f9bffd)
- Phase 1: node-cron 의존성 추가 — SUCCESS (29f9bffd)
- Phase 2: 스케줄러 코어 구현 — SUCCESS (9413fe3a)
- Phase 3: CLI 통합 — SUCCESS (5e9f927c)
- Phase 4: 테스트 작성 — SUCCESS (5e9f927c)

## Risks

- node-cron 의존성 추가로 번들 크기 증가 (minimal)
- cron 표현식 오류 시 런타임 에러 가능 — 검증 로직 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/437-feat-automation-scheduler-cron` → `develop`
- **Tokens**: 230 input, 25404 output{{#stats.cacheCreationTokens}}, 233592 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2563568 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #437