### PR TITLE
[AQ-#439] feat: 자동화 규칙 관리 UI — 대시보드 automations 메뉴

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -592,6 +592,10 @@ if (localStorage.getItem('aqm-theme') === 'light') {
           <span class="material-symbols-outlined text-sm">view_kanban</span>
           <span>Kanban</span>
         </button>
+        <button id="btn-automations-rules" onclick="setAutomationsView('rules')" class="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-bold transition-colors text-outline hover:text-on-surface">
+          <span class="material-symbols-outlined text-sm">smart_toy</span>
+          <span>Rules</span>
+        </button>
       </div>
     </div>
 
@@ -622,6 +626,20 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     <div id="automations-kanban-view" class="hidden">
       <div id="kanban-board" class="flex gap-6 overflow-x-auto custom-scrollbar pb-4" style="min-height: 60vh;">
         <!-- Columns populated by renderKanban() -->
+      </div>
+    </div>
+
+    <!-- Rules View -->
+    <div id="automations-rules-view" class="hidden">
+      <div class="flex items-center justify-between mb-4">
+        <p class="text-xs text-outline">이벤트 발생 시 자동으로 실행되는 규칙을 관리합니다.</p>
+        <button onclick="showAddRuleModal()" class="flex items-center gap-2 px-3 py-1.5 bg-primary text-on-primary rounded-lg text-xs font-bold hover:bg-primary/90 transition-colors">
+          <span class="material-symbols-outlined text-sm">add</span>
+          <span>규칙 추가</span>
+        </button>
+      </div>
+      <div id="rules-container">
+        <!-- Rules rendered by loadAutomationRules() -->
       </div>
     </div>
 
@@ -736,6 +754,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 <script src="js/render.js"></script>
 <script src="js/kanban.js"></script>
 <script src="js/timeline.js"></script>
+<script src="js/automations.js"></script>
 <script src="js/app.js"></script>
 
 <!-- Confirm Modal -->

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -697,18 +697,29 @@ applyTranslations();
   }
   initArchivedToggle();
 
-  // Restore automations view toggle state (kanban button/panel visibility)
-  if (currentAutomationsView === 'kanban') {
+  // Restore automations view toggle state
+  if (currentAutomationsView === 'kanban' || currentAutomationsView === 'rules') {
     var btnList    = document.getElementById('btn-automations-list');
     var btnKanban  = document.getElementById('btn-automations-kanban');
+    var btnRules   = document.getElementById('btn-automations-rules');
     var listView   = document.getElementById('automations-list-view');
     var kanbanView = document.getElementById('automations-kanban-view');
+    var rulesView  = document.getElementById('automations-rules-view');
     var activeClass   = 'flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-bold transition-colors bg-primary/10 text-primary';
     var inactiveClass = 'flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-bold transition-colors text-outline hover:text-on-surface';
     if (btnList)   btnList.className   = inactiveClass;
-    if (btnKanban) btnKanban.className = activeClass;
+    if (btnKanban) btnKanban.className = inactiveClass;
+    if (btnRules)  btnRules.className  = inactiveClass;
     if (listView)   listView.classList.add('hidden');
-    if (kanbanView) kanbanView.classList.remove('hidden');
+    if (kanbanView) kanbanView.classList.add('hidden');
+    if (rulesView)  rulesView.classList.add('hidden');
+    if (currentAutomationsView === 'kanban') {
+      if (btnKanban)  btnKanban.className = activeClass;
+      if (kanbanView) kanbanView.classList.remove('hidden');
+    } else {
+      if (btnRules)  btnRules.className  = activeClass;
+      if (rulesView) rulesView.classList.remove('hidden');
+    }
   }
 })();
 
@@ -825,23 +836,35 @@ function setAutomationsView(view) {
 
   var listView   = document.getElementById('automations-list-view');
   var kanbanView = document.getElementById('automations-kanban-view');
+  var rulesView  = document.getElementById('automations-rules-view');
   var btnList    = document.getElementById('btn-automations-list');
   var btnKanban  = document.getElementById('btn-automations-kanban');
+  var btnRules   = document.getElementById('btn-automations-rules');
 
   var activeClass   = 'flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-bold transition-colors bg-primary/10 text-primary';
   var inactiveClass = 'flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-bold transition-colors text-outline hover:text-on-surface';
 
+  // Hide all views
+  if (listView)   listView.classList.add('hidden');
+  if (kanbanView) kanbanView.classList.add('hidden');
+  if (rulesView)  rulesView.classList.add('hidden');
+
+  // Reset all buttons
+  if (btnList)   btnList.className   = inactiveClass;
+  if (btnKanban) btnKanban.className = inactiveClass;
+  if (btnRules)  btnRules.className  = inactiveClass;
+
   if (view === 'kanban') {
-    if (listView)   listView.classList.add('hidden');
     if (kanbanView) kanbanView.classList.remove('hidden');
-    if (btnList)   btnList.className   = inactiveClass;
-    if (btnKanban) btnKanban.className = activeClass;
+    if (btnKanban)  btnKanban.className = activeClass;
     renderAutomationsKanban();
+  } else if (view === 'rules') {
+    if (rulesView) rulesView.classList.remove('hidden');
+    if (btnRules)  btnRules.className = activeClass;
+    loadAutomationRules();
   } else {
-    if (listView)   listView.classList.remove('hidden');
-    if (kanbanView) kanbanView.classList.add('hidden');
-    if (btnList)   btnList.className   = activeClass;
-    if (btnKanban) btnKanban.className = inactiveClass;
+    if (listView) listView.classList.remove('hidden');
+    if (btnList)  btnList.className = activeClass;
     renderAutomationsList();
   }
 }
@@ -888,6 +911,8 @@ function renderAutomationsPanel() {
   if (currentView !== 'automations') return;
   if (currentAutomationsView === 'kanban') {
     renderAutomationsKanban();
+  } else if (currentAutomationsView === 'rules') {
+    // rules view는 loadAutomationRules()로 직접 갱신 — SSE 업데이트 시 재로드 불필요
   } else {
     renderAutomationsList();
   }

--- a/src/server/public/js/automations.js
+++ b/src/server/public/js/automations.js
@@ -1,0 +1,290 @@
+'use strict';
+
+/* ══════════════════════════════════════════════════════════════
+   Automation Rules Management
+   ══════════════════════════════════════════════════════════════ */
+var automationRules = [];
+
+function loadAutomationRules() {
+  var container = document.getElementById('rules-container');
+  if (!container) return;
+
+  container.innerHTML = '<div class="flex items-center justify-center py-16 text-outline text-sm"><span class="material-symbols-outlined text-lg mr-2 animate-spin">sync</span>규칙을 로딩 중...</div>';
+
+  apiFetch('/api/config')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      automationRules = (data.config && data.config.automations) || [];
+      renderAutomationRules();
+    })
+    .catch(function() {
+      container.innerHTML = '<div class="flex items-center justify-center py-16 text-outline text-sm"><span class="material-symbols-outlined text-lg mr-2">error</span>규칙을 불러오는데 실패했습니다.</div>';
+    });
+}
+
+function renderAutomationRules() {
+  var container = document.getElementById('rules-container');
+  if (!container) return;
+
+  if (automationRules.length === 0) {
+    container.innerHTML =
+      '<div class="flex flex-col items-center justify-center py-16 text-center">' +
+        '<span class="material-symbols-outlined text-5xl text-outline/30 mb-4">smart_toy</span>' +
+        '<p class="text-sm font-bold text-on-surface mb-1">자동화 규칙이 없습니다</p>' +
+        '<p class="text-xs text-outline mb-4">규칙을 추가하면 이벤트 발생 시 자동으로 액션이 실행됩니다.</p>' +
+        '<button onclick="showAddRuleModal()" class="flex items-center gap-2 px-4 py-2 bg-primary text-on-primary rounded-lg text-sm font-bold hover:bg-primary/90 transition-colors">' +
+          '<span class="material-symbols-outlined text-sm">add</span>' +
+          '<span>첫 번째 규칙 추가</span>' +
+        '</button>' +
+      '</div>';
+    return;
+  }
+
+  container.innerHTML =
+    '<div class="space-y-3">' +
+      automationRules.map(function(rule) { return renderRuleCard(rule); }).join('') +
+    '</div>';
+}
+
+function renderRuleCard(rule) {
+  var isEnabled = rule.enabled !== false;
+  var triggerLabel = getTriggerLabel(rule.trigger);
+  var actionsLabel = rule.actions.map(function(a) { return getActionLabel(a); }).join(', ');
+
+  return (
+    '<div class="bg-surface-container rounded-xl ring-1 ' + (isEnabled ? 'ring-outline-variant/20' : 'ring-outline-variant/10 opacity-60') + ' p-5 flex items-start gap-4">' +
+      '<div class="flex-1 min-w-0">' +
+        '<div class="flex items-center gap-2 mb-1">' +
+          '<span class="font-mono text-xs text-primary/70 bg-primary/10 px-2 py-0.5 rounded">' + esc(rule.id) + '</span>' +
+          (rule.description ? '<span class="text-sm font-bold text-on-surface truncate">' + esc(rule.description) + '</span>' : '') +
+        '</div>' +
+        '<div class="flex items-center gap-3 text-xs text-outline mt-2">' +
+          '<span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">bolt</span>' + esc(triggerLabel) + '</span>' +
+          '<span class="text-outline/40">→</span>' +
+          '<span class="flex items-center gap-1"><span class="material-symbols-outlined text-sm">play_arrow</span>' + esc(actionsLabel) + '</span>' +
+        '</div>' +
+      '</div>' +
+      '<div class="flex items-center gap-2 shrink-0">' +
+        '<button onclick="toggleAutomationRule(\'' + esc(rule.id) + '\')" title="' + (isEnabled ? '비활성화' : '활성화') + '" ' +
+          'class="flex items-center gap-1 px-2 py-1 rounded text-xs font-bold transition-colors ' +
+          (isEnabled ? 'text-[#3fb950] hover:bg-[#3fb950]/10' : 'text-outline hover:bg-surface-container-high') + '">' +
+          '<span class="material-symbols-outlined text-sm">' + (isEnabled ? 'toggle_on' : 'toggle_off') + '</span>' +
+        '</button>' +
+        '<button onclick="showEditRuleModal(\'' + esc(rule.id) + '\')" title="편집" ' +
+          'class="flex items-center gap-1 px-2 py-1 rounded text-xs text-outline hover:text-on-surface hover:bg-surface-container-high transition-colors">' +
+          '<span class="material-symbols-outlined text-sm">edit</span>' +
+        '</button>' +
+        '<button onclick="deleteAutomationRule(\'' + esc(rule.id) + '\')" title="삭제" ' +
+          'class="flex items-center gap-1 px-2 py-1 rounded text-xs text-outline hover:text-error hover:bg-error/10 transition-colors">' +
+          '<span class="material-symbols-outlined text-sm">delete</span>' +
+        '</button>' +
+      '</div>' +
+    '</div>'
+  );
+}
+
+function getTriggerLabel(trigger) {
+  if (!trigger) return '알 수 없음';
+  if (trigger.type === 'cron') return 'Cron: ' + (trigger.schedule || '');
+  if (trigger.type === 'event') return 'Event: ' + (trigger.event || '');
+  if (trigger.type === 'rate-limit') return 'Rate Limit: ' + (trigger.threshold || '') + '회';
+  return trigger.type;
+}
+
+function getActionLabel(action) {
+  if (!action) return '';
+  var labels = { notify: '알림', pause: '일시정지', retry: '재시도', label: '라벨', close: '종료' };
+  return labels[action.type] || action.type;
+}
+
+function toggleAutomationRule(id) {
+  var rule = automationRules.find(function(r) { return r.id === id; });
+  if (!rule) return;
+  rule.enabled = !(rule.enabled !== false);
+  saveAutomationRules(function() { renderAutomationRules(); });
+}
+
+function deleteAutomationRule(id) {
+  showConfirm('이 자동화 규칙을 삭제하시겠습니까?', '').then(function(ok) {
+    if (!ok) return;
+    automationRules = automationRules.filter(function(r) { return r.id !== id; });
+    saveAutomationRules(function() { renderAutomationRules(); });
+  });
+}
+
+function saveAutomationRules(onSuccess) {
+  apiFetch('/api/config')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var config = data.config || {};
+      config.automations = automationRules;
+      return apiFetch('/api/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config)
+      });
+    })
+    .then(function(r) {
+      if (r.ok && onSuccess) onSuccess();
+    })
+    .catch(function() {});
+}
+
+/* ── Add / Edit Modal ─────────────────────────────────────────── */
+
+function showAddRuleModal() {
+  openRuleModal(null);
+}
+
+function showEditRuleModal(id) {
+  var rule = automationRules.find(function(r) { return r.id === id; });
+  if (!rule) return;
+  openRuleModal(rule);
+}
+
+function openRuleModal(rule) {
+  var existingModal = document.getElementById('rule-modal');
+  if (existingModal) existingModal.remove();
+
+  var isEdit = rule !== null;
+  var title = isEdit ? '규칙 편집' : '규칙 추가';
+
+  var idVal          = rule ? rule.id : '';
+  var descVal        = rule ? (rule.description || '') : '';
+  var triggerType    = rule ? rule.trigger.type : 'event';
+  var triggerEvent   = rule ? (rule.trigger.event || 'pr-merged') : 'pr-merged';
+  var triggerSched   = rule ? (rule.trigger.schedule || 'daily') : 'daily';
+  var triggerThresh  = rule ? (rule.trigger.threshold || 3) : 3;
+  var actionType     = rule ? (rule.actions[0] ? rule.actions[0].type : 'notify') : 'notify';
+  var enabledVal     = rule ? (rule.enabled !== false) : true;
+
+  var fieldCls = 'w-full bg-surface-container-high border border-outline-variant/30 rounded-lg px-3 py-2 text-sm text-on-surface focus:border-primary focus:outline-none';
+  var labelCls = 'block text-xs font-bold text-outline mb-1';
+
+  var html =
+    '<div id="rule-modal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">' +
+    '<div class="bg-surface-container-lowest rounded-xl p-6 w-full max-w-md mx-4 border border-outline-variant/20">' +
+    '<div class="flex justify-between items-center mb-5">' +
+      '<h3 class="text-base font-bold text-on-surface">' + title + '</h3>' +
+      '<button onclick="closeRuleModal()" class="text-outline hover:text-on-surface"><span class="material-symbols-outlined">close</span></button>' +
+    '</div>' +
+    '<form id="rule-form" class="space-y-4">' +
+      '<div>' +
+        '<label class="' + labelCls + '">ID</label>' +
+        '<input id="rule-id" type="text" value="' + esc(idVal) + '" ' + (isEdit ? 'readonly' : '') +
+          ' placeholder="예: auto-notify-failure" class="' + fieldCls + (isEdit ? ' opacity-60 cursor-not-allowed' : '') + '">' +
+      '</div>' +
+      '<div>' +
+        '<label class="' + labelCls + '">설명 (선택)</label>' +
+        '<input id="rule-desc" type="text" value="' + esc(descVal) + '" placeholder="이 규칙에 대한 설명" class="' + fieldCls + '">' +
+      '</div>' +
+      '<div>' +
+        '<label class="' + labelCls + '">트리거 유형</label>' +
+        '<select id="rule-trigger-type" onchange="onTriggerTypeChange()" class="' + fieldCls + '">' +
+          '<option value="event"' + (triggerType === 'event' ? ' selected' : '') + '>Event (이벤트)</option>' +
+          '<option value="cron"' + (triggerType === 'cron' ? ' selected' : '') + '>Cron (스케줄)</option>' +
+          '<option value="rate-limit"' + (triggerType === 'rate-limit' ? ' selected' : '') + '>Rate Limit (임계값)</option>' +
+        '</select>' +
+      '</div>' +
+      '<div id="trigger-event-field"' + (triggerType !== 'event' ? ' class="hidden"' : '') + '>' +
+        '<label class="' + labelCls + '">이벤트</label>' +
+        '<select id="rule-trigger-event" class="' + fieldCls + '">' +
+          '<option value="pr-merged"' + (triggerEvent === 'pr-merged' ? ' selected' : '') + '>PR Merged</option>' +
+          '<option value="phase-failed"' + (triggerEvent === 'phase-failed' ? ' selected' : '') + '>Phase Failed</option>' +
+        '</select>' +
+      '</div>' +
+      '<div id="trigger-cron-field"' + (triggerType !== 'cron' ? ' class="hidden"' : '') + '>' +
+        '<label class="' + labelCls + '">스케줄</label>' +
+        '<select id="rule-trigger-schedule" class="' + fieldCls + '">' +
+          '<option value="daily"' + (triggerSched === 'daily' ? ' selected' : '') + '>매일 (daily)</option>' +
+          '<option value="weekly"' + (triggerSched === 'weekly' ? ' selected' : '') + '>매주 (weekly)</option>' +
+        '</select>' +
+      '</div>' +
+      '<div id="trigger-threshold-field"' + (triggerType !== 'rate-limit' ? ' class="hidden"' : '') + '>' +
+        '<label class="' + labelCls + '">임계값 (회)</label>' +
+        '<input id="rule-trigger-threshold" type="number" min="1" value="' + triggerThresh + '" class="' + fieldCls + '">' +
+      '</div>' +
+      '<div>' +
+        '<label class="' + labelCls + '">액션</label>' +
+        '<select id="rule-action-type" class="' + fieldCls + '">' +
+          '<option value="notify"' + (actionType === 'notify' ? ' selected' : '') + '>알림 (notify)</option>' +
+          '<option value="pause"' + (actionType === 'pause' ? ' selected' : '') + '>일시정지 (pause)</option>' +
+          '<option value="retry"' + (actionType === 'retry' ? ' selected' : '') + '>재시도 (retry)</option>' +
+          '<option value="label"' + (actionType === 'label' ? ' selected' : '') + '>라벨 (label)</option>' +
+          '<option value="close"' + (actionType === 'close' ? ' selected' : '') + '>종료 (close)</option>' +
+        '</select>' +
+      '</div>' +
+      '<div class="flex items-center gap-2">' +
+        '<input id="rule-enabled" type="checkbox"' + (enabledVal ? ' checked' : '') + ' class="w-4 h-4 accent-primary">' +
+        '<label for="rule-enabled" class="text-sm text-on-surface">활성화</label>' +
+      '</div>' +
+      '<div class="flex gap-2 pt-2">' +
+        '<button type="submit" class="flex-1 bg-primary text-on-primary font-bold py-2 px-4 rounded-lg hover:bg-primary/90 transition-colors flex items-center justify-center gap-2">' +
+          '<span class="material-symbols-outlined text-sm">save</span><span>저장</span>' +
+        '</button>' +
+        '<button type="button" onclick="closeRuleModal()" class="px-4 py-2 border border-outline-variant/30 rounded-lg text-outline hover:bg-surface-container-high transition-colors">취소</button>' +
+      '</div>' +
+    '</form>' +
+    '</div></div>';
+
+  document.body.insertAdjacentHTML('beforeend', html);
+  document.getElementById('rule-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    submitRuleForm(isEdit);
+  });
+}
+
+function onTriggerTypeChange() {
+  var type = document.getElementById('rule-trigger-type').value;
+  document.getElementById('trigger-event-field').classList.toggle('hidden', type !== 'event');
+  document.getElementById('trigger-cron-field').classList.toggle('hidden', type !== 'cron');
+  document.getElementById('trigger-threshold-field').classList.toggle('hidden', type !== 'rate-limit');
+}
+
+function closeRuleModal() {
+  var modal = document.getElementById('rule-modal');
+  if (modal) modal.remove();
+}
+
+function submitRuleForm(isEdit) {
+  var id = (document.getElementById('rule-id').value || '').trim();
+  if (!id) { alert('ID를 입력해주세요.'); return; }
+
+  var triggerType = document.getElementById('rule-trigger-type').value;
+  var trigger = { type: triggerType };
+  if (triggerType === 'event') {
+    trigger.event = document.getElementById('rule-trigger-event').value;
+  } else if (triggerType === 'cron') {
+    trigger.schedule = document.getElementById('rule-trigger-schedule').value;
+  } else if (triggerType === 'rate-limit') {
+    trigger.threshold = parseInt(document.getElementById('rule-trigger-threshold').value, 10) || 1;
+  }
+
+  var rule = {
+    id: id,
+    description: document.getElementById('rule-desc').value.trim() || undefined,
+    trigger: trigger,
+    actions: [{ type: document.getElementById('rule-action-type').value }],
+    enabled: document.getElementById('rule-enabled').checked
+  };
+
+  if (isEdit) {
+    var idx = automationRules.findIndex(function(r) { return r.id === id; });
+    if (idx !== -1) automationRules[idx] = rule;
+  } else {
+    var duplicate = automationRules.find(function(r) { return r.id === id; });
+    if (duplicate) { alert('이미 같은 ID의 규칙이 존재합니다.'); return; }
+    automationRules.push(rule);
+  }
+
+  closeRuleModal();
+  saveAutomationRules(function() { renderAutomationRules(); });
+}
+
+window.loadAutomationRules  = loadAutomationRules;
+window.toggleAutomationRule = toggleAutomationRule;
+window.deleteAutomationRule = deleteAutomationRule;
+window.showAddRuleModal     = showAddRuleModal;
+window.showEditRuleModal    = showEditRuleModal;
+window.closeRuleModal       = closeRuleModal;
+window.onTriggerTypeChange  = onTriggerTypeChange;


### PR DESCRIPTION
## Summary

Resolves #439 — feat: 자동화 규칙 관리 UI — 대시보드 automations 메뉴

대시보드에 자동화 규칙(AutomationRule) 관리 UI를 추가한다. 현재 Automations 뷰는 Job List/Kanban만 표시하는데, 여기에 규칙 관리 탭을 추가하여 규칙 목록 표시, CRUD, 활성/비활성 토글 기능을 구현한다. PUT /api/config를 통해 config.automations 배열을 저장한다.

## Requirements

- 규칙 목록 표시 (id, name, trigger type, enabled 상태)
- 규칙 추가 모달 (trigger/conditions/actions 설정)
- 규칙 수정 모달 (기존 값 로드 후 편집)
- 규칙 삭제 (확인 후 삭제)
- 규칙 활성/비활성 토글 스위치
- PUT /api/config로 automations 배열 저장
- Stitch 디자인 시스템 기반 UI (automations-kanban A3)

## Implementation Phases

- Phase 0: 타입 및 설정 스키마 추가 — SUCCESS (01a1b428)
- Phase 1: automations.js 신규 생성 — SUCCESS (372fe97f)
- Phase 2: index.html 규칙 관리 섹션 추가 — SUCCESS (eaea6306)
- Phase 3: 통합 테스트 및 검증 — SUCCESS (eaea6306)
- Phase 4: app.js 통합 및 테스트 — SUCCESS (0965453b)

## Risks

- Stitch 디자인 파일 없이 진행 시 CLAUDE.md 규칙 위반
- config.automations 스키마가 UpdateConfigRequestSchema에 포함되어 있는지 확인 필요
- 기존 Automations List/Kanban 뷰와 Rules 뷰 전환 UX 고려

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/439-feat-ui-automations` → `develop`
- **Tokens**: 132 input, 24630 output{{#stats.cacheCreationTokens}}, 114763 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1585418 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #439