### PR TITLE
[AQ-#433] feat: job-queue 우선순위 기반 정렬 — priority 높은 잡 먼저 처리

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -297,7 +297,7 @@ export class JobQueue {
   /**
    * Enqueues a new job. Returns the job or undefined if duplicate.
    */
-  enqueue(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean): Job | undefined {
+  enqueue(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, priority?: import("../types/pipeline.js").JobPriority): Job | undefined {
     if (this.shuttingDown) {
       logger.warn(`Job for issue #${issueNumber} (${repo}) rejected — queue is shutting down`);
       return undefined;
@@ -326,7 +326,7 @@ export class JobQueue {
       }
     }
 
-    const job = this.store.create(issueNumber, repo, dependencies, isRetry);
+    const job = this.store.create(issueNumber, repo, dependencies, isRetry, undefined, priority);
     // Convert StoreJob to discriminated union Job type
     const snapshot = convertStoreJobToJob(job);
     this.pending.push(job.id);
@@ -583,6 +583,45 @@ export class JobQueue {
     }
   }
 
+  /**
+   * Gets the highest priority job from the pending queue and removes it.
+   * Priority order: high (0) > normal (1) > low (2)
+   * Within same priority: FIFO (earliest createdAt first)
+   * Missing priority defaults to 'normal'
+   */
+  private getNextPriorityJob(): string | null {
+    if (this.pending.length === 0) return null;
+
+    let bestIndex = -1;
+    let bestPriorityValue = 3; // Lower than 'low' (2)
+    let bestCreatedAt = '';
+
+    // Find the job with highest priority (lowest numeric value)
+    for (let i = 0; i < this.pending.length; i++) {
+      const jobId = this.pending[i];
+      const job = this.store.get(jobId);
+      if (!job) continue;
+
+      // Map priority to numeric value for comparison: high=0, normal=1, low=2
+      const priority = job.priority ?? 'normal';
+      const priorityValue = priority === 'high' ? 0 : priority === 'normal' ? 1 : 2;
+
+      // Select if higher priority, or same priority but earlier created, or first job
+      if (bestIndex === -1 ||
+          priorityValue < bestPriorityValue ||
+          (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)) {
+        bestIndex = i;
+        bestPriorityValue = priorityValue;
+        bestCreatedAt = job.createdAt;
+      }
+    }
+
+    if (bestIndex >= 0) {
+      return this.pending.splice(bestIndex, 1)[0];
+    }
+    return null;
+  }
+
   private async processNext(): Promise<void> {
     // Prevent re-entrancy
     if (this.isProcessing) {
@@ -598,7 +637,8 @@ export class JobQueue {
       const deferred: string[] = [];
 
       while (this.running.size < this.concurrency && this.pending.length > 0) {
-        const jobId = this.pending.shift()!;
+        const jobId = this.getNextPriorityJob();
+        if (!jobId) break; // No valid jobs available
 
         if (this.cancelled.has(jobId)) {
           this.cancelled.delete(jobId);

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -290,7 +290,7 @@ export class JobStore extends EventEmitter {
     };
   }
 
-  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, initialPhaseResults?: PhaseResultInfo[]): QueuedJob {
+  create(issueNumber: number, repo: string, dependencies?: number[], isRetry?: boolean, initialPhaseResults?: PhaseResultInfo[], priority?: import("../types/pipeline.js").JobPriority): QueuedJob {
     const id = `aq-${issueNumber}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const job: QueuedJob = {
       id,
@@ -301,6 +301,7 @@ export class JobStore extends EventEmitter {
       ...(dependencies && dependencies.length > 0 ? { dependencies } : {}),
       ...(isRetry ? { isRetry } : {}),
       ...(initialPhaseResults && initialPhaseResults.length > 0 ? { phaseResults: initialPhaseResults } : {}),
+      ...(priority ? { priority } : {}),
     };
 
     // SQLite에 저장

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1572,4 +1572,115 @@ describe("JobQueue", () => {
       expect(handler).toHaveBeenCalledTimes(5);
     });
   });
+
+  describe("Priority Queue", () => {
+    it("should execute jobs in priority order: high -> normal -> low", async () => {
+      const executionOrder: number[] = [];
+      let firstJobStarted = false;
+      let resolveFirst: (() => void) | null = null;
+
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+
+        if (!firstJobStarted) {
+          firstJobStarted = true;
+          // Block first job until all jobs are enqueued
+          return new Promise<{ prUrl: string }>((resolve) => {
+            resolveFirst = () => resolve({ prUrl: "https://test-pr" });
+          });
+        } else {
+          // Other jobs complete quickly
+          await new Promise(r => setTimeout(r, 10));
+          return { prUrl: "https://test-pr" };
+        }
+      });
+
+      const queue = new JobQueue(store, 1, handler); // concurrency=1 for sequential execution
+
+      // Enqueue jobs in mixed order
+      queue.enqueue(1, "test/repo", undefined, false, "low");
+      await new Promise(r => setTimeout(r, 20)); // Let first job start
+
+      queue.enqueue(2, "test/repo", undefined, false, "high");
+      queue.enqueue(3, "test/repo", undefined, false, "normal");
+      queue.enqueue(4, "test/repo", undefined, false, "high");
+      queue.enqueue(5, "test/repo", undefined, false, "low");
+
+      // Wait a moment for all jobs to be queued
+      await new Promise(r => setTimeout(r, 50));
+
+      // Now release the first job
+      if (resolveFirst) resolveFirst();
+
+      // Wait for all jobs to complete
+      await new Promise(r => setTimeout(r, 200));
+
+      expect(handler).toHaveBeenCalledTimes(5);
+      // Should execute in order: low(1) first, then high(2,4), normal(3), low(5)
+      expect(executionOrder).toEqual([1, 2, 4, 3, 5]);
+    });
+
+    it("should treat jobs without priority as normal priority", async () => {
+      const executionOrder: number[] = [];
+      let firstJobStarted = false;
+      let resolveFirst: (() => void) | null = null;
+
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+
+        if (!firstJobStarted) {
+          firstJobStarted = true;
+          return new Promise<{ prUrl: string }>((resolve) => {
+            resolveFirst = () => resolve({ prUrl: "https://test-pr" });
+          });
+        } else {
+          await new Promise(r => setTimeout(r, 10));
+          return { prUrl: "https://test-pr" };
+        }
+      });
+
+      const queue = new JobQueue(store, 1, handler);
+
+      // Mix jobs with and without priority
+      queue.enqueue(1, "test/repo", undefined, false, "low");
+      await new Promise(r => setTimeout(r, 20));
+
+      queue.enqueue(2, "test/repo"); // no priority (should be normal)
+      queue.enqueue(3, "test/repo", undefined, false, "high");
+      queue.enqueue(4, "test/repo"); // no priority (should be normal)
+
+      await new Promise(r => setTimeout(r, 50));
+
+      // Release first job
+      if (resolveFirst) resolveFirst();
+
+      await new Promise(r => setTimeout(r, 150));
+
+      expect(handler).toHaveBeenCalledTimes(4);
+      // low(1) first, then high(3), normal(2,4),
+      expect(executionOrder).toEqual([1, 3, 2, 4]);
+    });
+
+    it("should maintain FIFO order within same priority level", async () => {
+      const executionOrder: number[] = [];
+      const handler: JobHandler = vi.fn().mockImplementation(async (job) => {
+        executionOrder.push(job.issueNumber);
+        await new Promise(r => setTimeout(r, 20));
+        return { prUrl: "https://test-pr" };
+      });
+
+      const queue = new JobQueue(store, 1, handler); // concurrency=1 ensures sequential execution
+
+      // Enqueue multiple jobs with same priority
+      queue.enqueue(1, "test/repo", undefined, false, "normal");
+      queue.enqueue(2, "test/repo", undefined, false, "normal");
+      queue.enqueue(3, "test/repo", undefined, false, "normal");
+
+      await new Promise(r => setTimeout(r, 150));
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      // Should maintain FIFO order for same priority
+      expect(executionOrder).toEqual([1, 2, 3]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #433 — feat: job-queue 우선순위 기반 정렬 — priority 높은 잡 먼저 처리

현재 JobQueue의 processNext()는 pending 배열을 FIFO(shift)로 처리하여 먼저 들어온 잡을 먼저 실행한다. priority 필드(high/normal/low)가 이미 타입에 정의되어 있지만, 실제 정렬에 반영되지 않아 우선순위가 높은 잡이 대기열에서 뒤로 밀릴 수 있다.

## Requirements

- priority 기준 정렬: high > normal > low 순서로 먼저 처리
- 동일 priority 내에서는 createdAt 오름차순 (먼저 생성된 잡 우선)
- priority 미지정 잡은 normal로 취급
- 기존 동작 호환: priority 없는 잡들만 있을 때 기존 FIFO 동작 유지

## Implementation Phases

- Phase 0: 타입 정의 추가 — SUCCESS (7d425059)
- Phase 1: DB 스키마 수정 — SUCCESS (3173a7e3)
- Phase 2: JobStore 수정 — SUCCESS (628c92ef)
- Phase 3: JobQueue 정렬 로직 — SUCCESS (954cb881)
- Phase 4: 테스트 추가 — SUCCESS (47abb506)

## Risks

- 정렬 로직이 매 processNext() 호출마다 실행되어 대량 pending 시 성능 영향 (현실적으로 큐 크기가 작아 무시 가능)
- deferred 잡 재추가 시 정렬 순서 깨질 수 있음 (정렬은 shift 전에 수행하므로 문제없음)

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/433-feat-job-queue-priority` → `develop`
- **Tokens**: 52 input, 3219 output{{#stats.cacheCreationTokens}}, 49995 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 213022 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #433