### PR TITLE
[AQ-#448] fix: Review retry가 이전 실패 사유를 반복 평가 — 수정 후에도 실패 판정

### DIFF
--- a/src/pipeline/pipeline-review.ts
+++ b/src/pipeline/pipeline-review.ts
@@ -234,9 +234,14 @@ export async function runReviewPhase(
           },
 
           revalidateFn: async () => {
-            // Re-run reviews
+            // Re-run reviews with fresh diff (code may have changed after fix)
             if (!reviewVariables) {
               reviewVariables = await buildReviewVars(ctx);
+            } else {
+              reviewVariables = {
+                ...reviewVariables,
+                diff: { full: await getDiffContent(ctx.gitConfig, ctx.project.baseBranch!, { cwd: ctx.worktreePath }) }
+              };
             }
 
             const retryReviewResult = await runReviews({


### PR DESCRIPTION
## Summary

Resolves #448 — fix: Review retry가 이전 실패 사유를 반복 평가 — 수정 후에도 실패 판정

Review retry가 수정된 코드를 평가하지 않고 초기 diff만 반복 평가하는 버그. pipeline-review.ts의 revalidateFn에서 reviewVariables를 재사용할 때 diff를 갱신하지 않아, Claude가 코드를 수정해도 리뷰가 같은 문제를 계속 지적함.

## Requirements

- revalidateFn에서 매 retry마다 최신 diff를 수집해야 함
- reviewVariables의 issue/plan 정보는 유지하고 diff만 갱신
- 기존 테스트 통과 유지
- 타입 에러 없음

## Implementation Phases

- Phase 0: revalidateFn diff 갱신 로직 수정 — SUCCESS (3bc96525)

## Risks

- getDiffContent 호출 추가로 인한 성능 오버헤드 (미미함)
- diff 수집 실패 시 에러 핸들링 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/448-fix-review-retry` → `develop`
- **Tokens**: 51 input, 4729 output{{#stats.cacheCreationTokens}}, 76618 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 310773 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #448