### PR TITLE
[AQ-#457] fix: 대시보드 업데이트 알림 UI 상단 화면 겹침

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -282,7 +282,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 </div>
 
 <!-- Update Banner -->
-<div id="update-banner" style="display:none;" class="fixed left-0 right-0 z-[998] bg-gradient-to-r from-primary/10 to-primary-container/10 border-b border-primary/30 px-6 py-3 flex items-center gap-4 flex-wrap" style="top: var(--api-banner-height, 0);">
+<div id="update-banner" style="display:none;" class="fixed left-0 right-0 z-[998] bg-gradient-to-r from-primary/10 to-primary-container/10 border-b border-primary/30 px-6 py-3 flex items-center gap-4 flex-wrap">
   <div class="flex items-center gap-2 text-primary">
     <span class="material-symbols-outlined text-lg animate-pulse" style="font-variation-settings: 'FILL' 1;">update</span>
     <span class="text-sm font-bold">새 업데이트 사용 가능</span>

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -612,6 +612,9 @@ function adjustPagePadding() {
     totalBannerHeight += updateBanner.offsetHeight;
   }
 
+  // 헤더 top을 배너 높이만큼 동적으로 조정 (sticky header가 배너 아래로 밀리도록)
+  header.style.top = totalBannerHeight > 0 ? totalBannerHeight + 'px' : '';
+
   // 헤더 아래 여백을 동적으로 조정
   var main = document.querySelector('main');
   if (main) {


### PR DESCRIPTION
## Summary

Resolves #457 — fix: 대시보드 업데이트 알림 UI 상단 화면 겹침

update-banner(fixed, z-[998])와 header(sticky, top-0)가 모두 상단에 위치하여 겹침 발생. adjustPagePadding()에서 main의 paddingTop만 조정하고 header의 top 값은 조정하지 않아 배너가 표시되면 header와 겹쳐 보임.

## Requirements

- 업데이트 알림 배너가 상단 콘텐츠(header)와 겹치지 않아야 함
- 배너 표시 시 header가 배너 아래로 밀려나야 함
- 배너 dismiss 시 레이아웃이 원래대로 복구되어야 함

## Implementation Phases

- Phase 0: 배너-헤더 겹침 수정 — SUCCESS (ab987f69)

## Risks

- CSS 변경이 다른 뷰(칸반, 설정 등)에 영향을 줄 수 있음 - 전체 페이지 테스트 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/457-fix-ui` → `develop`
- **Tokens**: 81 input, 7562 output{{#stats.cacheCreationTokens}}, 83249 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 579263 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #457