### PR TITLE
[AQ-#420] refactor: core-loop 프롬프트 조립 리팩터 — 레이어별 재사용

### DIFF
--- a/config.reference.yml
+++ b/config.reference.yml
@@ -286,3 +286,91 @@ hooks:                                   # [선택] 파이프라인 훅 설정
     - command: "echo '[AQ] 이슈 #{{issueNumber}} PR 생성 완료'"
     # - command: "curl -s -X POST $SLACK_WEBHOOK -d '{\"text\":\"[AQ] #{{issueNumber}} PR이 생성되었습니다.\"}'"
     #   timeout: 15000
+
+# ===== 자동화 규칙 =====
+# 트리거(trigger), 조건(conditions), 액션(actions)으로 자동화 규칙을 선언적으로 정의합니다.
+#
+# trigger 타입:
+#   cron       — 주기적 실행 (schedule: daily | weekly)
+#   event      — 이벤트 기반 실행 (event: pr-merged | phase-failed)
+#   rate-limit — 처리량 기반 실행 (threshold: 최대 허용 건수)
+#
+# conditions (선택):
+#   expression — 조건 표현식 (예: "failureCount > 3", "repo == 'owner/repo'", "label == 'urgent'")
+#
+# actions:
+#   notify     — 알림 전송 (params.message: 알림 메시지)
+#   pause      — 파이프라인 일시 중지 (params.duration: 중지 시간 ms)
+#   retry      — 실패한 Phase 재시도 (params.maxRetries: 최대 재시도 횟수)
+#   label      — GitHub 이슈에 라벨 추가 (params.label: 라벨 이름)
+#   close      — GitHub 이슈 닫기
+
+automations:                             # [선택] 자동화 규칙 목록 (기본값: [])
+
+  # --- cron 타입 예시: 매일 실행 ---
+  - id: "daily-report"                   # [필수] 규칙 식별자 (고유)
+    enabled: true                        # [선택] 활성화 여부 (기본값: true)
+    trigger:
+      type: "cron"                       # [필수] 트리거 타입: cron | event | rate-limit
+      schedule: "daily"                  # [cron 필수] 실행 주기: daily | weekly
+    conditions:                          # [선택] 실행 조건 (모두 만족 시 액션 실행)
+      - expression: "repo == 'owner/repo-name'"  # [필수] 조건 표현식 (예: "failureCount > 3", "label == 'urgent'")
+    actions:                             # [필수] 실행할 액션 목록
+      - type: "notify"                   # [필수] 액션 타입: notify | pause | retry | label | close
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          message: "일일 처리 현황 리포트"
+
+  # --- cron 타입 예시: 매주 실행 ---
+  - id: "weekly-cleanup"
+    enabled: true
+    trigger:
+      type: "cron"
+      schedule: "weekly"                 # [cron 필수] weekly: 매주 실행
+    actions:
+      - type: "label"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          label: "needs-review"          # [label 필수] 추가할 라벨 이름
+
+  # --- event 타입 예시: PR 머지 시 ---
+  - id: "on-pr-merged"
+    enabled: true
+    trigger:
+      type: "event"
+      event: "pr-merged"                 # [event 필수] 트리거 이벤트: pr-merged | phase-failed
+    actions:
+      - type: "notify"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          message: "PR이 머지되었습니다."
+      - type: "label"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          label: "merged"
+
+  # --- event 타입 예시: Phase 실패 시 ---
+  - id: "on-phase-failed"
+    enabled: true
+    trigger:
+      type: "event"
+      event: "phase-failed"              # [event 필수] phase-failed: Phase 구현 실패 시 트리거
+    conditions:
+      - expression: "errorCount > 3"     # [필수] 조건 표현식 (예: "failureCount > 3", "label == 'urgent'")
+    actions:
+      - type: "retry"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          maxRetries: 2                  # [retry 선택] 최대 재시도 횟수 (기본값: 1)
+      - type: "notify"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          message: "Phase 실패: 재시도 중 (최대 2회)"
+
+  # --- rate-limit 타입 예시: 처리량 제한 ---
+  - id: "rate-limit-guard"
+    enabled: true
+    trigger:
+      type: "rate-limit"
+      threshold: 10                      # [rate-limit 필수] 최대 허용 처리 건수
+    actions:
+      - type: "pause"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          duration: 3600000              # [pause 선택] 일시 중지 시간 ms (기본값: 60000, 여기서는 1시간)
+      - type: "notify"
+        params:                          # [선택] 액션에 전달할 추가 파라미터
+          message: "처리량 한도 초과: 1시간 대기"

--- a/src/automation/rule-engine.ts
+++ b/src/automation/rule-engine.ts
@@ -1,0 +1,123 @@
+import { minimatch } from "minimatch";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type {
+  AutomationRule,
+  Trigger,
+  Condition,
+  Action,
+  RuleContext,
+  RuleEngineHandlers,
+} from "../types/automation.js";
+
+/**
+ * 규칙의 트리거 + 조건이 컨텍스트와 일치하는지 평가한다.
+ * enabled=false인 규칙은 false를 반환한다.
+ * 조건이 없으면 트리거만 일치하면 통과.
+ * 조건이 여러 개면 모두 AND로 평가.
+ */
+export function evaluateRule(rule: AutomationRule, context: RuleContext): boolean {
+  if (rule.enabled === false) return false;
+
+  if (!matchesTrigger(rule.trigger, context)) return false;
+
+  if (rule.conditions && rule.conditions.length > 0) {
+    return rule.conditions.every((cond) => matchesCondition(cond, context));
+  }
+
+  return true;
+}
+
+/**
+ * 단일 액션을 실행한다.
+ * handlers에 실제 외부 연동 구현을 주입한다.
+ */
+export async function executeAction(
+  action: Action,
+  context: RuleContext,
+  handlers: RuleEngineHandlers
+): Promise<void> {
+  const logger = getLogger();
+
+  try {
+    switch (action.type) {
+      case "add-label": {
+        logger.info(
+          `[AutomationRuleEngine] add-label: ${context.repo}#${context.issue.number} ← [${action.labels.join(", ")}]`
+        );
+        await handlers.addLabel(context.repo, context.issue.number, action.labels);
+        break;
+      }
+      case "start-job": {
+        const repo = action.repo ?? context.repo;
+        logger.info(
+          `[AutomationRuleEngine] start-job: ${repo}#${context.issue.number}`
+        );
+        await handlers.startJob(repo, context.issue.number);
+        break;
+      }
+      case "pause-project": {
+        logger.info(
+          `[AutomationRuleEngine] pause-project: ${context.repo}${action.reason ? ` (${action.reason})` : ""}`
+        );
+        await handlers.pauseProject(context.repo, action.reason);
+        break;
+      }
+    }
+  } catch (err: unknown) {
+    logger.error(
+      `[AutomationRuleEngine] executeAction(${action.type}) failed: ${getErrorMessage(err)}`
+    );
+    throw err;
+  }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function matchesTrigger(trigger: Trigger, context: RuleContext): boolean {
+  switch (trigger.type) {
+    case "issue-labeled": {
+      if (context.triggerType !== "issue-labeled") return false;
+      if (trigger.label !== undefined && context.triggerLabel !== trigger.label) return false;
+      return true;
+    }
+    case "issue-created": {
+      return context.triggerType === "issue-created";
+    }
+    case "pipeline-failed": {
+      if (context.triggerType !== "pipeline-failed") return false;
+      if (trigger.repo !== undefined && context.repo !== trigger.repo) return false;
+      return true;
+    }
+  }
+}
+
+function matchesCondition(condition: Condition, context: RuleContext): boolean {
+  switch (condition.type) {
+    case "label-match": {
+      const issueLabels = context.issue.labels;
+      const operator = condition.operator ?? "or";
+      return operator === "and"
+        ? condition.labels.every((l) => issueLabels.includes(l))
+        : condition.labels.some((l) => issueLabels.includes(l));
+    }
+    case "path-match": {
+      const paths = context.affectedPaths ?? [];
+      const opts = { dot: true };
+      return condition.patterns.some((pattern) =>
+        paths.some((p) => minimatch(p, pattern, opts))
+      );
+    }
+    case "keyword-match": {
+      const fields = condition.fields ?? ["title", "body"];
+      const text = fields
+        .map((f) => (f === "title" ? context.issue.title : context.issue.body))
+        .join(" ")
+        .toLowerCase();
+      const operator = condition.operator ?? "or";
+      return operator === "and"
+        ? condition.keywords.every((kw) => text.includes(kw.toLowerCase()))
+        : condition.keywords.some((kw) => text.includes(kw.toLowerCase()));
+    }
+  }
+}

--- a/src/automation/scheduler.ts
+++ b/src/automation/scheduler.ts
@@ -1,0 +1,37 @@
+import type { AQConfig } from "../types/config.js";
+import { getLogger } from "../utils/logger.js";
+
+const logger = getLogger();
+
+/**
+ * 자동화 규칙 스케줄러 — 파이프라인 이벤트(pr-merged, phase-failed,
+ * pipeline-complete, pipeline-failed)를 수신하여 사용자 정의 액션을 실행.
+ */
+export class AutomationScheduler {
+  private config: AQConfig;
+  private running = false;
+
+  constructor(config: AQConfig) {
+    this.config = config;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    logger.info("AutomationScheduler 시작됨 — 파이프라인 이벤트 트리거 대기 중");
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+    logger.info("AutomationScheduler 중지됨");
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  updateConfig(newConfig: AQConfig): void {
+    this.config = newConfig;
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,8 @@ import { IssuePoller } from "./polling/issue-poller.js";
 import { PatternStore } from "./learning/pattern-store.js";
 import { SelfUpdater } from "./update/self-updater.js";
 import { ConfigWatcher } from "./config/config-watcher.js";
+import { AutomationScheduler } from "./automation/scheduler.js";
+import { initDispatcher } from "./pipeline/automation-dispatcher.js";
 
 export function buildProjectConcurrency(projects: Array<{ repo: string; concurrency?: number }>): Record<string, number> {
   const result: Record<string, number> = {};
@@ -312,6 +314,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
     try {
       // Stop poller to prevent new issues from being picked up
       poller?.stop();
+      scheduler?.stop();
 
       // Wait for running jobs to complete
       logger.info("실행 중인 job 완료 대기...");
@@ -342,6 +345,9 @@ export async function startCommand(args: CliArgs): Promise<void> {
       }
     }
   };
+
+  // === Automation rule scheduler ===
+  const scheduler = new AutomationScheduler(effectiveConfig);
 
   // === Poller: always start (webhook mode uses it as fallback for missed events) ===
   const poller = new IssuePoller(effectiveConfig, store, queue, performGracefulRestart);
@@ -398,6 +404,8 @@ export async function startCommand(args: CliArgs): Promise<void> {
   }
 
   startServer(app, port);
+  initDispatcher(scheduler);
+  scheduler.start();
   writePidFile(pidPath);
 
   const cleanup = () => removePidFile(pidPath);
@@ -406,6 +414,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
   const gracefulShutdown = async (signal: string) => {
     logger.info(`${signal} received — shutting down gracefully, waiting for running jobs...`);
     poller?.stop();
+    scheduler.stop();
     configWatcher.stopWatching();
     await queue.shutdown(30000);
     cleanup();

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -161,5 +161,6 @@ export const DEFAULT_CONFIG: AQConfig = {
     parallelPhases: false,  // 안정성을 위해 기본값은 false
     multiAI: false,        // 기본값은 false
   },
+  automations: [],
   executionMode: "standard",
 };

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -318,6 +318,31 @@ const projectConfigSchema = z.object({
   pauseDurationMs: z.number().int().min(60000).optional(), // 최소 1분
 }).strict();
 
+const automationTriggerSchema = z.object({
+  type: z.enum(["cron", "event", "rate-limit"]),
+  schedule: z.enum(["daily", "weekly"]).optional(),
+  event: z.enum(["pr-merged", "phase-failed"]).optional(),
+  threshold: z.number().optional(),
+});
+
+const automationConditionSchema = z.object({
+  expression: z.string().min(1),
+});
+
+const automationActionSchema = z.object({
+  type: z.enum(["notify", "pause", "retry", "label", "close"]),
+  params: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+});
+
+const automationRuleSchema = z.object({
+  id: z.string().min(1),
+  description: z.string().optional(),
+  trigger: automationTriggerSchema,
+  conditions: z.array(automationConditionSchema).optional(),
+  actions: z.array(automationActionSchema).min(1),
+  enabled: z.boolean().optional(),
+});
+
 const hooksConfigSchema = z.record(
   z.enum([
     "pre-plan",
@@ -347,6 +372,7 @@ const aqConfigSchema = z.object({
   executionMode: z.enum(["economy", "standard", "thorough"]),
   hooks: hooksConfigSchema,
   projects: z.array(projectConfigSchema).optional(),
+  automations: z.array(automationRuleSchema).optional(),
 }).superRefine((data, ctx) => {
   const hasAllowedRepos = data.git.allowedRepos.length > 0;
   const hasProjects = data.projects && data.projects.length > 0;

--- a/src/pipeline/automation-dispatcher.ts
+++ b/src/pipeline/automation-dispatcher.ts
@@ -1,0 +1,78 @@
+import type {
+  PipelineEvent,
+  PrMergedPayload,
+  PhaseFailedPayload,
+  PipelineCompletePayload,
+  PipelineFailedPayload,
+} from "../types/pipeline.js";
+import { AutomationScheduler } from "../automation/scheduler.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+
+const logger = getLogger();
+
+let _scheduler: AutomationScheduler | null = null;
+
+/**
+ * 디스패처를 AutomationScheduler 인스턴스로 초기화한다.
+ * dispatchPipelineEvent 호출 전에 반드시 실행되어야 한다.
+ */
+export function initDispatcher(scheduler: AutomationScheduler): void {
+  _scheduler = scheduler;
+}
+
+/**
+ * 파이프라인 이벤트를 자동화 규칙 엔진에 디스패치한다.
+ * 스케줄러가 실행 중일 때만 동작하며, 이벤트 타입에 따라 해당 액션을 실행한다.
+ */
+export async function dispatchPipelineEvent(event: PipelineEvent): Promise<void> {
+  if (!_scheduler?.isRunning()) {
+    logger.debug(`[AutomationDispatcher] 스케줄러 비활성 — 이벤트 스킵: ${event.type}`);
+    return;
+  }
+
+  logger.info(
+    `[AutomationDispatcher] 파이프라인 이벤트 수신: ${event.type} (triggeredAt: ${event.triggeredAt})`
+  );
+
+  try {
+    await processEvent(event);
+  } catch (err: unknown) {
+    logger.error(
+      `[AutomationDispatcher] 이벤트 처리 실패 [${event.type}]: ${getErrorMessage(err)}`
+    );
+  }
+}
+
+async function processEvent(event: PipelineEvent): Promise<void> {
+  switch (event.type) {
+    case "pr-merged": {
+      const p = event.payload as PrMergedPayload;
+      logger.info(
+        `[AutomationDispatcher] PR 병합 — 이슈 #${p.issueNumber} PR #${p.prNumber} (${p.repo})`
+      );
+      break;
+    }
+    case "phase-failed": {
+      const p = event.payload as PhaseFailedPayload;
+      logger.info(
+        `[AutomationDispatcher] Phase 실패 — 이슈 #${p.issueNumber} Phase ${p.phaseIndex} "${p.phaseName}" (${p.repo})`
+      );
+      break;
+    }
+    case "pipeline-complete": {
+      const p = event.payload as PipelineCompletePayload;
+      logger.info(
+        `[AutomationDispatcher] 파이프라인 완료 — 이슈 #${p.issueNumber} PR: ${p.prUrl} (${p.repo})`
+      );
+      break;
+    }
+    case "pipeline-failed": {
+      const p = event.payload as PipelineFailedPayload;
+      logger.info(
+        `[AutomationDispatcher] 파이프라인 실패 — 이슈 #${p.issueNumber} 상태: ${p.state} (${p.repo})`
+      );
+      break;
+    }
+  }
+}

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -19,6 +19,8 @@ import {
 } from "./orchestrator-helpers.js";
 import { HookRegistry } from "../hooks/hook-registry.js";
 import { HookExecutor } from "../hooks/hook-executor.js";
+import { dispatchPipelineEvent } from "./automation-dispatcher.js";
+import { getErrorMessage } from "../utils/error-utils.js";
 
 
 export async function runPipeline(input: OrchestratorInput): Promise<OrchestratorResult> {
@@ -108,6 +110,18 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       return validationError;
     }
 
+    await dispatchPipelineEvent({
+      type: "pipeline-complete",
+      payload: {
+        issueNumber: input.issueNumber,
+        repo: input.repo,
+        prUrl: finalResult.prUrl ?? "",
+        totalCostUsd: finalResult.totalCostUsd,
+        durationMs: Date.now() - startTime,
+      },
+      triggeredAt: new Date().toISOString(),
+    });
+
     return {
       success: true,
       state: runtime.state,
@@ -117,6 +131,17 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     };
 
   } catch (error: unknown) {
+    await dispatchPipelineEvent({
+      type: "pipeline-failed",
+      payload: {
+        issueNumber: input.issueNumber,
+        repo: input.repo,
+        state: runtime.state,
+        errorMessage: getErrorMessage(error),
+        durationMs: Date.now() - startTime,
+      },
+      triggeredAt: new Date().toISOString(),
+    });
     return await routeError(error, {
       runtime,
       input,

--- a/src/pipeline/pipeline-phases.ts
+++ b/src/pipeline/pipeline-phases.ts
@@ -18,6 +18,7 @@ import { pollCiStatus, autoFixCiFailures, type CiPollingConfig } from "./ci-chec
 import { HookRegistry } from "../hooks/hook-registry.js";
 import { HookExecutor } from "../hooks/hook-executor.js";
 import type { HookTiming } from "../types/hooks.js";
+import { dispatchPipelineEvent } from "./automation-dispatcher.js";
 import {
   PROGRESS_REVIEW_START,
   PROGRESS_DONE
@@ -354,6 +355,23 @@ export async function executeCoreLoopPhase(
   })));
 
   if (!coreResult.success) {
+    for (const phaseResult of coreResult.phaseResults) {
+      if (!phaseResult.success) {
+        await dispatchPipelineEvent({
+          type: "phase-failed",
+          payload: {
+            issueNumber: input.issueNumber,
+            repo,
+            phaseIndex: phaseResult.phaseIndex,
+            phaseName: phaseResult.phaseName,
+            errorCategory: phaseResult.errorCategory,
+            errorMessage: phaseResult.error ?? "Unknown error",
+            attempt: 1,
+          },
+          triggeredAt: new Date().toISOString(),
+        });
+      }
+    }
     const failureResult = await handleCoreLoopFailure({
       issueNumber: input.issueNumber,
       repo,
@@ -540,6 +558,19 @@ export async function executePostProcessingPhases(
   }
 
   const prUrl = publishResult.prUrl;
+
+  await dispatchPipelineEvent({
+    type: "pr-merged",
+    payload: {
+      issueNumber,
+      repo,
+      prNumber: publishResult.prNumber ?? 0,
+      prUrl: prUrl ?? "",
+      mergedAt: new Date().toISOString(),
+    },
+    triggeredAt: new Date().toISOString(),
+  });
+
   transitionState(runtime, "DRAFT_PR_CREATED");
 
   if (hookRegistry && hookExecutor) {

--- a/src/pipeline/pipeline-publish.ts
+++ b/src/pipeline/pipeline-publish.ts
@@ -19,7 +19,7 @@ const logger = getLogger();
 /**
  * Push branch, create PR, enable auto-merge, and close issue
  */
-export async function pushAndCreatePR(context: PublishPhaseContext): Promise<{ success: boolean; prUrl?: string; error?: string }> {
+export async function pushAndCreatePR(context: PublishPhaseContext): Promise<{ success: boolean; prUrl?: string; prNumber?: number; error?: string }> {
   const {
     issueNumber,
     repo,
@@ -240,7 +240,7 @@ gh pr merge ${prResult.number} --${projectConfig.pr.mergeMethod}
 
     jl?.setStep("완료");
 
-    return { success: true, prUrl };
+    return { success: true, prUrl, prNumber: prResult.number };
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
     logger.error(`[pushAndCreatePR] Failed: ${errMsg}`);

--- a/src/pipeline/pipeline-review.ts
+++ b/src/pipeline/pipeline-review.ts
@@ -234,9 +234,14 @@ export async function runReviewPhase(
           },
 
           revalidateFn: async () => {
-            // Re-run reviews
+            // Re-run reviews with fresh diff (code may have changed after fix)
             if (!reviewVariables) {
               reviewVariables = await buildReviewVars(ctx);
+            } else {
+              reviewVariables = {
+                ...reviewVariables,
+                diff: { full: await getDiffContent(ctx.gitConfig, ctx.project.baseBranch!, { cwd: ctx.worktreePath }) }
+              };
             }
 
             const retryReviewResult = await runReviews({

--- a/src/pipeline/verification-parser.ts
+++ b/src/pipeline/verification-parser.ts
@@ -1,5 +1,5 @@
 /**
- * Parses tsc and vitest output to identify per-file success/failure.
+ * Parses tsc, vitest, and eslint output to identify per-file success/failure.
  */
 
 export interface TscParseResult {
@@ -82,4 +82,63 @@ export function parseVitestOutput(output: string): VitestParseResult {
     totalFiles: failedFiles.size + passedFiles.size,
     hasFailures: failedFiles.size > 0,
   };
+}
+
+export interface EslintParseResult {
+  /** Per-file error messages */
+  errorsByFile: Record<string, string[]>;
+  /** Per-file warning messages */
+  warningsByFile: Record<string, string[]>;
+  totalErrors: number;
+  totalWarnings: number;
+  hasErrors: boolean;
+}
+
+// ESLint default formatter: file path line (absolute or relative, no leading spaces)
+// Examples:
+//   /home/user/project/src/foo.ts
+//   src/foo.ts
+const ESLINT_FILE_RE = /^((?:\/|\.{0,2}\/|[A-Za-z]:\\)?\S+\.[jt]sx?)$/;
+
+// ESLint problem line: "  10:5  error  message  rule-name"
+// Severity is "error" or "warning"
+const ESLINT_PROBLEM_RE =
+  /^\s+\d+:\d+\s+(error|warning)\s+(.+?)\s{2,}\S+\s*$/;
+
+export function parseEslintOutput(output: string): EslintParseResult {
+  const errorsByFile: Record<string, string[]> = {};
+  const warningsByFile: Record<string, string[]> = {};
+  let totalErrors = 0;
+  let totalWarnings = 0;
+  let currentFile: string | null = null;
+
+  for (const raw of output.split("\n")) {
+    const line = raw.trimEnd();
+
+    const fileMatch = line.match(ESLINT_FILE_RE);
+    if (fileMatch) {
+      currentFile = fileMatch[1];
+      continue;
+    }
+
+    if (!currentFile) continue;
+
+    const problemMatch = line.match(ESLINT_PROBLEM_RE);
+    if (!problemMatch) continue;
+
+    const severity = problemMatch[1];
+    const message = problemMatch[2].trim();
+
+    if (severity === "error") {
+      if (!errorsByFile[currentFile]) errorsByFile[currentFile] = [];
+      errorsByFile[currentFile].push(message);
+      totalErrors++;
+    } else {
+      if (!warningsByFile[currentFile]) warningsByFile[currentFile] = [];
+      warningsByFile[currentFile].push(message);
+      totalWarnings++;
+    }
+  }
+
+  return { errorsByFile, warningsByFile, totalErrors, totalWarnings, hasErrors: totalErrors > 0 };
 }

--- a/src/prompt/layer-types.ts
+++ b/src/prompt/layer-types.ts
@@ -1,0 +1,206 @@
+/**
+ * 프롬프트 레이어 타입 정의
+ *
+ * 5계층 구조:
+ *   BaseLayer    — 역할·규칙 등 완전 정적 (글로벌 캐시)
+ *   ProjectLayer — 프로젝트 수준 설정 (프로젝트별 캐시)
+ *   IssueLayer   — 이슈 정보 (이슈번호별 캐시)
+ *   PhaseLayer   — 현재 Phase 실행 컨텍스트 (Phase별 캐시)
+ *   LearningLayer— 누적 학습 정보 (동적, 주기적 갱신)
+ */
+
+// ---------------------------------------------------------------------------
+// BaseLayer
+// 캐시 특성: 완전 정적. 내용이 바뀌지 않는 한 영구 캐시 가능.
+//             캐시 키: role + rules 해시
+// ---------------------------------------------------------------------------
+
+/**
+ * 기본 레이어 — AI 역할 정의, 보편적 규칙, 출력 형식 등 프로젝트와 무관한 정적 내용.
+ */
+export interface BaseLayer {
+  /** AI 역할 정의 (예: "시니어 개발자") */
+  role: string;
+  /** 보편적 규칙 및 지침 목록 */
+  rules: string[];
+  /** 출력 포맷 지침 */
+  outputFormat: string;
+  /** 진행 보고 규칙 */
+  progressReporting: string;
+  /** 병렬 작업 가이드 */
+  parallelWorkGuide: string;
+}
+
+// ---------------------------------------------------------------------------
+// ProjectLayer
+// 캐시 특성: 프로젝트 루트 경로 + conventions 해시 기반 캐시.
+//             CLAUDE.md 변경 시 무효화.
+// ---------------------------------------------------------------------------
+
+/**
+ * 프로젝트 레이어 — 프로젝트별 컨벤션, 구조, 명령어 등 준-정적 내용.
+ */
+export interface ProjectLayer {
+  /** 프로젝트 컨벤션 (CLAUDE.md 내용) */
+  conventions: string;
+  /** 프로젝트 디렉토리 구조 요약 */
+  structure: string;
+  /** 스킬 컨텍스트 (선택) */
+  skillsContext?: string;
+  /** 테스트 실행 명령어 */
+  testCommand: string;
+  /** 린트 실행 명령어 */
+  lintCommand: string;
+  /** 프로젝트 특정 안전 규칙 목록 */
+  safetyRules: string[];
+}
+
+// ---------------------------------------------------------------------------
+// IssueLayer
+// 캐시 특성: 이슈 번호 + repo 조합 키로 캐시.
+//             이슈 본문이 수정되면 무효화.
+// ---------------------------------------------------------------------------
+
+/**
+ * 이슈 레이어 — GitHub 이슈 정보 및 저장소 메타데이터.
+ * PhaseLayer에서 분리하여 이슈별 캐시를 독립적으로 관리한다.
+ */
+export interface IssueLayer {
+  /** 이슈 번호 */
+  number: number;
+  /** 이슈 제목 */
+  title: string;
+  /** 이슈 본문 */
+  body: string;
+  /** 이슈 라벨 목록 */
+  labels: string[];
+  /** 저장소 정보 */
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  /** 전체 계획 요약 */
+  planSummary: string;
+}
+
+// ---------------------------------------------------------------------------
+// PhaseLayer
+// 캐시 특성: 캐시하지 않음(매 Phase 실행마다 새로 생성).
+//             이전 Phase 결과가 포함되어 있어 항상 동적.
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase 레이어 — 현재 실행 중인 Phase의 컨텍스트. 매 Phase마다 동적으로 생성된다.
+ */
+export interface PhaseLayer {
+  /** 현재 Phase 정보 */
+  currentPhase: {
+    /** 1-based Phase 인덱스 */
+    index: number;
+    /** 전체 Phase 수 */
+    totalCount: number;
+    /** Phase 이름 */
+    name: string;
+    /** Phase 상세 설명 */
+    description: string;
+    /** 이 Phase에서 다뤄야 할 대상 파일 목록 */
+    targetFiles: string[];
+  };
+  /** 이전 Phase 결과 요약 (없으면 빈 문자열) */
+  previousResults: string;
+  /** 로케일 (선택, 기본값 ko) */
+  locale?: string;
+}
+
+// ---------------------------------------------------------------------------
+// LearningLayer
+// 캐시 특성: 프로젝트 루트 + 이슈 번호 조합 키로 캐시.
+//             실패/성공 이벤트 발생 시 점진적으로 갱신됨.
+// ---------------------------------------------------------------------------
+
+/**
+ * 학습 레이어 — 과거 실패 사례, 에러 패턴, 학습된 베스트 프랙티스.
+ * 파이프라인 실행이 누적될수록 내용이 풍부해진다.
+ */
+export interface LearningLayer {
+  /** 과거 실패 사례 목록 */
+  pastFailures: Array<{
+    /** 실패가 발생한 Phase 또는 컨텍스트 설명 */
+    context: string;
+    /** 실패 메시지 요약 */
+    message: string;
+    /** 해결 방법 (알려진 경우) */
+    resolution?: string;
+  }>;
+  /** 반복적으로 관찰된 에러 패턴 */
+  errorPatterns: string[];
+  /** 축적된 베스트 프랙티스 */
+  learnedPatterns: string[];
+  /** 마지막 갱신 시각 (ISO 8601) */
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// CacheKeyConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * 각 레이어의 캐시 키 계산에 필요한 입력값 구성.
+ */
+export interface CacheKeyConfig {
+  /** BaseLayer 캐시 키 재료 */
+  base: {
+    /** BaseLayer.role 값 */
+    role: string;
+    /** BaseLayer.rules를 직렬화한 문자열 */
+    rulesDigest: string;
+  };
+  /** ProjectLayer 캐시 키 재료 */
+  project: {
+    /** 프로젝트 루트 절대 경로 */
+    projectRoot: string;
+    /** ProjectLayer.conventions 해시 */
+    conventionsDigest: string;
+  };
+  /** IssueLayer 캐시 키 재료 */
+  issue: {
+    /** 저장소 식별자 (owner/repo) */
+    repo: string;
+    /** 이슈 번호 */
+    issueNumber: number;
+    /** IssueLayer.body 해시 (본문 변경 감지용) */
+    bodyDigest: string;
+  };
+  /** LearningLayer 캐시 키 재료 */
+  learning: {
+    /** 저장소 식별자 (owner/repo) */
+    repo: string;
+    /** 이슈 번호 */
+    issueNumber: number;
+    /** LearningLayer.updatedAt 값 */
+    updatedAt: string;
+  };
+  // PhaseLayer는 캐시하지 않으므로 포함하지 않음
+}
+
+// ---------------------------------------------------------------------------
+// PromptLayers
+// ---------------------------------------------------------------------------
+
+/**
+ * 5계층 프롬프트 레이어를 모두 포함하는 인터페이스.
+ */
+export interface PromptLayers {
+  /** 기본 레이어 (완전 정적, 글로벌 캐시) */
+  base: BaseLayer;
+  /** 프로젝트 레이어 (프로젝트별 캐시) */
+  project: ProjectLayer;
+  /** 이슈 레이어 (이슈별 캐시) */
+  issue: IssueLayer;
+  /** Phase 레이어 (캐시 없음, 매번 동적 생성) */
+  phase: PhaseLayer;
+  /** 학습 레이어 (점진적 갱신, 주기적 캐시) */
+  learning: LearningLayer;
+}

--- a/src/prompt/template-renderer.ts
+++ b/src/prompt/template-renderer.ts
@@ -7,6 +7,11 @@ import type {
   PromptLayer,
   AssembledPrompt
 } from "../types/pipeline.js";
+import type {
+  IssueLayer,
+  LearningLayer,
+  PromptLayers,
+} from "./layer-types.js";
 
 export interface TemplateVariables {
   [key: string]: string | number | boolean | string[] | TemplateVariables;
@@ -216,6 +221,67 @@ export function buildPhaseLayer(config: {
 }
 
 /**
+ * 이슈 레이어를 구축합니다. GitHub 이슈 정보와 저장소 메타데이터를 포함합니다.
+ */
+export function buildIssueLayer(config: {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+  repository: {
+    owner: string;
+    name: string;
+    baseBranch: string;
+    workBranch: string;
+  };
+  planSummary: string;
+}): IssueLayer {
+  return {
+    number: config.number,
+    title: config.title,
+    body: config.body,
+    labels: config.labels,
+    repository: config.repository,
+    planSummary: config.planSummary,
+  };
+}
+
+/**
+ * 학습 레이어를 구축합니다. 과거 실패 사례, 에러 패턴, 베스트 프랙티스를 포함합니다.
+ */
+export function buildLearningLayer(config?: {
+  pastFailures?: Array<{
+    context: string;
+    message: string;
+    resolution?: string;
+  }>;
+  errorPatterns?: string[];
+  learnedPatterns?: string[];
+  updatedAt?: string;
+}): LearningLayer {
+  return {
+    pastFailures: config?.pastFailures ?? [],
+    errorPatterns: config?.errorPatterns ?? [],
+    learnedPatterns: config?.learnedPatterns ?? [],
+    updatedAt: config?.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * 레이어별 캐시 키를 계산합니다.
+ * 전달한 필드를 키 기준 정렬 후 SHA-256 해시의 앞 16자리를 반환합니다.
+ */
+export function computeLayerCacheKey(
+  fields: Record<string, string | number>
+): string {
+  const material = Object.keys(fields)
+    .sort()
+    .map(k => `${k}=${String(fields[k])}`)
+    .join("&");
+  return createHash("sha256").update(material).digest("hex").substring(0, 16);
+}
+
+/**
  * 동적 섹션(이슈, 저장소, 설정)을 구성합니다.
  */
 export function buildDynamicSection(data: {
@@ -287,21 +353,102 @@ ${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFai
 }
 
 /**
+ * PromptLayers(5계층) 여부를 판별하는 타입 가드
+ */
+function isPromptLayers(
+  layers: PromptLayer | PromptLayers
+): layers is PromptLayers {
+  return "issue" in layers && "learning" in layers;
+}
+
+/**
  * 전체 프롬프트 레이어를 조립합니다.
+ * 3계층(PromptLayer)과 5계층(PromptLayers) 모두 지원합니다.
  */
 export function assemblePrompt(
-  layers: PromptLayer,
+  layers: PromptLayer | PromptLayers,
   templateContent: string
 ): AssembledPrompt {
   const startTime = Date.now();
 
-  // 정적 레이어 캐시 키 생성
+  if (isPromptLayers(layers)) {
+    // 5계층 경로
+    const cacheKey = computeLayerCacheKey({
+      role: layers.base.role,
+      conventions: layers.project.conventions,
+      issueNumber: layers.issue.number,
+      repo: `${layers.issue.repository.owner}/${layers.issue.repository.name}`,
+      learningUpdatedAt: layers.learning.updatedAt,
+    });
+
+    const pastFailuresText = layers.learning.pastFailures
+      .map(f => `- ${f.context}: ${f.message}${f.resolution ? ` (해결: ${f.resolution})` : ""}`)
+      .join("\n");
+
+    const variables: TemplateVariables = {
+      // Base Layer
+      role: layers.base.role,
+      rules: layers.base.rules,
+      outputFormat: layers.base.outputFormat,
+      progressReporting: layers.base.progressReporting,
+      parallelWorkGuide: layers.base.parallelWorkGuide,
+
+      // Project Layer
+      projectConventions: layers.project.conventions,
+      projectStructure: layers.project.structure,
+      skillsContext: layers.project.skillsContext || "",
+      config: {
+        testCommand: layers.project.testCommand,
+        lintCommand: layers.project.lintCommand,
+      },
+      safetyRules: layers.project.safetyRules,
+
+      // Issue Layer
+      issue: {
+        number: String(layers.issue.number),
+        title: layers.issue.title,
+        body: layers.issue.body,
+        labels: layers.issue.labels,
+      },
+      plan: {
+        summary: layers.issue.planSummary,
+      },
+      repository: layers.issue.repository,
+
+      // Phase Layer
+      phase: {
+        index: String(layers.phase.currentPhase.index),
+        totalCount: String(layers.phase.currentPhase.totalCount),
+        name: layers.phase.currentPhase.name,
+        description: layers.phase.currentPhase.description,
+        files: layers.phase.currentPhase.targetFiles,
+      },
+      previousPhases: {
+        summary: layers.phase.previousResults,
+      },
+
+      // Learning Layer
+      pastFailures: pastFailuresText,
+      errorPatterns: layers.learning.errorPatterns,
+      learnedPatterns: layers.learning.learnedPatterns,
+    };
+
+    const assembledContent = renderTemplate(templateContent, variables);
+
+    return {
+      content: assembledContent,
+      cacheKey,
+      cacheHit: false,
+      assemblyTimeMs: Date.now() - startTime,
+    };
+  }
+
+  // 3계층 경로 (하위호환)
   const cacheKey = createHash("sha256")
     .update(layers.base.role + JSON.stringify(layers.base.rules) + layers.project.conventions)
     .digest("hex")
     .substring(0, 16);
 
-  // 템플릿 변수 준비
   const variables: TemplateVariables = {
     // Base Layer
     role: layers.base.role,
@@ -345,12 +492,11 @@ export function assemblePrompt(
   };
 
   const assembledContent = renderTemplate(templateContent, variables);
-  const assemblyTime = Date.now() - startTime;
 
   return {
     content: assembledContent,
     cacheKey,
     cacheHit: false,
-    assemblyTimeMs: assemblyTime,
+    assemblyTimeMs: Date.now() - startTime,
   };
 }

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -392,7 +392,8 @@ export class JobStore extends EventEmitter {
           isRetry: baseFields.isRetry,
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
-          totalUsage: baseFields.totalUsage
+          totalUsage: baseFields.totalUsage,
+          priority: baseFields.priority
         } as QueuedJob;
         break;
 
@@ -414,7 +415,8 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
-          error: baseFields.error
+          error: baseFields.error,
+          priority: baseFields.priority
         } as RunningJob;
         break;
 
@@ -437,7 +439,8 @@ export class JobStore extends EventEmitter {
           isRetry: baseFields.isRetry,
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
-          totalUsage: baseFields.totalUsage
+          totalUsage: baseFields.totalUsage,
+          priority: baseFields.priority
         } as SuccessJob;
         break;
 
@@ -461,7 +464,8 @@ export class JobStore extends EventEmitter {
           isRetry: baseFields.isRetry,
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
-          totalUsage: baseFields.totalUsage
+          totalUsage: baseFields.totalUsage,
+          priority: baseFields.priority
         } as FailureJob;
         break;
 
@@ -484,7 +488,8 @@ export class JobStore extends EventEmitter {
           isRetry: baseFields.isRetry,
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
-          totalUsage: baseFields.totalUsage
+          totalUsage: baseFields.totalUsage,
+          priority: baseFields.priority
         } as CancelledJob;
         break;
 
@@ -508,7 +513,8 @@ export class JobStore extends EventEmitter {
           isRetry: baseFields.isRetry,
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
-          totalUsage: baseFields.totalUsage
+          totalUsage: baseFields.totalUsage,
+          priority: baseFields.priority
         } as ArchivedJob;
         break;
 

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -10,7 +10,7 @@ import { maskSensitiveConfig } from "../utils/config-masker.js";
 import type { ProjectConfig, AQConfig } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, type HealthCheckResponse } from "../types/api.js";
+import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, UpdateJobPriorityRequestSchema, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary } from "../store/queries.js";
 import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
@@ -771,6 +771,32 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     const cancelled = queue.cancel(id);
     if (!cancelled) return c.json({ error: "Job not found or not cancellable" }, 404);
     return c.json({ status: "cancelled", id });
+  });
+
+  // Update job priority
+  api.put("/api/jobs/:id/priority", async (c) => {
+    const id = c.req.param("id");
+    const job = store.get(id);
+    if (!job) return c.json({ error: "Job not found" }, 404);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const parseResult = UpdateJobPriorityRequestSchema.safeParse(body);
+    if (!parseResult.success) {
+      return c.json({ error: "Invalid request body", details: parseResult.error }, 400);
+    }
+
+    const { priority } = parseResult.data;
+    const updatedJob = store.update(id, { priority });
+    if (!updatedJob) return c.json({ error: "Failed to update priority" }, 500);
+
+    broadcastToAllClients("job-updated", updatedJob);
+    return c.json(updatedJob);
   });
 
   // Delete a completed/failed job

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import { mkdirSync } from "fs";
 import { getLogger } from "../utils/logger.js";
 import { AQM_HOME } from "../config/project-resolver.js";
+import type { JobPriority } from "../types/pipeline.js";
 
 const logger = getLogger();
 
@@ -28,6 +29,7 @@ interface JobRow {
   total_output_tokens: number | null;
   total_cache_creation_input_tokens: number | null;
   total_cache_read_input_tokens: number | null;
+  priority: string | null;
 }
 
 interface PhaseRow {
@@ -76,6 +78,7 @@ export interface DatabaseJob {
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
   };
+  priority?: JobPriority;
 }
 
 export interface DatabasePhase {
@@ -141,7 +144,8 @@ export class AQDatabase {
         total_input_tokens INTEGER CHECK (total_input_tokens >= 0),
         total_output_tokens INTEGER CHECK (total_output_tokens >= 0),
         total_cache_creation_input_tokens INTEGER CHECK (total_cache_creation_input_tokens >= 0),
-        total_cache_read_input_tokens INTEGER CHECK (total_cache_read_input_tokens >= 0)
+        total_cache_read_input_tokens INTEGER CHECK (total_cache_read_input_tokens >= 0),
+        priority TEXT CHECK (priority IN ('high', 'normal', 'low'))
       )
     `);
 
@@ -191,7 +195,19 @@ export class AQDatabase {
     // Foreign key 제약조건 활성화
     this.db.exec("PRAGMA foreign_keys = ON;");
 
+    this.migrateSchema();
+
     logger.info("Database schema initialized successfully");
+  }
+
+  private migrateSchema(): void {
+    // jobs 테이블에 priority 컬럼 추가 (기존 DB 마이그레이션)
+    const columns = this.db.pragma("table_info(jobs)") as Array<{ name: string }>;
+    const hasPriority = columns.some(col => col.name === "priority");
+    if (!hasPriority) {
+      this.db.exec(`ALTER TABLE jobs ADD COLUMN priority TEXT CHECK (priority IN ('high', 'normal', 'low'))`);
+      logger.info("Migration: added priority column to jobs table");
+    }
   }
 
   // === Job CRUD ===
@@ -202,15 +218,15 @@ export class AQDatabase {
         id, issue_number, repo, status, created_at, started_at, completed_at,
         pr_url, error, last_updated_at, current_step, dependencies, progress,
         is_retry, cost_usd, total_cost_usd, total_input_tokens, total_output_tokens,
-        total_cache_creation_input_tokens, total_cache_read_input_tokens
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        total_cache_creation_input_tokens, total_cache_read_input_tokens, priority
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const params = this.jobToParams(job);
     stmt.run(
       params[0], params[1], params[2], params[3], params[4], params[5], params[6],
       params[7], params[8], params[9], params[10], params[11], params[12], params[13],
-      params[14], params[15], params[16], params[17], params[18], params[19]
+      params[14], params[15], params[16], params[17], params[18], params[19], params[20]
     );
 
     logger.debug(`Job created: ${job.id}`);
@@ -235,7 +251,7 @@ export class AQDatabase {
         last_updated_at = ?, current_step = ?, dependencies = ?,
         progress = ?, is_retry = ?, cost_usd = ?, total_cost_usd = ?,
         total_input_tokens = ?, total_output_tokens = ?, total_cache_creation_input_tokens = ?,
-        total_cache_read_input_tokens = ?
+        total_cache_read_input_tokens = ?, priority = ?
       WHERE id = ?
     `);
 
@@ -243,7 +259,7 @@ export class AQDatabase {
     const changes = stmt.run(
       params[1], params[2], params[3], params[4], params[5], params[6], params[7],
       params[8], params[9], params[10], params[11], params[12], params[13], params[14],
-      params[15], params[16], params[17], params[18], params[19], id
+      params[15], params[16], params[17], params[18], params[19], params[20], id
     ).changes;
 
     if (changes > 0) {
@@ -403,7 +419,8 @@ export class AQDatabase {
       job.totalUsage?.input_tokens || null,
       job.totalUsage?.output_tokens || null,
       job.totalUsage?.cache_creation_input_tokens || null,
-      job.totalUsage?.cache_read_input_tokens || null
+      job.totalUsage?.cache_read_input_tokens || null,
+      job.priority || null
     ];
   }
 
@@ -430,7 +447,8 @@ export class AQDatabase {
         output_tokens: row.total_output_tokens,
         cache_creation_input_tokens: row.total_cache_creation_input_tokens ?? undefined,
         cache_read_input_tokens: row.total_cache_read_input_tokens ?? undefined
-      } : undefined
+      } : undefined,
+      priority: (row.priority as JobPriority | null) ?? undefined
     };
   }
 

--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -23,7 +23,7 @@ export enum TaskStatus {
  * 지원하는 태스크 타입
  * 향후 CodexTask, GeminiTask 등 확장 가능
  */
-export type AQMTaskType = "claude" | "codex" | "gemini";
+export type AQMTaskType = "claude" | "codex" | "gemini" | "validation";
 
 /**
  * 태스크 라이프사이클 이벤트 타입

--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -26,6 +26,26 @@ export enum TaskStatus {
 export type AQMTaskType = "claude" | "codex" | "gemini";
 
 /**
+ * 태스크 라이프사이클 이벤트 타입
+ */
+export type TaskLifecycleEvent = "started" | "completed" | "failed" | "killed";
+
+/**
+ * 태스크 이벤트 리스너 타입
+ */
+export type TaskEventListener = () => void;
+
+/**
+ * 태스크 이벤트 에미터 인터페이스
+ * 라이프사이클 이벤트를 구독/해제하는 메서드 계약
+ */
+export interface TaskEventEmitter {
+  on(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+  off(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+  once(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+}
+
+/**
  * 태스크 JSON 직렬화를 위한 요약 정보
  */
 export interface AQMTaskSummary {
@@ -44,6 +64,12 @@ export interface AQMTaskSummary {
   /** 실행 결과 메타데이터 */
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * 태스크 역직렬화(fromJSON)를 위한 직렬화 형태
+ * AQMTaskSummary와 동일한 구조이나, 역직렬화 목적으로 분리
+ */
+export type SerializedTask = AQMTaskSummary;
 
 /**
  * AQM 태스크 공통 인터페이스
@@ -70,6 +96,21 @@ export interface AQMTask {
    * @returns 직렬화된 태스크 요약 정보
    */
   toJSON(): AQMTaskSummary;
+
+  /**
+   * 라이프사이클 이벤트 리스너 등록
+   */
+  on?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+
+  /**
+   * 라이프사이클 이벤트 리스너 해제
+   */
+  off?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
+
+  /**
+   * 라이프사이클 이벤트 리스너 1회 등록 (이벤트 발생 후 자동 해제)
+   */
+  once?(event: TaskLifecycleEvent, listener: TaskEventListener): void;
 }
 
 /**

--- a/src/tasks/claude-task.ts
+++ b/src/tasks/claude-task.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
-import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions } from "./aqm-task.js";
+import { EventEmitter } from "events";
+import { AQMTask, TaskStatus, AQMTaskSummary, BaseTaskOptions, TaskLifecycleEvent, TaskEventListener, SerializedTask } from "./aqm-task.js";
 import { runClaude, getActiveProcessPids, type ClaudeRunResult, type ClaudeRunOptions } from "../claude/claude-runner.js";
 import type { ClaudeCliConfig } from "../types/config.js";
 
@@ -38,6 +39,7 @@ export class ClaudeTask implements AQMTask {
   private _result?: ClaudeRunResult;
   private _processId?: number;
   private readonly _options: ClaudeTaskOptions;
+  private readonly _emitter = new EventEmitter();
 
   constructor(options: ClaudeTaskOptions) {
     this.id = options.id || randomUUID();
@@ -56,6 +58,18 @@ export class ClaudeTask implements AQMTask {
     return this._status;
   }
 
+  on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.on(event, listener);
+  }
+
+  off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.off(event, listener);
+  }
+
+  once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.once(event, listener);
+  }
+
   async run(): Promise<ClaudeRunResult> {
     if (this._status !== "PENDING") {
       throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
@@ -63,6 +77,7 @@ export class ClaudeTask implements AQMTask {
 
     this._status = TaskStatus.RUNNING;
     this._startedAt = new Date();
+    this._emitter.emit("started");
 
     try {
       // Claude 실행 옵션 구성
@@ -92,10 +107,17 @@ export class ClaudeTask implements AQMTask {
       this._completedAt = new Date();
       this._status = this._result.success ? TaskStatus.SUCCESS : TaskStatus.FAILED;
 
+      if (this._result.success) {
+        this._emitter.emit("completed");
+      } else {
+        this._emitter.emit("failed");
+      }
+
       return this._result;
     } catch (error) {
       this._completedAt = new Date();
       this._status = TaskStatus.FAILED;
+      this._emitter.emit("failed");
 
       // 에러를 ClaudeRunResult 형태로 변환
       this._result = {
@@ -135,6 +157,7 @@ export class ClaudeTask implements AQMTask {
     this._status = TaskStatus.KILLED;
     this._completedAt = new Date();
     this._processId = undefined;
+    this._emitter.emit("killed");
   }
 
   toJSON(): AQMTaskSummary {
@@ -168,5 +191,26 @@ export class ClaudeTask implements AQMTask {
 
   getResult(): ClaudeRunResult | undefined {
     return this._result;
+  }
+
+  /**
+   * SerializedTask로부터 ClaudeTask를 복원
+   * 복원된 태스크는 PENDING 상태로 시작
+   */
+  static fromJSON(data: SerializedTask, config: ClaudeCliConfig): ClaudeTask {
+    const metadata = data.metadata ?? {};
+    const prompt = typeof metadata.prompt === "string" ? metadata.prompt : "";
+    const systemPrompt = typeof metadata.systemPrompt === "string" ? metadata.systemPrompt : undefined;
+    const maxTurns = typeof metadata.maxTurns === "number" ? metadata.maxTurns : undefined;
+    const enableAgents = typeof metadata.enableAgents === "boolean" ? metadata.enableAgents : undefined;
+
+    return new ClaudeTask({
+      id: data.id,
+      prompt,
+      config,
+      systemPrompt,
+      maxTurns,
+      enableAgents,
+    });
   }
 }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -20,3 +20,11 @@ export {
   ClaudeTask,
   ClaudeTaskOptions
 } from "./claude-task.js";
+
+// Validation 태스크 구현체 (typecheck/lint/test)
+export {
+  ValidationTask,
+  ValidationTaskOptions,
+  ValidationTaskType,
+  ValidationResult,
+} from "./validation-task.js";

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -8,7 +8,11 @@ export {
   TaskStatus,
   AQMTaskType,
   AQMTaskSummary,
-  BaseTaskOptions
+  BaseTaskOptions,
+  SerializedTask,
+  TaskLifecycleEvent,
+  TaskEventListener,
+  TaskEventEmitter
 } from "./aqm-task.js";
 
 // Claude 태스크 구현체

--- a/src/tasks/validation-task.ts
+++ b/src/tasks/validation-task.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "crypto";
+import { spawn, type ChildProcess } from "child_process";
+import { AQMTask, TaskStatus, type AQMTaskSummary, type BaseTaskOptions } from "./aqm-task.js";
+import {
+  parseTscOutput,
+  parseVitestOutput,
+  parseEslintOutput,
+  type TscParseResult,
+  type VitestParseResult,
+  type EslintParseResult,
+} from "../pipeline/verification-parser.js";
+
+export type ValidationTaskType = "typecheck" | "lint" | "test";
+
+export interface ValidationResult {
+  success: boolean;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  parsed: TscParseResult | VitestParseResult | EslintParseResult;
+}
+
+export interface ValidationTaskOptions extends BaseTaskOptions {
+  validationType: ValidationTaskType;
+  command: string;
+  args: string[];
+  timeout?: number;
+}
+
+/**
+ * typecheck/lint/test 명령을 spawn으로 실행하고 결과를 파싱하는 AQMTask 구현체
+ */
+export class ValidationTask implements AQMTask {
+  public readonly id: string;
+  public readonly type = "validation" as const;
+
+  private _status: TaskStatus = TaskStatus.PENDING;
+  private _startedAt?: Date;
+  private _completedAt?: Date;
+  private _result?: ValidationResult;
+  private _child?: ChildProcess;
+  private readonly _options: ValidationTaskOptions;
+
+  constructor(options: ValidationTaskOptions) {
+    this.id = options.id ?? randomUUID();
+    this._options = { ...options, id: this.id };
+  }
+
+  get status(): TaskStatus {
+    return this._status;
+  }
+
+  async run(): Promise<ValidationResult> {
+    if (this._status !== TaskStatus.PENDING) {
+      throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
+    }
+
+    this._status = TaskStatus.RUNNING;
+    this._startedAt = new Date();
+
+    try {
+      const result = await this._spawnCommand();
+      this._completedAt = new Date();
+      this._status = result.exitCode === 0 ? TaskStatus.SUCCESS : TaskStatus.FAILED;
+      this._result = result;
+      return result;
+    } catch (err: unknown) {
+      this._completedAt = new Date();
+      this._status = TaskStatus.FAILED;
+      const durationMs = this._completedAt.getTime() - (this._startedAt?.getTime() ?? 0);
+      this._result = {
+        success: false,
+        exitCode: 1,
+        stdout: "",
+        stderr: err instanceof Error ? err.message : String(err),
+        durationMs,
+        parsed: this._parseOutput("", ""),
+      };
+      throw err;
+    }
+  }
+
+  private _spawnCommand(): Promise<ValidationResult> {
+    return new Promise((resolve, reject) => {
+      const startTime = this._startedAt?.getTime() ?? Date.now();
+      let stdout = "";
+      let stderr = "";
+
+      this._child = spawn(this._options.command, this._options.args, {
+        cwd: this._options.cwd ?? process.cwd(),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      this._child.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+      this._child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+      this._child.on("close", (code) => {
+        this._child = undefined;
+        const exitCode = code ?? 1;
+        const durationMs = Date.now() - startTime;
+        resolve({
+          success: exitCode === 0,
+          exitCode,
+          stdout,
+          stderr,
+          durationMs,
+          parsed: this._parseOutput(stdout, stderr),
+        });
+      });
+
+      this._child.on("error", (err) => {
+        this._child = undefined;
+        reject(err);
+      });
+
+      if (this._options.timeout) {
+        setTimeout(() => {
+          this._child?.kill("SIGTERM");
+        }, this._options.timeout);
+      }
+    });
+  }
+
+  private _parseOutput(
+    stdout: string,
+    stderr: string,
+  ): TscParseResult | VitestParseResult | EslintParseResult {
+    const combined = stdout + "\n" + stderr;
+    switch (this._options.validationType) {
+      case "typecheck":
+        return parseTscOutput(combined);
+      case "test":
+        return parseVitestOutput(combined);
+      case "lint":
+        return parseEslintOutput(combined);
+    }
+  }
+
+  async kill(): Promise<void> {
+    if (this._status !== TaskStatus.RUNNING) {
+      return;
+    }
+
+    if (this._child) {
+      try {
+        this._child.kill("SIGTERM");
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        this._child?.kill("SIGKILL");
+      } catch {
+        // 프로세스가 이미 종료되었거나 권한 없음 — 무시
+      }
+    }
+
+    this._status = TaskStatus.KILLED;
+    this._completedAt = new Date();
+    this._child = undefined;
+  }
+
+  toJSON(): AQMTaskSummary {
+    const durationMs =
+      this._completedAt && this._startedAt
+        ? this._completedAt.getTime() - this._startedAt.getTime()
+        : undefined;
+
+    return {
+      id: this.id,
+      type: this.type,
+      status: this.status,
+      startedAt: this._startedAt?.toISOString(),
+      completedAt: this._completedAt?.toISOString(),
+      durationMs,
+      metadata: {
+        ...this._options.metadata,
+        validationType: this._options.validationType,
+        command: this._options.command,
+        args: this._options.args,
+        success: this._result?.success,
+        exitCode: this._result?.exitCode,
+      },
+    };
+  }
+
+  getResult(): ValidationResult | undefined {
+    return this._result;
+  }
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -270,3 +270,10 @@ export const HealthCheckResponseSchema = z.object({
 }).strict();
 
 export type HealthCheckResponse = z.infer<typeof HealthCheckResponseSchema>;
+
+// UpdateJobPriority 요청 스키마 (PUT /api/jobs/:id/priority)
+export const UpdateJobPriorityRequestSchema = z.object({
+  priority: z.enum(["high", "normal", "low"]),
+}).strict();
+
+export type UpdateJobPriorityRequest = z.infer<typeof UpdateJobPriorityRequestSchema>;

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -1,0 +1,113 @@
+import type { GitHubIssue } from "../github/issue-fetcher.js";
+
+// ─── Trigger Types ───────────────────────────────────────────────────────────
+
+export interface IssueLabeledTrigger {
+  type: "issue-labeled";
+  /** 특정 라벨에만 반응 (생략 시 모든 라벨에 반응) */
+  label?: string;
+}
+
+export interface IssueCreatedTrigger {
+  type: "issue-created";
+}
+
+export interface PipelineFailedTrigger {
+  type: "pipeline-failed";
+  /** 특정 repo에만 반응 (생략 시 모든 repo) */
+  repo?: string;
+}
+
+export type Trigger =
+  | IssueLabeledTrigger
+  | IssueCreatedTrigger
+  | PipelineFailedTrigger;
+
+export type TriggerType = Trigger["type"];
+
+// ─── Condition Types ──────────────────────────────────────────────────────────
+
+export interface LabelMatchCondition {
+  type: "label-match";
+  labels: string[];
+  /** 기본값: "or" */
+  operator?: "and" | "or";
+}
+
+export interface PathMatchCondition {
+  type: "path-match";
+  /** minimatch glob 패턴 목록 (하나라도 매칭되면 통과) */
+  patterns: string[];
+}
+
+export interface KeywordMatchCondition {
+  type: "keyword-match";
+  keywords: string[];
+  /** 검사할 필드 (기본값: ["title", "body"]) */
+  fields?: Array<"title" | "body">;
+  /** 기본값: "or" */
+  operator?: "and" | "or";
+}
+
+export type Condition =
+  | LabelMatchCondition
+  | PathMatchCondition
+  | KeywordMatchCondition;
+
+// ─── Action Types ─────────────────────────────────────────────────────────────
+
+export interface AddLabelAction {
+  type: "add-label";
+  labels: string[];
+}
+
+export interface StartJobAction {
+  type: "start-job";
+  /** 기본값: context.repo */
+  repo?: string;
+}
+
+export interface PauseProjectAction {
+  type: "pause-project";
+  reason?: string;
+}
+
+export type Action =
+  | AddLabelAction
+  | StartJobAction
+  | PauseProjectAction;
+
+export type ActionType = Action["type"];
+
+// ─── AutomationRule ───────────────────────────────────────────────────────────
+
+export interface AutomationRule {
+  id: string;
+  name: string;
+  /** 기본값: true */
+  enabled?: boolean;
+  trigger: Trigger;
+  /** 모든 조건이 AND로 평가됨 */
+  conditions?: Condition[];
+  actions: Action[];
+}
+
+// ─── Rule Engine Context ──────────────────────────────────────────────────────
+
+export interface RuleContext {
+  triggerType: TriggerType;
+  issue: GitHubIssue;
+  repo: string;
+  /** issue-labeled 트리거 시 추가된 라벨 */
+  triggerLabel?: string;
+  /** pipeline 영향을 받은 파일 경로 목록 (path-match 조건에 사용) */
+  affectedPaths?: string[];
+}
+
+// ─── Rule Engine Handlers ─────────────────────────────────────────────────────
+
+export interface RuleEngineHandlers {
+  addLabel: (repo: string, issueNumber: number, labels: string[]) => Promise<void>;
+  startJob: (repo: string, issueNumber: number) => Promise<void>;
+  pauseProject: (repo: string, reason?: string) => Promise<void>;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -242,6 +242,48 @@ export interface ProjectConfig {
   pauseDurationMs?: number;
 }
 
+export type AutomationTriggerType = "cron" | "event" | "rate-limit";
+export type AutomationEventType = "pr-merged" | "phase-failed";
+export type AutomationCronSchedule = "daily" | "weekly";
+
+export interface AutomationTrigger {
+  type: AutomationTriggerType;
+  /** cron 트리거 스케줄 (type이 "cron"일 때) */
+  schedule?: AutomationCronSchedule;
+  /** event 트리거 이벤트명 (type이 "event"일 때) */
+  event?: AutomationEventType;
+  /** rate-limit 트리거 임계값 (type이 "rate-limit"일 때) */
+  threshold?: number;
+}
+
+export interface AutomationCondition {
+  /** 조건 표현식 (예: "failureCount > 3", "label == 'urgent'") */
+  expression: string;
+}
+
+export type AutomationActionType = "notify" | "pause" | "retry" | "label" | "close";
+
+export interface AutomationAction {
+  type: AutomationActionType;
+  /** 액션에 전달할 추가 파라미터 */
+  params?: Record<string, string | number | boolean>;
+}
+
+export interface AutomationRule {
+  /** 규칙 식별자 */
+  id: string;
+  /** 규칙 설명 */
+  description?: string;
+  /** 트리거 조건 */
+  trigger: AutomationTrigger;
+  /** 선택적 조건 (모두 충족해야 액션 실행) */
+  conditions?: AutomationCondition[];
+  /** 실행할 액션 목록 */
+  actions: AutomationAction[];
+  /** 규칙 활성화 여부 (기본값: true) */
+  enabled?: boolean;
+}
+
 export interface AQConfig {
   general: GeneralConfig;
   git: GitConfig;
@@ -254,4 +296,5 @@ export interface AQConfig {
   executionMode: ExecutionMode;
   hooks?: HooksConfig;        // pipeline hooks configuration
   projects?: ProjectConfig[];  // per-project overrides
+  automations?: AutomationRule[];  // automation rules
 }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -263,24 +263,22 @@ export interface PlanRetryContext {
 
 // 프롬프트 레이어 분리를 위한 타입 정의
 
-/**
- * 기본 레이어 - 역할과 규칙 등 정적 내용
- */
-export interface BaseLayer {
-  /** AI 역할 정의 (예: "시니어 개발자", "소프트웨어 아키텍트") */
-  role: string;
-  /** 기본 규칙과 지침 */
-  rules: string[];
-  /** 출력 포맷 지침 */
-  outputFormat: string;
-  /** 진행 보고 규칙 */
-  progressReporting: string;
-  /** 병렬 작업 가이드 */
-  parallelWorkGuide: string;
-}
+// BaseLayer는 layer-types.ts와 동일 — import 후 re-export로 중복 제거
+import type { BaseLayer } from "../prompt/layer-types.js";
+export type { BaseLayer };
+
+// IssueLayer, LearningLayer, CacheKeyConfig, PromptLayers는 새 5계층 타입 — 호환성을 위해 re-export
+export type {
+  IssueLayer,
+  LearningLayer,
+  CacheKeyConfig,
+  PromptLayers,
+} from "../prompt/layer-types.js";
 
 /**
  * 프로젝트 레이어 - 프로젝트 수준 설정 (정적)
+ * @note layer-types.ts의 ProjectLayer보다 pastFailures? 필드가 추가됨.
+ *       template-renderer.ts에서 사용 중이므로 별도 유지.
  */
 export interface ProjectLayer {
   /** 프로젝트 컨벤션 (CLAUDE.md 내용) */

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -375,6 +375,8 @@ export interface AssembledPrompt {
 
 export type JobStatus = "queued" | "running" | "success" | "failure" | "cancelled" | "archived";
 
+export type JobPriority = "high" | "normal" | "low";
+
 export interface UsageStats {
   input_tokens: number;
   output_tokens: number;
@@ -407,6 +409,7 @@ export interface JobBase {
   phaseResults?: PhaseResultInfo[];
   progress?: number;
   isRetry?: boolean;
+  priority?: JobPriority;
   costUsd?: number;
   totalCostUsd?: number;
   totalUsage?: UsageStats;

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -371,6 +371,69 @@ export interface AssembledPrompt {
   assemblyTimeMs: number;
 }
 
+// Pipeline Event Types
+
+export type PipelineEventType =
+  | "pr-merged"
+  | "phase-failed"
+  | "pipeline-complete"
+  | "pipeline-failed";
+
+export interface PrMergedPayload {
+  issueNumber: number;
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  mergedAt: string;
+}
+
+export interface PhaseFailedPayload {
+  issueNumber: number;
+  repo: string;
+  phaseIndex: number;
+  phaseName: string;
+  errorCategory?: ErrorCategory;
+  errorMessage: string;
+  attempt: number;
+}
+
+export interface PipelineCompletePayload {
+  issueNumber: number;
+  repo: string;
+  prUrl: string;
+  totalCostUsd?: number;
+  durationMs: number;
+}
+
+export interface PipelineFailedPayload {
+  issueNumber: number;
+  repo: string;
+  state: PipelineState;
+  errorCategory?: ErrorCategory;
+  errorMessage: string;
+  durationMs: number;
+}
+
+export type PipelineEventPayload =
+  | PrMergedPayload
+  | PhaseFailedPayload
+  | PipelineCompletePayload
+  | PipelineFailedPayload;
+
+export interface PipelineEvent<T extends PipelineEventType = PipelineEventType> {
+  type: T;
+  payload: T extends "pr-merged"
+    ? PrMergedPayload
+    : T extends "phase-failed"
+      ? PhaseFailedPayload
+      : T extends "pipeline-complete"
+        ? PipelineCompletePayload
+        : T extends "pipeline-failed"
+          ? PipelineFailedPayload
+          : never;
+  triggeredAt: string;
+}
+
 // Job Discriminated Union Types
 
 export type JobStatus = "queued" | "running" | "success" | "failure" | "cancelled" | "archived";

--- a/tests/automation/rule-engine.test.ts
+++ b/tests/automation/rule-engine.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi } from "vitest";
+import { evaluateRule, executeAction } from "../../src/automation/rule-engine.js";
+import type {
+  AutomationRule,
+  RuleContext,
+  RuleEngineHandlers,
+} from "../../src/types/automation.js";
+import type { GitHubIssue } from "../../src/github/issue-fetcher.js";
+
+const baseIssue: GitHubIssue = {
+  number: 1,
+  title: "Fix login bug",
+  body: "Users cannot log in with SSO",
+  labels: ["bug"],
+};
+
+const baseContext: RuleContext = {
+  triggerType: "issue-created",
+  issue: baseIssue,
+  repo: "org/repo",
+};
+
+const noopHandlers: RuleEngineHandlers = {
+  addLabel: vi.fn().mockResolvedValue(undefined),
+  startJob: vi.fn().mockResolvedValue(undefined),
+  pauseProject: vi.fn().mockResolvedValue(undefined),
+};
+
+// ─── evaluateRule ─────────────────────────────────────────────────────────────
+
+describe("evaluateRule", () => {
+  describe("enabled flag", () => {
+    it("returns false when enabled=false", () => {
+      const rule: AutomationRule = {
+        id: "r1",
+        name: "disabled",
+        enabled: false,
+        trigger: { type: "issue-created" },
+        actions: [{ type: "add-label", labels: ["auto"] }],
+      };
+      expect(evaluateRule(rule, baseContext)).toBe(false);
+    });
+
+    it("returns true when enabled is omitted (default=true)", () => {
+      const rule: AutomationRule = {
+        id: "r2",
+        name: "default-enabled",
+        trigger: { type: "issue-created" },
+        actions: [{ type: "add-label", labels: ["auto"] }],
+      };
+      expect(evaluateRule(rule, baseContext)).toBe(true);
+    });
+  });
+
+  describe("trigger matching", () => {
+    it("issue-created matches issue-created context", () => {
+      const rule: AutomationRule = {
+        id: "r3",
+        name: "on-create",
+        trigger: { type: "issue-created" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "issue-created" })).toBe(true);
+    });
+
+    it("issue-created does not match issue-labeled context", () => {
+      const rule: AutomationRule = {
+        id: "r4",
+        name: "on-create",
+        trigger: { type: "issue-created" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "issue-labeled" })).toBe(false);
+    });
+
+    it("issue-labeled matches with any label when trigger.label is omitted", () => {
+      const rule: AutomationRule = {
+        id: "r5",
+        name: "on-any-label",
+        trigger: { type: "issue-labeled" },
+        actions: [],
+      };
+      expect(
+        evaluateRule(rule, { ...baseContext, triggerType: "issue-labeled", triggerLabel: "bug" })
+      ).toBe(true);
+    });
+
+    it("issue-labeled only matches specified label", () => {
+      const rule: AutomationRule = {
+        id: "r6",
+        name: "on-bug-label",
+        trigger: { type: "issue-labeled", label: "bug" },
+        actions: [],
+      };
+      const ctx: RuleContext = { ...baseContext, triggerType: "issue-labeled", triggerLabel: "bug" };
+      expect(evaluateRule(rule, ctx)).toBe(true);
+
+      const ctxOther: RuleContext = { ...baseContext, triggerType: "issue-labeled", triggerLabel: "feature" };
+      expect(evaluateRule(rule, ctxOther)).toBe(false);
+    });
+
+    it("pipeline-failed matches with any repo when trigger.repo is omitted", () => {
+      const rule: AutomationRule = {
+        id: "r7",
+        name: "on-fail",
+        trigger: { type: "pipeline-failed" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed" })).toBe(true);
+    });
+
+    it("pipeline-failed only matches specified repo", () => {
+      const rule: AutomationRule = {
+        id: "r8",
+        name: "on-fail-specific",
+        trigger: { type: "pipeline-failed", repo: "org/repo" },
+        actions: [],
+      };
+      expect(evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed" })).toBe(true);
+      expect(
+        evaluateRule(rule, { ...baseContext, triggerType: "pipeline-failed", repo: "org/other" })
+      ).toBe(false);
+    });
+  });
+
+  describe("label-match condition", () => {
+    const rule = (operator?: "and" | "or"): AutomationRule => ({
+      id: "r9",
+      name: "label-check",
+      trigger: { type: "issue-created" },
+      conditions: [{ type: "label-match", labels: ["bug", "urgent"], operator }],
+      actions: [],
+    });
+
+    it("or: matches when at least one label is present (default)", () => {
+      const ctx: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug"] } };
+      expect(evaluateRule(rule(), ctx)).toBe(true);
+    });
+
+    it("or: does not match when no label is present", () => {
+      const ctx: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["feature"] } };
+      expect(evaluateRule(rule("or"), ctx)).toBe(false);
+    });
+
+    it("and: requires all labels to be present", () => {
+      const ctxBoth: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug", "urgent"] } };
+      expect(evaluateRule(rule("and"), ctxBoth)).toBe(true);
+
+      const ctxOne: RuleContext = { ...baseContext, issue: { ...baseIssue, labels: ["bug"] } };
+      expect(evaluateRule(rule("and"), ctxOne)).toBe(false);
+    });
+  });
+
+  describe("path-match condition", () => {
+    const rule: AutomationRule = {
+      id: "r10",
+      name: "path-check",
+      trigger: { type: "pipeline-failed" },
+      conditions: [{ type: "path-match", patterns: ["src/**/*.ts"] }],
+      actions: [],
+    };
+
+    it("matches when an affected path matches the pattern", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        triggerType: "pipeline-failed",
+        affectedPaths: ["src/utils/helper.ts"],
+      };
+      expect(evaluateRule(rule, ctx)).toBe(true);
+    });
+
+    it("does not match when no affected path matches", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        triggerType: "pipeline-failed",
+        affectedPaths: ["docs/readme.md"],
+      };
+      expect(evaluateRule(rule, ctx)).toBe(false);
+    });
+
+    it("returns false when affectedPaths is empty", () => {
+      const ctx: RuleContext = { ...baseContext, triggerType: "pipeline-failed", affectedPaths: [] };
+      expect(evaluateRule(rule, ctx)).toBe(false);
+    });
+  });
+
+  describe("keyword-match condition", () => {
+    const rule = (operator?: "and" | "or", fields?: Array<"title" | "body">): AutomationRule => ({
+      id: "r11",
+      name: "keyword-check",
+      trigger: { type: "issue-created" },
+      conditions: [{ type: "keyword-match", keywords: ["login", "sso"], operator, fields }],
+      actions: [],
+    });
+
+    it("or: matches when any keyword found in title or body", () => {
+      expect(evaluateRule(rule(), baseContext)).toBe(true); // "login" in title, "SSO" in body
+    });
+
+    it("and: requires all keywords to be present", () => {
+      const ctx: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login issue", body: "sso broken" },
+      };
+      expect(evaluateRule(rule("and"), ctx)).toBe(true);
+
+      const ctxMissing: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login issue", body: "no relevant info" },
+      };
+      expect(evaluateRule(rule("and"), ctxMissing)).toBe(false);
+    });
+
+    it("only checks title when fields=['title']", () => {
+      const ctxTitleOnly: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "login problem", body: "no keywords here" },
+      };
+      expect(evaluateRule(rule(undefined, ["title"]), ctxTitleOnly)).toBe(true);
+
+      const ctxBodyOnly: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, title: "generic issue", body: "login problem" },
+      };
+      expect(evaluateRule(rule(undefined, ["title"]), ctxBodyOnly)).toBe(false);
+    });
+  });
+
+  describe("multiple conditions (AND)", () => {
+    it("all conditions must pass", () => {
+      const rule: AutomationRule = {
+        id: "r12",
+        name: "multi-cond",
+        trigger: { type: "issue-created" },
+        conditions: [
+          { type: "label-match", labels: ["bug"] },
+          { type: "keyword-match", keywords: ["login"] },
+        ],
+        actions: [],
+      };
+
+      const ctxPass: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, labels: ["bug"], title: "login bug", body: "" },
+      };
+      expect(evaluateRule(rule, ctxPass)).toBe(true);
+
+      const ctxFail: RuleContext = {
+        ...baseContext,
+        issue: { ...baseIssue, labels: ["feature"], title: "login issue", body: "" },
+      };
+      expect(evaluateRule(rule, ctxFail)).toBe(false);
+    });
+  });
+});
+
+// ─── executeAction ────────────────────────────────────────────────────────────
+
+describe("executeAction", () => {
+  it("add-label calls handlers.addLabel with correct args", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn().mockResolvedValue(undefined),
+      startJob: vi.fn(),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "add-label", labels: ["auto", "triaged"] }, baseContext, handlers);
+    expect(handlers.addLabel).toHaveBeenCalledWith("org/repo", 1, ["auto", "triaged"]);
+  });
+
+  it("start-job uses action.repo when provided", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn().mockResolvedValue(undefined),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "start-job", repo: "org/other" }, baseContext, handlers);
+    expect(handlers.startJob).toHaveBeenCalledWith("org/other", 1);
+  });
+
+  it("start-job falls back to context.repo when action.repo is omitted", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn().mockResolvedValue(undefined),
+      pauseProject: vi.fn(),
+    };
+    await executeAction({ type: "start-job" }, baseContext, handlers);
+    expect(handlers.startJob).toHaveBeenCalledWith("org/repo", 1);
+  });
+
+  it("pause-project calls handlers.pauseProject with reason", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn(),
+      pauseProject: vi.fn().mockResolvedValue(undefined),
+    };
+    await executeAction({ type: "pause-project", reason: "rate limit" }, baseContext, handlers);
+    expect(handlers.pauseProject).toHaveBeenCalledWith("org/repo", "rate limit");
+  });
+
+  it("pause-project works without reason", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn(),
+      startJob: vi.fn(),
+      pauseProject: vi.fn().mockResolvedValue(undefined),
+    };
+    await executeAction({ type: "pause-project" }, baseContext, handlers);
+    expect(handlers.pauseProject).toHaveBeenCalledWith("org/repo", undefined);
+  });
+
+  it("re-throws handler errors", async () => {
+    const handlers: RuleEngineHandlers = {
+      addLabel: vi.fn().mockRejectedValue(new Error("GitHub API error")),
+      startJob: vi.fn(),
+      pauseProject: vi.fn(),
+    };
+    await expect(
+      executeAction({ type: "add-label", labels: ["fail"] }, baseContext, handlers)
+    ).rejects.toThrow("GitHub API error");
+  });
+
+  it("unused handlers are not called", async () => {
+    await executeAction({ type: "add-label", labels: ["x"] }, baseContext, noopHandlers);
+    expect(noopHandlers.startJob).not.toHaveBeenCalled();
+    expect(noopHandlers.pauseProject).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pipeline/automation-dispatcher.test.ts
+++ b/tests/pipeline/automation-dispatcher.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock은 호이스팅되므로 mockLogger도 vi.hoisted()로 호이스팅해야 함
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: vi.fn(() => mockLogger),
+}));
+
+import { initDispatcher, dispatchPipelineEvent } from "../../src/pipeline/automation-dispatcher.js";
+import { AutomationScheduler } from "../../src/automation/scheduler.js";
+import type {
+  PipelineEvent,
+  PrMergedPayload,
+  PhaseFailedPayload,
+  PipelineCompletePayload,
+  PipelineFailedPayload,
+} from "../../src/types/pipeline.js";
+import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+
+function makeScheduler(running: boolean): AutomationScheduler {
+  const scheduler = new AutomationScheduler(DEFAULT_CONFIG);
+  if (running) scheduler.start();
+  return scheduler;
+}
+
+function makePrMergedEvent(): PipelineEvent<"pr-merged"> {
+  return {
+    type: "pr-merged",
+    payload: {
+      issueNumber: 42,
+      repo: "test/repo",
+      prNumber: 7,
+      prUrl: "https://github.com/test/repo/pull/7",
+      mergedAt: "2026-04-10T12:00:00Z",
+    } satisfies PrMergedPayload,
+    triggeredAt: "2026-04-10T12:00:00Z",
+  };
+}
+
+function makePhaseFailedEvent(): PipelineEvent<"phase-failed"> {
+  return {
+    type: "phase-failed",
+    payload: {
+      issueNumber: 42,
+      repo: "test/repo",
+      phaseIndex: 2,
+      phaseName: "테스트 작성",
+      errorCategory: "TS_ERROR",
+      errorMessage: "Type error in foo.ts",
+      attempt: 1,
+    } satisfies PhaseFailedPayload,
+    triggeredAt: "2026-04-10T12:01:00Z",
+  };
+}
+
+function makePipelineCompleteEvent(): PipelineEvent<"pipeline-complete"> {
+  return {
+    type: "pipeline-complete",
+    payload: {
+      issueNumber: 42,
+      repo: "test/repo",
+      prUrl: "https://github.com/test/repo/pull/7",
+      totalCostUsd: 0.05,
+      durationMs: 12000,
+    } satisfies PipelineCompletePayload,
+    triggeredAt: "2026-04-10T12:02:00Z",
+  };
+}
+
+function makePipelineFailedEvent(): PipelineEvent<"pipeline-failed"> {
+  return {
+    type: "pipeline-failed",
+    payload: {
+      issueNumber: 42,
+      repo: "test/repo",
+      state: "PHASE_FAILED",
+      errorCategory: "TIMEOUT",
+      errorMessage: "Pipeline timed out",
+      durationMs: 60000,
+    } satisfies PipelineFailedPayload,
+    triggeredAt: "2026-04-10T12:03:00Z",
+  };
+}
+
+describe("automation-dispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 각 테스트 전 스케줄러를 비활성 상태로 리셋
+    initDispatcher(makeScheduler(false));
+  });
+
+  describe("initDispatcher", () => {
+    it("스케줄러를 초기화한다", async () => {
+      const scheduler = makeScheduler(true);
+      initDispatcher(scheduler);
+      // 초기화 후 이벤트가 처리되어야 함
+      await dispatchPipelineEvent(makePrMergedEvent());
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("pr-merged")
+      );
+    });
+  });
+
+  describe("dispatchPipelineEvent", () => {
+    it("스케줄러가 실행 중이 아니면 이벤트를 스킵한다", async () => {
+      const scheduler = makeScheduler(false);
+      initDispatcher(scheduler);
+      await dispatchPipelineEvent(makePrMergedEvent());
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("스케줄러 비활성")
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("pr-merged")
+      );
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining("파이프라인 이벤트 수신")
+      );
+    });
+
+    it("스케줄러가 실행 중이면 이벤트 수신 로그를 남긴다", async () => {
+      const scheduler = makeScheduler(true);
+      initDispatcher(scheduler);
+      const event = makePrMergedEvent();
+      await dispatchPipelineEvent(event);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("파이프라인 이벤트 수신")
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("pr-merged")
+      );
+    });
+
+    describe("이벤트 타입별 처리", () => {
+      beforeEach(() => {
+        initDispatcher(makeScheduler(true));
+      });
+
+      it("pr-merged 이벤트를 처리한다", async () => {
+        const event = makePrMergedEvent();
+        await dispatchPipelineEvent(event);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("PR 병합")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("42")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("7")
+        );
+      });
+
+      it("phase-failed 이벤트를 처리한다", async () => {
+        const event = makePhaseFailedEvent();
+        await dispatchPipelineEvent(event);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("Phase 실패")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("테스트 작성")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("2")
+        );
+      });
+
+      it("pipeline-complete 이벤트를 처리한다", async () => {
+        const event = makePipelineCompleteEvent();
+        await dispatchPipelineEvent(event);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("파이프라인 완료")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("https://github.com/test/repo/pull/7")
+        );
+      });
+
+      it("pipeline-failed 이벤트를 처리한다", async () => {
+        const event = makePipelineFailedEvent();
+        await dispatchPipelineEvent(event);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("파이프라인 실패")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("PHASE_FAILED")
+        );
+      });
+    });
+
+    it("이벤트 처리 중 예외가 발생해도 throw하지 않고 에러 로그를 남긴다", async () => {
+      const scheduler = makeScheduler(true);
+      initDispatcher(scheduler);
+
+      // processEvent 내부에서 에러를 발생시키기 위해 logger.info를 덮어씀
+      let callCount = 0;
+      mockLogger.info.mockImplementation(() => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error("unexpected error");
+        }
+      });
+
+      await expect(dispatchPipelineEvent(makePrMergedEvent())).resolves.toBeUndefined();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("이벤트 처리 실패")
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("pr-merged")
+      );
+    });
+
+    it("스케줄러 중지 후 이벤트를 스킵한다", async () => {
+      const scheduler = makeScheduler(true);
+      initDispatcher(scheduler);
+
+      // 실행 중일 때는 처리
+      await dispatchPipelineEvent(makePrMergedEvent());
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("파이프라인 이벤트 수신")
+      );
+
+      vi.clearAllMocks();
+
+      // 중지 후에는 스킵
+      scheduler.stop();
+      await dispatchPipelineEvent(makePrMergedEvent());
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("스케줄러 비활성")
+      );
+    });
+
+    it("여러 이벤트를 순서대로 처리한다", async () => {
+      const scheduler = makeScheduler(true);
+      initDispatcher(scheduler);
+
+      await dispatchPipelineEvent(makePhaseFailedEvent());
+      await dispatchPipelineEvent(makePipelineFailedEvent());
+
+      const infoCalls = mockLogger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+      const phaseFailedIdx = infoCalls.findIndex((msg) => msg.includes("Phase 실패"));
+      const pipelineFailedIdx = infoCalls.findIndex((msg) => msg.includes("파이프라인 실패"));
+      expect(phaseFailedIdx).toBeLessThan(pipelineFailedIdx);
+    });
+  });
+});

--- a/tests/pipeline/phase-executor.test.ts
+++ b/tests/pipeline/phase-executor.test.ts
@@ -696,6 +696,50 @@ describe("executePhase", () => {
     expect(result.errors!.filter(e => e.startsWith("src/bar.ts:")).length).toBe(2);
   });
 
+  it("uses cachedLayers.phaseTemplate instead of loadTemplate when cachedLayers is provided", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+    mockRunShell.mockResolvedValue({ stdout: "ok", stderr: "", exitCode: 0 });
+
+    const cachedLayers = {
+      staticContent: "static base + project content",
+      cacheKey: "abc123def456",
+      createdAt: new Date().toISOString(),
+      phaseTemplate: "cached phase template content",
+    };
+
+    const result = await executePhase(makeCtx({ cachedLayers }));
+
+    expect(result.success).toBe(true);
+    // loadTemplate should NOT have been called when cachedLayers is provided
+    expect(mockLoadTemplate).not.toHaveBeenCalled();
+    // renderTemplate should have been called with the cached phaseTemplate
+    expect(mockRenderTemplate).toHaveBeenCalledWith(
+      "cached phase template content",
+      expect.any(Object)
+    );
+  });
+
+  it("falls back to loadTemplate when cachedLayers is not provided", async () => {
+    mockRunClaude.mockResolvedValue({ success: true, output: "done" });
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git status (clean)
+      .mockResolvedValueOnce({ stdout: "abc12345", stderr: "", exitCode: 0 }); // git log
+    mockRunShell.mockResolvedValue({ stdout: "ok", stderr: "", exitCode: 0 });
+
+    // No cachedLayers — should use loadTemplate
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(mockLoadTemplate).toHaveBeenCalledOnce();
+    expect(mockRenderTemplate).toHaveBeenCalledWith(
+      "template content",
+      expect.any(Object)
+    );
+  });
+
   it("falls through to full failure when vitest output has no passed files", async () => {
     mockRunClaude.mockResolvedValue({ success: true, output: "done" });
     mockRunCli

--- a/tests/prompt/layer-types.test.ts
+++ b/tests/prompt/layer-types.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildIssueLayer,
+  buildLearningLayer,
+  computeLayerCacheKey,
+  buildBaseLayer,
+  buildProjectLayer,
+} from "../../src/prompt/template-renderer.js";
+import type {
+  IssueLayer,
+  LearningLayer,
+  PhaseLayer,
+  PromptLayers,
+  CacheKeyConfig,
+} from "../../src/prompt/layer-types.js";
+
+// ---------------------------------------------------------------------------
+// IssueLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("IssueLayer 구조", () => {
+  it("buildIssueLayer 결과가 IssueLayer 인터페이스를 충족한다", () => {
+    const layer: IssueLayer = buildIssueLayer({
+      number: 42,
+      title: "Fix critical bug",
+      body: "Detailed description",
+      labels: ["bug", "priority"],
+      repository: {
+        owner: "my-org",
+        name: "my-repo",
+        baseBranch: "main",
+        workBranch: "fix/42-bug",
+      },
+      planSummary: "Fix the bug in 2 phases",
+    });
+
+    expect(layer.number).toBe(42);
+    expect(layer.title).toBe("Fix critical bug");
+    expect(layer.body).toBe("Detailed description");
+    expect(layer.labels).toEqual(["bug", "priority"]);
+    expect(layer.repository.owner).toBe("my-org");
+    expect(layer.repository.name).toBe("my-repo");
+    expect(layer.repository.baseBranch).toBe("main");
+    expect(layer.repository.workBranch).toBe("fix/42-bug");
+    expect(layer.planSummary).toBe("Fix the bug in 2 phases");
+  });
+
+  it("repository 중첩 구조가 모든 필수 필드를 포함한다", () => {
+    const layer = buildIssueLayer({
+      number: 1,
+      title: "T",
+      body: "B",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+
+    expect(layer.repository).toHaveProperty("owner");
+    expect(layer.repository).toHaveProperty("name");
+    expect(layer.repository).toHaveProperty("baseBranch");
+    expect(layer.repository).toHaveProperty("workBranch");
+  });
+
+  it("빈 labels와 빈 body를 허용한다", () => {
+    const layer = buildIssueLayer({
+      number: 0,
+      title: "Empty",
+      body: "",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "",
+    });
+
+    expect(layer.labels).toEqual([]);
+    expect(layer.body).toBe("");
+    expect(layer.planSummary).toBe("");
+  });
+
+  it("다수의 labels를 배열로 유지한다", () => {
+    const layer = buildIssueLayer({
+      number: 1,
+      title: "T",
+      body: "B",
+      labels: ["bug", "feature", "help-wanted", "good-first-issue"],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+
+    expect(layer.labels).toHaveLength(4);
+    expect(layer.labels).toContain("good-first-issue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LearningLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("LearningLayer 구조", () => {
+  it("buildLearningLayer() 결과가 LearningLayer 인터페이스를 충족한다", () => {
+    const layer: LearningLayer = buildLearningLayer();
+
+    expect(layer).toHaveProperty("pastFailures");
+    expect(layer).toHaveProperty("errorPatterns");
+    expect(layer).toHaveProperty("learnedPatterns");
+    expect(layer).toHaveProperty("updatedAt");
+    expect(Array.isArray(layer.pastFailures)).toBe(true);
+    expect(Array.isArray(layer.errorPatterns)).toBe(true);
+    expect(Array.isArray(layer.learnedPatterns)).toBe(true);
+  });
+
+  it("인자 없이 호출하면 모든 배열이 비어 있고 updatedAt이 ISO 8601 형식이다", () => {
+    const layer = buildLearningLayer();
+
+    expect(layer.pastFailures).toEqual([]);
+    expect(layer.errorPatterns).toEqual([]);
+    expect(layer.learnedPatterns).toEqual([]);
+    expect(layer.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("pastFailures 각 항목이 context, message를 가지며 resolution은 선택이다", () => {
+    const layer = buildLearningLayer({
+      pastFailures: [
+        { context: "Phase 1", message: "Login error", resolution: "Run /login" },
+        { context: "Phase 2", message: "Type error" },
+      ],
+    });
+
+    expect(layer.pastFailures[0].context).toBe("Phase 1");
+    expect(layer.pastFailures[0].message).toBe("Login error");
+    expect(layer.pastFailures[0].resolution).toBe("Run /login");
+    expect(layer.pastFailures[1].resolution).toBeUndefined();
+  });
+
+  it("updatedAt을 명시하면 그 값을 그대로 보존한다", () => {
+    const ts = "2026-04-10T12:34:56.789Z";
+    const layer = buildLearningLayer({ updatedAt: ts });
+    expect(layer.updatedAt).toBe(ts);
+  });
+
+  it("일부 필드만 제공하면 나머지는 빈 배열로 기본값 처리된다", () => {
+    const layer = buildLearningLayer({ learnedPatterns: ["Always check auth"] });
+    expect(layer.pastFailures).toEqual([]);
+    expect(layer.errorPatterns).toEqual([]);
+    expect(layer.learnedPatterns).toEqual(["Always check auth"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhaseLayer 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("PhaseLayer 구조", () => {
+  it("PhaseLayer 인터페이스에 맞는 객체를 직접 생성할 수 있다", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 1,
+        totalCount: 3,
+        name: "Implementation",
+        description: "Implement the feature",
+        targetFiles: ["src/feature.ts", "tests/feature.test.ts"],
+      },
+      previousResults: "Phase 0: SUCCESS",
+    };
+
+    expect(layer.currentPhase.index).toBe(1);
+    expect(layer.currentPhase.totalCount).toBe(3);
+    expect(layer.currentPhase.targetFiles).toHaveLength(2);
+    expect(layer.previousResults).toBe("Phase 0: SUCCESS");
+    expect(layer.locale).toBeUndefined();
+  });
+
+  it("locale 필드는 선택적으로 지정 가능하다", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 2,
+        totalCount: 2,
+        name: "Test",
+        description: "Write tests",
+        targetFiles: [],
+      },
+      previousResults: "",
+      locale: "en",
+    };
+
+    expect(layer.locale).toBe("en");
+  });
+
+  it("previousResults가 빈 문자열인 경우를 허용한다 (첫 Phase)", () => {
+    const layer: PhaseLayer = {
+      currentPhase: {
+        index: 1,
+        totalCount: 1,
+        name: "Only Phase",
+        description: "Do everything",
+        targetFiles: [],
+      },
+      previousResults: "",
+    };
+
+    expect(layer.previousResults).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PromptLayers 5계층 조합
+// ---------------------------------------------------------------------------
+
+describe("PromptLayers 5계층 구조", () => {
+  function makePromptLayers(): PromptLayers {
+    return {
+      base: buildBaseLayer({ role: "시니어 개발자" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM + Vitest",
+        testCommand: "npx vitest run",
+        lintCommand: "npx eslint src/ tests/",
+      }),
+      issue: buildIssueLayer({
+        number: 419,
+        title: "refactor: 5-layer prompt",
+        body: "Issue body",
+        labels: ["refactor"],
+        repository: {
+          owner: "test-org",
+          name: "ai-quartermaster",
+          baseBranch: "main",
+          workBranch: "aq/419-refactor",
+        },
+        planSummary: "5계층 레이어 분리",
+      }),
+      phase: {
+        currentPhase: {
+          index: 4,
+          totalCount: 4,
+          name: "테스트 추가",
+          description: "레이어 타입 테스트 작성",
+          targetFiles: ["tests/prompt/layer-types.test.ts"],
+        },
+        previousResults: "Phase 3: SUCCESS",
+      },
+      learning: buildLearningLayer({
+        pastFailures: [{ context: "UNKNOWN", message: "Not logged in", resolution: "Run /login" }],
+        errorPatterns: ["Not logged in"],
+        learnedPatterns: ["Check auth before start"],
+        updatedAt: "2026-04-10T00:00:00.000Z",
+      }),
+    };
+  }
+
+  it("모든 5개 레이어를 포함하는 PromptLayers를 생성할 수 있다", () => {
+    const layers = makePromptLayers();
+
+    expect(layers).toHaveProperty("base");
+    expect(layers).toHaveProperty("project");
+    expect(layers).toHaveProperty("issue");
+    expect(layers).toHaveProperty("phase");
+    expect(layers).toHaveProperty("learning");
+  });
+
+  it("각 레이어는 독립적인 타입 구조를 가진다", () => {
+    const layers = makePromptLayers();
+
+    // base
+    expect(typeof layers.base.role).toBe("string");
+    expect(Array.isArray(layers.base.rules)).toBe(true);
+
+    // project
+    expect(typeof layers.project.conventions).toBe("string");
+    expect(typeof layers.project.testCommand).toBe("string");
+
+    // issue
+    expect(typeof layers.issue.number).toBe("number");
+    expect(typeof layers.issue.repository.owner).toBe("string");
+
+    // phase
+    expect(typeof layers.phase.currentPhase.index).toBe("number");
+    expect(Array.isArray(layers.phase.currentPhase.targetFiles)).toBe(true);
+
+    // learning
+    expect(Array.isArray(layers.learning.pastFailures)).toBe(true);
+    expect(typeof layers.learning.updatedAt).toBe("string");
+  });
+
+  it("issue와 phase는 서로 독립적이다 (이슈 정보는 issue 레이어에만 있다)", () => {
+    const layers = makePromptLayers();
+
+    expect(layers.issue.number).toBe(419);
+    expect(layers.issue.planSummary).toBe("5계층 레이어 분리");
+    // phase는 currentPhase와 previousResults만 가진다
+    expect(layers.phase).not.toHaveProperty("issue");
+    expect(layers.phase).not.toHaveProperty("planSummary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CacheKeyConfig 타입 계약
+// ---------------------------------------------------------------------------
+
+describe("CacheKeyConfig 구조", () => {
+  it("CacheKeyConfig 인터페이스에 맞는 객체를 생성할 수 있다", () => {
+    const config: CacheKeyConfig = {
+      base: { role: "Developer", rulesDigest: "abc123" },
+      project: { projectRoot: "/home/user/repo", conventionsDigest: "def456" },
+      issue: { repo: "owner/repo", issueNumber: 42, bodyDigest: "ghi789" },
+      learning: { repo: "owner/repo", issueNumber: 42, updatedAt: "2026-04-10T00:00:00.000Z" },
+    };
+
+    expect(config.base.role).toBe("Developer");
+    expect(config.project.projectRoot).toBe("/home/user/repo");
+    expect(config.issue.issueNumber).toBe(42);
+    expect(config.learning.updatedAt).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("PhaseLayer 캐시 키 재료는 CacheKeyConfig에 포함되지 않는다", () => {
+    const config: CacheKeyConfig = {
+      base: { role: "Developer", rulesDigest: "abc" },
+      project: { projectRoot: "/repo", conventionsDigest: "def" },
+      issue: { repo: "o/r", issueNumber: 1, bodyDigest: "ghi" },
+      learning: { repo: "o/r", issueNumber: 1, updatedAt: "2026-01-01T00:00:00.000Z" },
+    };
+
+    // phase는 키 없음 — 타입이 강제하는 계약 확인
+    expect(Object.keys(config)).not.toContain("phase");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLayerCacheKey 함수
+// ---------------------------------------------------------------------------
+
+describe("computeLayerCacheKey", () => {
+  it("16자리 소문자 16진수 문자열을 반환한다", () => {
+    const key = computeLayerCacheKey({ role: "Developer", rulesDigest: "abc123" });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("동일한 입력에 대해 항상 같은 키를 반환한다 (결정론적)", () => {
+    const fields = { role: "Developer", issueNumber: 42 };
+    expect(computeLayerCacheKey(fields)).toBe(computeLayerCacheKey(fields));
+  });
+
+  it("다른 입력에 대해 다른 키를 반환한다", () => {
+    expect(computeLayerCacheKey({ role: "Developer" }))
+      .not.toBe(computeLayerCacheKey({ role: "Architect" }));
+  });
+
+  it("키 순서에 무관하게 같은 결과를 반환한다 (순서 독립)", () => {
+    const key1 = computeLayerCacheKey({ a: "1", b: "2", c: "3" });
+    const key2 = computeLayerCacheKey({ c: "3", a: "1", b: "2" });
+    expect(key1).toBe(key2);
+  });
+
+  it("숫자 값을 처리할 수 있다", () => {
+    const key = computeLayerCacheKey({ issueNumber: 419, version: 1 });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("빈 객체에 대해서도 유효한 키를 반환한다", () => {
+    const key = computeLayerCacheKey({});
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("BaseLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const base = buildBaseLayer({ role: "시니어 개발자" });
+    const key = computeLayerCacheKey({
+      role: base.role,
+      rulesDigest: base.rules.join("|"),
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("IssueLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const issue = buildIssueLayer({
+      number: 42,
+      title: "Test",
+      body: "Body",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "P",
+    });
+    const key = computeLayerCacheKey({
+      repo: `${issue.repository.owner}/${issue.repository.name}`,
+      issueNumber: issue.number,
+      bodyDigest: issue.body,
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("LearningLayer 재료로 캐시 키를 계산할 수 있다", () => {
+    const learning = buildLearningLayer({ updatedAt: "2026-04-10T00:00:00.000Z" });
+    const key = computeLayerCacheKey({
+      repo: "owner/repo",
+      issueNumber: 42,
+      updatedAt: learning.updatedAt,
+    });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+});

--- a/tests/prompt/template-renderer.test.ts
+++ b/tests/prompt/template-renderer.test.ts
@@ -4,9 +4,13 @@ import {
   buildBaseLayer,
   buildProjectLayer,
   buildPhaseLayer,
+  buildIssueLayer,
+  buildLearningLayer,
+  computeLayerCacheKey,
   assemblePrompt
 } from "../../src/prompt/template-renderer.js";
 import type { PromptLayer } from "../../src/types/pipeline.js";
+import type { PromptLayers } from "../../src/prompt/layer-types.js";
 
 describe("renderTemplate", () => {
   it("should replace simple variables", () => {
@@ -315,5 +319,224 @@ Target Files: {{phase.files}}
     expect(typeof result.assemblyTimeMs).toBe("number");
     expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
     expect(result.assemblyTimeMs).toBeLessThan(1000); // Should be fast
+  });
+});
+
+describe("buildIssueLayer", () => {
+  it("should create issue layer with all required fields", () => {
+    const result = buildIssueLayer({
+      number: 42,
+      title: "Fix critical bug",
+      body: "Detailed description",
+      labels: ["bug", "priority"],
+      repository: {
+        owner: "my-org",
+        name: "my-repo",
+        baseBranch: "main",
+        workBranch: "fix/42-bug",
+      },
+      planSummary: "Fix the bug in 2 phases",
+    });
+
+    expect(result.number).toBe(42);
+    expect(result.title).toBe("Fix critical bug");
+    expect(result.body).toBe("Detailed description");
+    expect(result.labels).toEqual(["bug", "priority"]);
+    expect(result.repository.owner).toBe("my-org");
+    expect(result.repository.name).toBe("my-repo");
+    expect(result.repository.baseBranch).toBe("main");
+    expect(result.repository.workBranch).toBe("fix/42-bug");
+    expect(result.planSummary).toBe("Fix the bug in 2 phases");
+  });
+
+  it("should handle empty labels", () => {
+    const result = buildIssueLayer({
+      number: 1,
+      title: "Test",
+      body: "",
+      labels: [],
+      repository: { owner: "o", name: "r", baseBranch: "main", workBranch: "b" },
+      planSummary: "",
+    });
+    expect(result.labels).toEqual([]);
+  });
+});
+
+describe("buildLearningLayer", () => {
+  it("should create empty learning layer when no config provided", () => {
+    const result = buildLearningLayer();
+
+    expect(result.pastFailures).toEqual([]);
+    expect(result.errorPatterns).toEqual([]);
+    expect(result.learnedPatterns).toEqual([]);
+    expect(result.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("should create learning layer with provided data", () => {
+    const result = buildLearningLayer({
+      pastFailures: [
+        { context: "Phase 1", message: "Login error", resolution: "Run /login" },
+        { context: "Phase 2", message: "Type error" },
+      ],
+      errorPatterns: ["Not logged in", "TS error"],
+      learnedPatterns: ["Always check auth first"],
+      updatedAt: "2026-04-10T00:00:00.000Z",
+    });
+
+    expect(result.pastFailures).toHaveLength(2);
+    expect(result.pastFailures[0].context).toBe("Phase 1");
+    expect(result.pastFailures[0].resolution).toBe("Run /login");
+    expect(result.pastFailures[1].resolution).toBeUndefined();
+    expect(result.errorPatterns).toEqual(["Not logged in", "TS error"]);
+    expect(result.learnedPatterns).toEqual(["Always check auth first"]);
+    expect(result.updatedAt).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("should use defaults for missing optional fields", () => {
+    const result = buildLearningLayer({ updatedAt: "2026-04-10T00:00:00.000Z" });
+    expect(result.pastFailures).toEqual([]);
+    expect(result.errorPatterns).toEqual([]);
+    expect(result.learnedPatterns).toEqual([]);
+  });
+});
+
+describe("computeLayerCacheKey", () => {
+  it("should return 16-char hex string", () => {
+    const key = computeLayerCacheKey({ role: "Developer", rulesDigest: "abc123" });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("should produce consistent keys for same input", () => {
+    const fields = { role: "Developer", rulesDigest: "abc123" };
+    expect(computeLayerCacheKey(fields)).toBe(computeLayerCacheKey(fields));
+  });
+
+  it("should produce different keys for different inputs", () => {
+    const key1 = computeLayerCacheKey({ role: "Developer" });
+    const key2 = computeLayerCacheKey({ role: "Architect" });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("should be order-independent (sorts keys)", () => {
+    const key1 = computeLayerCacheKey({ a: "1", b: "2" });
+    const key2 = computeLayerCacheKey({ b: "2", a: "1" });
+    expect(key1).toBe(key2);
+  });
+
+  it("should handle numeric values", () => {
+    const key = computeLayerCacheKey({ issueNumber: 42, version: 1 });
+    expect(key).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+describe("assemblePrompt (5계층 PromptLayers)", () => {
+  function createFiveLayerLayers(): PromptLayers {
+    return {
+      base: buildBaseLayer({ role: "Test Developer" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM",
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+      }),
+      issue: buildIssueLayer({
+        number: 99,
+        title: "5-layer Test Issue",
+        body: "Issue body text",
+        labels: ["feature"],
+        repository: {
+          owner: "five-org",
+          name: "five-repo",
+          baseBranch: "main",
+          workBranch: "feat/99",
+        },
+        planSummary: "Five layer plan",
+      }),
+      phase: {
+        currentPhase: {
+          index: 2,
+          totalCount: 3,
+          name: "Implementation",
+          description: "Implement the feature",
+          targetFiles: ["src/feature.ts"],
+        },
+        previousResults: "Phase 1: SUCCESS",
+      },
+      learning: buildLearningLayer({
+        pastFailures: [{ context: "Phase 1", message: "Login required", resolution: "Run /login" }],
+        errorPatterns: ["Not logged in"],
+        learnedPatterns: ["Check auth before start"],
+        updatedAt: "2026-04-10T00:00:00.000Z",
+      }),
+    };
+  }
+
+  it("should assemble 5-layer prompt with all layer variables", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Role: {{role}}\nIssue #{{issue.number}}: {{issue.title}}\nPhase {{phase.index}}/{{phase.totalCount}}\nRepo: {{repository.owner}}/{{repository.name}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Role: Test Developer");
+    expect(result.content).toContain("Issue #99: 5-layer Test Issue");
+    expect(result.content).toContain("Phase 2/3");
+    expect(result.content).toContain("Repo: five-org/five-repo");
+    expect(result.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+    expect(result.cacheHit).toBe(false);
+    expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should include learning layer data in variables", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Patterns: {{errorPatterns}}\nLearned: {{learnedPatterns}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Not logged in");
+    expect(result.content).toContain("Check auth before start");
+  });
+
+  it("should include plan summary from issue layer", () => {
+    const layers = createFiveLayerLayers();
+    const template = "Plan: {{plan.summary}}";
+
+    const result = assemblePrompt(layers, template);
+
+    expect(result.content).toContain("Plan: Five layer plan");
+  });
+
+  it("should generate consistent cache keys for same 5-layer content", () => {
+    const layers1 = createFiveLayerLayers();
+    const layers2 = createFiveLayerLayers();
+
+    const r1 = assemblePrompt(layers1, "{{role}}");
+    const r2 = assemblePrompt(layers2, "{{role}}");
+
+    expect(r1.cacheKey).toBe(r2.cacheKey);
+  });
+
+  it("should generate different cache key from 3-layer for same role/conventions", () => {
+    const threeLayers = {
+      base: buildBaseLayer({ role: "Test Developer" }),
+      project: buildProjectLayer({
+        conventions: "TypeScript + ESM",
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+      }),
+      phase: buildPhaseLayer({
+        issue: { number: 99, title: "Test", body: "", labels: [] },
+        planSummary: "",
+        currentPhase: { index: 1, totalCount: 1, name: "P", description: "", targetFiles: [] },
+        previousResults: "",
+        repository: { owner: "five-org", name: "five-repo", baseBranch: "main", workBranch: "b" },
+      }),
+    };
+    const fiveLayers = createFiveLayerLayers();
+
+    const r3 = assemblePrompt(threeLayers, "{{role}}");
+    const r5 = assemblePrompt(fiveLayers, "{{role}}");
+
+    // Both produce valid 16-char hex keys
+    expect(r3.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+    expect(r5.cacheKey).toMatch(/^[a-f0-9]{16}$/);
   });
 });

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -2204,3 +2204,234 @@ describe("Dashboard API - SSE Connection Management", () => {
     });
   });
 });
+
+describe("Dashboard API - PUT /api/jobs/:id/priority", () => {
+  let app: Hono;
+  let localStore: JobStore;
+
+  const mockJob = {
+    id: "job-123",
+    issueNumber: 42,
+    repo: "owner/repo",
+    status: "queued" as const,
+    priority: "normal" as const,
+    createdAt: "2026-04-10T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const emitter = new EventEmitter();
+    localStore = {
+      list: vi.fn().mockReturnValue([]),
+      get: vi.fn(),
+      set: vi.fn(),
+      remove: vi.fn(),
+      update: vi.fn(),
+      on: emitter.on.bind(emitter),
+      emit: emitter.emit.bind(emitter),
+    } as any;
+
+    const localQueue = {
+      getStatus: vi.fn().mockReturnValue({ running: 0, queued: 0 }),
+      cancel: vi.fn(),
+      retryJob: vi.fn(),
+    } as any;
+
+    app = createDashboardRoutes(localStore, localQueue);
+  });
+
+  it("should update job priority to high", async () => {
+    const updatedJob = { ...mockJob, priority: "high" as const };
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+    vi.mocked(localStore.update).mockReturnValue(updatedJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "high" }),
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    expect(result.priority).toBe("high");
+    expect(localStore.update).toHaveBeenCalledWith("job-123", { priority: "high" });
+  });
+
+  it("should update job priority to normal", async () => {
+    const updatedJob = { ...mockJob, priority: "normal" as const };
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+    vi.mocked(localStore.update).mockReturnValue(updatedJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "normal" }),
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    expect(result.priority).toBe("normal");
+    expect(localStore.update).toHaveBeenCalledWith("job-123", { priority: "normal" });
+  });
+
+  it("should update job priority to low", async () => {
+    const updatedJob = { ...mockJob, priority: "low" as const };
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+    vi.mocked(localStore.update).mockReturnValue(updatedJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "low" }),
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json();
+    expect(result.priority).toBe("low");
+    expect(localStore.update).toHaveBeenCalledWith("job-123", { priority: "low" });
+  });
+
+  it("should return 404 when job not found", async () => {
+    vi.mocked(localStore.get).mockReturnValue(undefined);
+
+    const response = await app.request("/api/jobs/nonexistent/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "high" }),
+    });
+
+    expect(response.status).toBe(404);
+    const result = await response.json();
+    expect(result.error).toBe("Job not found");
+  });
+
+  it("should return 400 for invalid JSON body", async () => {
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "not-valid-json",
+    });
+
+    expect(response.status).toBe(400);
+    const result = await response.json();
+    expect(result.error).toBe("Invalid JSON body");
+  });
+
+  it("should return 400 for invalid priority value", async () => {
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "urgent" }),
+    });
+
+    expect(response.status).toBe(400);
+    const result = await response.json();
+    expect(result.error).toBe("Invalid request body");
+    expect(result.details).toBeDefined();
+  });
+
+  it("should return 400 for missing priority field", async () => {
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    const result = await response.json();
+    expect(result.error).toBe("Invalid request body");
+    expect(result.details).toBeDefined();
+  });
+
+  it("should return 400 for extra fields in request body", async () => {
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "high", extra: "field" }),
+    });
+
+    expect(response.status).toBe(400);
+    const result = await response.json();
+    expect(result.error).toBe("Invalid request body");
+    expect(result.details).toBeDefined();
+  });
+
+  it("should return 500 when store.update fails", async () => {
+    vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+    vi.mocked(localStore.update).mockReturnValue(undefined);
+
+    const response = await app.request("/api/jobs/job-123/priority", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priority: "high" }),
+    });
+
+    expect(response.status).toBe(500);
+    const result = await response.json();
+    expect(result.error).toBe("Failed to update priority");
+  });
+
+  describe("with API key", () => {
+    beforeEach(() => {
+      const apiKey = "test-api-key-123";
+      const emitter = new EventEmitter();
+      localStore = {
+        list: vi.fn().mockReturnValue([]),
+        get: vi.fn(),
+        set: vi.fn(),
+        remove: vi.fn(),
+        update: vi.fn(),
+        on: emitter.on.bind(emitter),
+        emit: emitter.emit.bind(emitter),
+      } as any;
+
+      const localQueue = {
+        getStatus: vi.fn().mockReturnValue({ running: 0, queued: 0 }),
+        cancel: vi.fn(),
+        retryJob: vi.fn(),
+      } as any;
+
+      app = createDashboardRoutes(localStore, localQueue, undefined, apiKey);
+    });
+
+    it("should return 401 without authentication", async () => {
+      const response = await app.request("/api/jobs/job-123/priority", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priority: "high" }),
+      });
+
+      expect(response.status).toBe(401);
+      const result = await response.json();
+      expect(result.error).toBe("Unauthorized");
+    });
+
+    it("should update priority with valid Bearer token", async () => {
+      const updatedJob = { ...mockJob, priority: "high" as const };
+      vi.mocked(localStore.get).mockReturnValue(mockJob as any);
+      vi.mocked(localStore.update).mockReturnValue(updatedJob as any);
+
+      const response = await app.request("/api/jobs/job-123/priority", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-api-key-123",
+        },
+        body: JSON.stringify({ priority: "high" }),
+      });
+
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result.priority).toBe("high");
+    });
+  });
+});

--- a/tests/tasks/aqm-task.test.ts
+++ b/tests/tasks/aqm-task.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   TaskStatus,
   AQMTaskType,
   AQMTaskSummary,
   AQMTask,
-  BaseTaskOptions
+  BaseTaskOptions,
+  SerializedTask,
+  TaskLifecycleEvent,
+  TaskEventEmitter,
+  TaskEventListener,
 } from "../../src/tasks/aqm-task.js";
 
 describe("AQMTask 인터페이스 및 타입 정의", () => {
@@ -155,6 +159,273 @@ describe("AQMTask 인터페이스 및 타입 정의", () => {
         type: "claude",
         status: TaskStatus.PENDING
       });
+    });
+
+    it("should support optional on/off/once event methods", () => {
+      // AQMTask interface defines on/off/once as optional
+      // A task without event support is valid
+      const task = new TestTask();
+      expect(task.on).toBeUndefined();
+      expect(task.off).toBeUndefined();
+      expect(task.once).toBeUndefined();
+    });
+
+    it("should support implementation with event methods", () => {
+      class EventedTask implements AQMTask {
+        readonly id = "evented-task";
+        readonly type: AQMTaskType = "claude";
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        get status() { return TaskStatus.PENDING; }
+        async kill() {}
+        toJSON(): AQMTaskSummary {
+          return { id: this.id, type: this.type, status: this.status };
+        }
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const task = new EventedTask();
+      const fn = vi.fn();
+      task.on("started", fn);
+      task.emit("started");
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      task.off("started", fn);
+      task.emit("started");
+      expect(fn).toHaveBeenCalledTimes(1); // not called again
+    });
+  });
+
+  describe("SerializedTask 타입", () => {
+    it("should be structurally identical to AQMTaskSummary", () => {
+      // SerializedTask = AQMTaskSummary (type alias)
+      const serialized: SerializedTask = {
+        id: "task-123",
+        type: "claude",
+        status: TaskStatus.SUCCESS
+      };
+
+      expect(serialized.id).toBe("task-123");
+      expect(serialized.type).toBe("claude");
+      expect(serialized.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should accept all optional fields", () => {
+      const serialized: SerializedTask = {
+        id: "task-456",
+        type: "codex",
+        status: TaskStatus.FAILED,
+        startedAt: "2026-04-10T10:00:00.000Z",
+        completedAt: "2026-04-10T10:01:00.000Z",
+        durationMs: 60000,
+        metadata: { prompt: "test", retryCount: 2 }
+      };
+
+      expect(serialized.startedAt).toBe("2026-04-10T10:00:00.000Z");
+      expect(serialized.completedAt).toBe("2026-04-10T10:01:00.000Z");
+      expect(serialized.durationMs).toBe(60000);
+      expect(serialized.metadata?.retryCount).toBe(2);
+    });
+
+    it("should be usable as AQMTaskSummary and vice versa", () => {
+      // SerializedTask and AQMTaskSummary are interchangeable
+      const summary: AQMTaskSummary = {
+        id: "task-789",
+        type: "gemini",
+        status: TaskStatus.PENDING
+      };
+
+      const serialized: SerializedTask = summary;
+      const backToSummary: AQMTaskSummary = serialized;
+
+      expect(backToSummary.id).toBe("task-789");
+    });
+  });
+
+  describe("TaskLifecycleEvent 타입", () => {
+    it("should accept all valid lifecycle event values", () => {
+      const events: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      expect(events).toHaveLength(4);
+      expect(events).toContain("started");
+      expect(events).toContain("completed");
+      expect(events).toContain("failed");
+      expect(events).toContain("killed");
+    });
+
+    it("should be usable as event key in a map", () => {
+      const callCounts = new Map<TaskLifecycleEvent, number>();
+      const allEvents: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      for (const event of allEvents) {
+        callCounts.set(event, 0);
+      }
+
+      callCounts.set("started", 1);
+      expect(callCounts.get("started")).toBe(1);
+    });
+  });
+
+  describe("TaskEventListener 타입", () => {
+    it("should be a callable with no parameters", () => {
+      const listener: TaskEventListener = vi.fn();
+      listener();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support multiple listener instances", () => {
+      const listeners: TaskEventListener[] = [vi.fn(), vi.fn(), vi.fn()];
+      listeners.forEach(l => l());
+
+      listeners.forEach(l => expect(l).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe("TaskEventEmitter 인터페이스", () => {
+    it("should be implementable with on/off/once methods", () => {
+      class SimpleEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const emitter = new SimpleEmitter();
+      const fn = vi.fn();
+
+      emitter.on("started", fn);
+      emitter.emit("started");
+      emitter.emit("started");
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      emitter.off("started", fn);
+      emitter.emit("started");
+      expect(fn).toHaveBeenCalledTimes(2); // not called again
+    });
+
+    it("should support once semantics — fires only once", () => {
+      class SimpleEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          [...(this._listeners.get(event) ?? [])].forEach(l => l());
+        }
+      }
+
+      const emitter = new SimpleEmitter();
+      const fn = vi.fn();
+
+      emitter.once("completed", fn);
+      emitter.emit("completed");
+      emitter.emit("completed");
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle all four lifecycle events independently", () => {
+      const calls: TaskLifecycleEvent[] = [];
+
+      class TrackingEmitter implements TaskEventEmitter {
+        private _listeners: Map<TaskLifecycleEvent, TaskEventListener[]> = new Map();
+
+        on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = this._listeners.get(event) ?? [];
+          list.push(listener);
+          this._listeners.set(event, list);
+        }
+
+        off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const list = (this._listeners.get(event) ?? []).filter(l => l !== listener);
+          this._listeners.set(event, list);
+        }
+
+        once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+          const wrapper: TaskEventListener = () => {
+            listener();
+            this.off(event, wrapper);
+          };
+          this.on(event, wrapper);
+        }
+
+        emit(event: TaskLifecycleEvent): void {
+          (this._listeners.get(event) ?? []).forEach(l => l());
+        }
+      }
+
+      const emitter = new TrackingEmitter();
+      const allEvents: TaskLifecycleEvent[] = ["started", "completed", "failed", "killed"];
+
+      for (const event of allEvents) {
+        emitter.on(event, () => calls.push(event));
+      }
+
+      emitter.emit("started");
+      emitter.emit("failed");
+      emitter.emit("killed");
+
+      expect(calls).toEqual(["started", "failed", "killed"]);
+      expect(calls).not.toContain("completed");
     });
   });
 });

--- a/tests/tasks/claude-task.test.ts
+++ b/tests/tasks/claude-task.test.ts
@@ -276,6 +276,99 @@ describe("ClaudeTask", () => {
     });
   });
 
+  describe("라이프사이클 이벤트", () => {
+    it("should emit started event when run begins", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit completed event on success", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await task.run();
+
+      expect(completedFn).toHaveBeenCalledTimes(1);
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it("should emit failed event on unsuccessful result", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: false, output: "err", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await task.run();
+
+      expect(failedFn).toHaveBeenCalledTimes(1);
+      expect(completedFn).not.toHaveBeenCalled();
+    });
+
+    it("should emit failed event on thrown error", async () => {
+      mockRunClaude.mockRejectedValueOnce(new Error("crash"));
+
+      const task = new ClaudeTask(testOptions);
+      const failedFn = vi.fn();
+      task.on("failed", failedFn);
+
+      await expect(task.run()).rejects.toThrow("crash");
+
+      expect(failedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit killed event when kill is called", async () => {
+      const task = new ClaudeTask(testOptions);
+      const killedFn = vi.fn();
+      task.on("killed", killedFn);
+
+      (task as any)._status = TaskStatus.RUNNING;
+      await task.kill();
+
+      expect(killedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support once listener (fires only once)", async () => {
+      mockRunClaude
+        .mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const onceFn = vi.fn();
+      task.once("started", onceFn);
+
+      await task.run();
+
+      expect(onceFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support off (remove listener)", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const task = new ClaudeTask(testOptions);
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+      task.off("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).not.toHaveBeenCalled();
+    });
+  });
+
   describe("직렬화", () => {
     it("should serialize task to JSON summary", () => {
       const task = new ClaudeTask({
@@ -347,6 +440,98 @@ describe("ClaudeTask", () => {
       expect(json.durationMs).toBeDefined();
       expect(typeof json.durationMs).toBe("number");
       expect(json.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("fromJSON", () => {
+    const baseConfig: ClaudeTaskOptions["config"] = {
+      path: "claude",
+      model: "sonnet",
+      maxTurns: 10,
+      timeout: 30000,
+      additionalArgs: []
+    };
+
+    it("should restore task from SerializedTask in PENDING state", () => {
+      const serialized = {
+        id: "restored-id",
+        type: "claude" as const,
+        status: TaskStatus.SUCCESS,
+        metadata: { prompt: "Restored prompt" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+
+      expect(task.id).toBe("restored-id");
+      expect(task.type).toBe("claude");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should restore prompt from metadata", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.FAILED,
+        metadata: { prompt: "Hello world" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const json = task.toJSON();
+
+      expect(json.metadata?.prompt).toBe("Hello world");
+    });
+
+    it("should restore optional fields from metadata", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.SUCCESS,
+        metadata: {
+          prompt: "Test",
+          systemPrompt: "Be helpful",
+          maxTurns: 5,
+          enableAgents: true
+        }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const json = task.toJSON();
+
+      expect(json.metadata?.systemPrompt).toBe("Be helpful");
+      expect(json.metadata?.maxTurns).toBe(5);
+      expect(json.metadata?.enableAgents).toBe(true);
+    });
+
+    it("should handle missing metadata gracefully", () => {
+      const serialized = {
+        id: "test-id",
+        type: "claude" as const,
+        status: TaskStatus.PENDING,
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+
+      expect(task.id).toBe("test-id");
+      expect(task.status).toBe(TaskStatus.PENDING);
+      const json = task.toJSON();
+      expect(json.metadata?.prompt).toBe("");
+    });
+
+    it("should be runnable after restoration", async () => {
+      mockRunClaude.mockResolvedValueOnce({ success: true, output: "ok", durationMs: 100 });
+
+      const serialized = {
+        id: "runnable-id",
+        type: "claude" as const,
+        status: TaskStatus.FAILED,
+        metadata: { prompt: "Run me again" }
+      };
+
+      const task = ClaudeTask.fromJSON(serialized, baseConfig);
+      const result = await task.run();
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
     });
   });
 });

--- a/tests/tasks/validation-task.test.ts
+++ b/tests/tasks/validation-task.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { ValidationTask, ValidationTaskOptions, ValidationTaskType } from "../../src/tasks/validation-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+
+// child_process spawn 모킹
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+import { spawn } from "child_process";
+const mockSpawn = vi.mocked(spawn);
+
+/**
+ * 가짜 ChildProcess를 생성하는 헬퍼
+ * stdout/stderr/process 이벤트를 직접 제어할 수 있다
+ */
+function createMockChild() {
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+    pid: number;
+  };
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.kill = vi.fn();
+  proc.pid = 12345;
+  return proc;
+}
+
+function makeOptions(
+  validationType: ValidationTaskType,
+  overrides: Partial<ValidationTaskOptions> = {}
+): ValidationTaskOptions {
+  return {
+    validationType,
+    command: "npx",
+    args: validationType === "typecheck"
+      ? ["tsc", "--noEmit"]
+      : validationType === "test"
+      ? ["vitest", "run"]
+      : ["eslint", "src/"],
+    cwd: "/fake/cwd",
+    ...overrides,
+  };
+}
+
+describe("ValidationTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 생성 및 기본 속성
+  // ---------------------------------------------------------------------------
+  describe("생성 및 기본 속성", () => {
+    it("should auto-generate UUID when id is not provided", () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      expect(task.id).toBeDefined();
+      expect(task.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("should use provided id", () => {
+      const task = new ValidationTask(makeOptions("typecheck", { id: "my-task" }));
+      expect(task.id).toBe("my-task");
+    });
+
+    it("should have type = 'validation'", () => {
+      const task = new ValidationTask(makeOptions("lint"));
+      expect(task.type).toBe("validation");
+    });
+
+    it("should start with PENDING status", () => {
+      const task = new ValidationTask(makeOptions("test"));
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should return undefined result before run", () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+      expect(task.getResult()).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // typecheck 성공 케이스
+  // ---------------------------------------------------------------------------
+  describe("typecheck 성공 케이스", () => {
+    it("should return SUCCESS status and parsed TscParseResult on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      // stdout 없이 종료
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+      expect(result.parsed).toMatchObject({ totalErrors: 0, hasErrors: false });
+    });
+
+    it("should collect stdout and stderr before close", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from("some output"));
+      child.stderr.emit("data", Buffer.from("some stderr"));
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.stdout).toBe("some output");
+      expect(result.stderr).toBe("some stderr");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // typecheck 실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("typecheck 실패 케이스", () => {
+    it("should return FAILED status and parsed errors on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const tscOutput =
+        "src/foo.ts(10,5): error TS2345: Argument of type 'string' is not assignable to type 'number'.\n";
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(tscOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number; errorsByFile: Record<string, string[]> };
+      expect(parsed.hasErrors).toBe(true);
+      expect(parsed.totalErrors).toBe(1);
+      expect(parsed.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // test 성공/실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("test 성공/실패 케이스", () => {
+    it("should parse vitest PASS output on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const vitestOutput = " PASS  tests/foo.test.ts\n";
+
+      const task = new ValidationTask(makeOptions("test"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(vitestOutput));
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+
+      const parsed = result.parsed as { hasFailures: boolean; passedFiles: string[]; failedFiles: string[] };
+      expect(parsed.hasFailures).toBe(false);
+      expect(parsed.passedFiles).toContain("tests/foo.test.ts");
+    });
+
+    it("should parse vitest FAIL output on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const vitestOutput = " FAIL  tests/bar.test.ts\n     × should work\n";
+
+      const task = new ValidationTask(makeOptions("test"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(vitestOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasFailures: boolean; failedFiles: string[]; failedTests: string[] };
+      expect(parsed.hasFailures).toBe(true);
+      expect(parsed.failedFiles).toContain("tests/bar.test.ts");
+      expect(parsed.failedTests).toContain("should work");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // lint 성공/실패 케이스
+  // ---------------------------------------------------------------------------
+  describe("lint 성공/실패 케이스", () => {
+    it("should parse eslint output on exit 0", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("lint"));
+      const runPromise = task.run();
+
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(true);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number };
+      expect(parsed.hasErrors).toBe(false);
+      expect(parsed.totalErrors).toBe(0);
+    });
+
+    it("should parse eslint errors on non-zero exit", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const eslintOutput =
+        "src/foo.ts\n  10:5  error  no-unused-vars  no-unused-vars\n\n";
+
+      const task = new ValidationTask(makeOptions("lint"));
+      const runPromise = task.run();
+
+      child.stdout.emit("data", Buffer.from(eslintOutput));
+      child.emit("close", 1);
+
+      const result = await runPromise;
+
+      expect(result.success).toBe(false);
+      expect(task.status).toBe(TaskStatus.FAILED);
+
+      const parsed = result.parsed as { hasErrors: boolean; totalErrors: number; errorsByFile: Record<string, string[]> };
+      expect(parsed.hasErrors).toBe(true);
+      expect(parsed.totalErrors).toBe(1);
+      expect(parsed.errorsByFile["src/foo.ts"]).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 중복 실행 방지
+  // ---------------------------------------------------------------------------
+  describe("중복 실행 방지", () => {
+    it("should throw when run() is called on already-running task", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      // 첫 번째 run은 닫히지 않은 채로 대기
+      const runPromise = task.run();
+
+      // 즉시 두 번째 run 시도
+      await expect(task.run()).rejects.toThrow(/already RUNNING/);
+
+      // 정리
+      child.emit("close", 0);
+      await runPromise;
+    });
+
+    it("should throw when run() is called on completed task", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      await expect(task.run()).rejects.toThrow(/already SUCCESS/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 프로세스 오류 이벤트
+  // ---------------------------------------------------------------------------
+  describe("프로세스 오류 이벤트", () => {
+    it("should reject run() and set FAILED status on spawn error event", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.emit("error", new Error("ENOENT: command not found"));
+
+      await expect(runPromise).rejects.toThrow("ENOENT: command not found");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+
+    it("should store error info in result on spawn error", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      child.emit("error", new Error("spawn failed"));
+
+      await expect(runPromise).rejects.toThrow();
+      expect(task.getResult()).toMatchObject({
+        success: false,
+        exitCode: 1,
+        stderr: "spawn failed",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // durationMs
+  // ---------------------------------------------------------------------------
+  describe("실행 시간 측정", () => {
+    it("should report non-negative durationMs", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+
+      const result = await runPromise;
+
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // kill()
+  // ---------------------------------------------------------------------------
+  describe("kill()", () => {
+    it("should set status to KILLED when task is running", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+
+      // 실행 중인 상태에서 kill
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+
+      // runPromise가 resolve될 수 있도록 close 이벤트 발생
+      child.emit("close", 0);
+      // kill 후에는 resolve되지 않을 수도 있으므로 race
+      await Promise.race([runPromise, Promise.resolve()]);
+    });
+
+    it("should be no-op when task is PENDING", async () => {
+      const task = new ValidationTask(makeOptions("typecheck"));
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should be no-op when task is already SUCCESS", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("should call kill on child process", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck"));
+      task.run(); // 대기하지 않음 — 비동기 실행 중
+
+      // 잠깐 대기하여 spawn이 호출된 상태가 되도록
+      await new Promise((r) => setTimeout(r, 0));
+
+      await task.kill();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toJSON()
+  // ---------------------------------------------------------------------------
+  describe("toJSON()", () => {
+    it("should include id, type, status in JSON", () => {
+      const task = new ValidationTask(makeOptions("typecheck", { id: "t-001" }));
+      const json = task.toJSON();
+
+      expect(json.id).toBe("t-001");
+      expect(json.type).toBe("validation");
+      expect(json.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("should include validationType and command in metadata", () => {
+      const task = new ValidationTask(makeOptions("lint", { id: "t-002" }));
+      const json = task.toJSON();
+
+      expect(json.metadata?.validationType).toBe("lint");
+      expect(json.metadata?.command).toBe("npx");
+      expect(json.metadata?.args).toEqual(["eslint", "src/"]);
+    });
+
+    it("should include execution result in metadata after run", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck", { id: "t-003" }));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      const json = task.toJSON();
+
+      expect(json.metadata?.success).toBe(true);
+      expect(json.metadata?.exitCode).toBe(0);
+      expect(json.durationMs).toBeGreaterThanOrEqual(0);
+      expect(json.startedAt).toBeDefined();
+      expect(json.completedAt).toBeDefined();
+    });
+
+    it("should include custom metadata", () => {
+      const task = new ValidationTask(
+        makeOptions("test", { id: "t-004", metadata: { issueId: 42 } })
+      );
+      const json = task.toJSON();
+
+      expect(json.metadata?.issueId).toBe(42);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // spawn 호출 검증
+  // ---------------------------------------------------------------------------
+  describe("spawn 호출 검증", () => {
+    it("should call spawn with correct command and args", async () => {
+      const child = createMockChild();
+      mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+      const task = new ValidationTask(makeOptions("typecheck", { cwd: "/my/project" }));
+      const runPromise = task.run();
+      child.emit("close", 0);
+      await runPromise;
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "npx",
+        ["tsc", "--noEmit"],
+        expect.objectContaining({ cwd: "/my/project" })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #420 — refactor: core-loop 프롬프트 조립 리팩터 — 레이어별 재사용

현재 core-loop.ts에서 Base+Project 레이어를 buildStaticContent()로 조립하여 cachedLayers.staticContent에 캐싱하지만, phase-executor.ts에서 이 staticContent를 실제로 사용하지 않고 매 Phase마다 전체 템플릿을 다시 렌더링한다. 레이어 1-2(Base, Project)는 파이프라인 시작 시 1회만 조립하고, 레이어 3-5(Issue, Phase, Learning)만 Phase마다 재조립하도록 리팩터링이 필요하다.

## Requirements

- 레이어 1-2(Base, Project)는 파이프라인 시작 시 1회 조립하여 캐싱
- 레이어 3-5(Issue, Phase, Learning)만 Phase마다 재조립
- phase-executor.ts가 cachedLayers.staticContent를 실제로 활용
- prompts/phase-implementation.md를 정적/동적 부분으로 분리
- 기존 동작 100% 유지 (하위 호환성)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: 프롬프트 템플릿 레이어 분리 — SUCCESS (e53a3f6e)
- Phase 1: template-renderer 레이어 조립 함수 개선 — SUCCESS (2420c37b)
- Phase 2: core-loop 캐시 로직 명확화 — SUCCESS (895c6c8d)
- Phase 3: phase-executor 캐시된 레이어 활용 — SUCCESS (1b94570e)
- Phase 4: 테스트 추가 및 전체 검증 — SUCCESS (cdee6ac5)
- Phase 5: 테스트 및 검증 — SUCCESS (95c18c9a)

## Risks

- 기존 프롬프트 출력 변경으로 인한 Claude 응답 품질 저하
- 템플릿 분리 시 변수 누락 가능성
- cachedLayers 구조 변경 시 하위 호환성 문제

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 6/6 completed
- **Branch**: `aq/420-refactor-core-loop` → `develop`
- **Tokens**: 84 input, 9104 output{{#stats.cacheCreationTokens}}, 135743 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 808114 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #420