### PR TITLE
[AQ-#425] refactor: job-queue Task 팩토리 통합 — AQMTask 기반 실행

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -10,7 +10,7 @@ import { removeWorktree } from "../git/worktree-manager.js";
 import { deleteRemoteBranch } from "../git/branch-manager.js";
 import { loadConfig } from "../config/loader.js";
 import { ProjectErrorState } from "../types/config.js";
-import type { AQMTask } from "../tasks/aqm-task.js";
+import type { AQMTask, AQMTaskSummary } from "../tasks/aqm-task.js";
 
 const logger = getLogger();
 
@@ -145,6 +145,7 @@ export class JobQueue {
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
   private projectErrorState: Map<string, ProjectErrorState> = new Map(); // repo -> error state
   private runningTasks: Map<string, AQMTask> = new Map(); // jobId -> 실행 중인 AQMTask
+  private taskSnapshots: Map<string, AQMTaskSummary> = new Map(); // jobId -> 마지막 Task 스냅샷
 
   constructor(
     store: JobStore,
@@ -821,18 +822,66 @@ export class JobQueue {
       const handle = handlerResult;
       this.runningTasks.set(job.id, handle.task);
 
+      // 초기 스냅샷 저장 (PENDING 상태)
+      this.taskSnapshots.set(job.id, handle.task.toJSON());
+
+      // lifecycle 이벤트: 스냅샷 최신 상태로 업데이트
+      const updateSnapshot = () => {
+        this.taskSnapshots.set(job.id, handle.task.toJSON());
+      };
+      handle.task.on?.("started", updateSnapshot);
+      handle.task.on?.("completed", updateSnapshot);
+      handle.task.on?.("failed", updateSnapshot);
+
       // killed 이벤트: stuck 감지 외부에서 kill된 경우 stuckAborted로 표시
       handle.task.on?.("killed", () => {
         logger.info(`Task killed for job ${job.id}`);
         if (!this.stuckAborted.has(job.id)) {
           this.stuckAborted.add(job.id);
         }
+        updateSnapshot();
       });
 
-      return handle.run();
+      const result = await handle.run();
+      // 실행 완료 후 최종 스냅샷 저장 (완료 상태 반영)
+      this.taskSnapshots.set(job.id, handle.task.toJSON());
+      return result;
     }
 
     // 레거시 JobHandler — 직접 결과 반환
     return handlerResult;
+  }
+
+  /**
+   * 특정 잡의 마지막으로 저장된 Task 스냅샷을 반환한다.
+   * 직렬화된 스냅샷은 ClaudeTask.fromJSON() 등으로 복원할 수 있다.
+   * @returns AQMTaskSummary 또는 Task가 없는 경우 undefined
+   */
+  getTaskSnapshot(jobId: string): AQMTaskSummary | undefined {
+    return this.taskSnapshots.get(jobId);
+  }
+
+  /**
+   * 현재 실행 중인 모든 Task의 최신 스냅샷을 직렬화하여 반환한다.
+   * 서버 종료 전 상태 저장에 사용된다.
+   * 반환된 Record는 loadTaskSnapshots()로 재주입 가능하다.
+   */
+  serializeActiveTasks(): Record<string, AQMTaskSummary> {
+    const result: Record<string, AQMTaskSummary> = {};
+    for (const [jobId, task] of this.runningTasks) {
+      result[jobId] = task.toJSON();
+    }
+    return result;
+  }
+
+  /**
+   * 외부에서 직렬화된 Task 스냅샷을 주입한다.
+   * 서버 재시작 후 recover() 호출 전에 이전 세션의 스냅샷을 복원하는데 사용된다.
+   * 핸들러는 getTaskSnapshot(jobId)로 스냅샷을 조회하고 fromJSON()으로 Task를 재구성한다.
+   */
+  loadTaskSnapshots(snapshots: Record<string, AQMTaskSummary>): void {
+    for (const [jobId, snapshot] of Object.entries(snapshots)) {
+      this.taskSnapshots.set(jobId, snapshot);
+    }
   }
 }

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -10,10 +10,35 @@ import { removeWorktree } from "../git/worktree-manager.js";
 import { deleteRemoteBranch } from "../git/branch-manager.js";
 import { loadConfig } from "../config/loader.js";
 import { ProjectErrorState } from "../types/config.js";
+import type { AQMTask } from "../tasks/aqm-task.js";
 
 const logger = getLogger();
 
-export type JobHandler = (job: Job) => Promise<{ prUrl?: string; error?: string }>;
+/** 잡 실행 결과 */
+export interface JobResult {
+  prUrl?: string;
+  error?: string;
+}
+
+/**
+ * Task 기반 잡 핸들 — AQMTask 인스턴스와 실행 함수를 함께 제공한다.
+ * lifecycle 이벤트 구독 및 stuck 시 kill() 호출에 사용된다.
+ */
+export interface JobTaskHandle {
+  /** 이번 잡에서 실행되는 AQMTask 인스턴스 */
+  task: AQMTask;
+  /** 태스크를 실행하고 잡 결과를 반환하는 함수 */
+  run(): Promise<JobResult>;
+}
+
+/**
+ * Task 기반 핸들러 — JobTaskHandle을 반환한다.
+ * lifecycle 이벤트 연동과 task.kill() 지원을 위해 사용한다.
+ */
+export type TaskHandler = (job: Job) => JobTaskHandle | Promise<JobTaskHandle>;
+
+/** 레거시 JobHandler — 직접 결과를 반환하는 콜백 패턴 */
+export type JobHandler = (job: Job) => Promise<JobResult>;
 
 /**
  * StoreJob을 새로운 discriminated union Job 타입으로 변환
@@ -87,6 +112,20 @@ function convertStoreJobToJob(storeJob: StoreJob): Job {
   }
 }
 
+/**
+ * 핸들러 반환값이 JobTaskHandle인지 판별하는 타입 가드.
+ * TaskHandler는 { task, run } 을 반환하고, JobHandler는 { prUrl?, error? }를 반환한다.
+ */
+function isJobTaskHandle(value: unknown): value is JobTaskHandle {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "task" in value &&
+    "run" in value &&
+    typeof (value as Record<string, unknown>).run === "function"
+  );
+}
+
 const STUCK_CHECK_INTERVAL_MS = 60 * 1000; // check every minute
 
 export class JobQueue {
@@ -94,7 +133,7 @@ export class JobQueue {
   private running: Set<string> = new Set();
   private store: JobStore;
   private concurrency: number;
-  private handler: JobHandler;
+  private handler: JobHandler | TaskHandler;
   private cancelled: Set<string> = new Set();
   private stuckChecker: ReturnType<typeof setInterval> | undefined;
   private stuckTimeoutMs: number;
@@ -105,11 +144,12 @@ export class JobQueue {
   private projectConcurrency: Map<string, number> = new Map(); // repo -> concurrency limit
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
   private projectErrorState: Map<string, ProjectErrorState> = new Map(); // repo -> error state
+  private runningTasks: Map<string, AQMTask> = new Map(); // jobId -> 실행 중인 AQMTask
 
   constructor(
     store: JobStore,
     concurrency: number,
-    handler: JobHandler,
+    handler: JobHandler | TaskHandler,
     stuckTimeoutMs: number = 600000,
     projectConcurrency?: Record<string, number>
   ) {
@@ -151,25 +191,29 @@ export class JobQueue {
           this.store.update(jobId, { lastUpdatedAt: new Date().toISOString() });
         } else if (processAlive && (lastActivityMs < 0 || lastActivityMs >= ACTIVITY_THRESHOLD_MS)) {
           // Process alive but no recent activity — Claude stuck
-          logger.error(`Job ${jobId}: ${Math.round(elapsed / 60000)}분 경과, Claude 무응답 ${Math.round((lastActivityMs >= 0 ? lastActivityMs : elapsed) / 60000)}분 — 실패 처리`);
+          const inactiveMin = Math.round((lastActivityMs >= 0 ? lastActivityMs : elapsed) / 60000);
+          logger.error(`Job ${jobId}: ${Math.round(elapsed / 60000)}분 경과, Claude 무응답 ${inactiveMin}분 — 실패 처리`);
           this.store.update(jobId, {
             status: "failure",
             completedAt: new Date().toISOString(),
-            error: `Claude가 ${Math.round((lastActivityMs >= 0 ? lastActivityMs : elapsed) / 60000)}분간 무응답 (프로세스는 살아있으나 활동 없음)`,
+            error: `Claude가 ${inactiveMin}분간 무응답 (프로세스는 살아있으나 활동 없음)`,
           });
           this.stuckAborted.add(jobId);
           this.running.delete(jobId);
+          this.killAndCleanupTask(jobId);
           setTimeout(() => this.processNext(), 0);
         } else {
           // No process, exceeded 2x timeout — genuinely stuck
-          logger.error(`Job ${jobId}: ${Math.round(elapsed / 60000)}분 경과, 프로세스 없음 — 실패 처리`);
+          const elapsedMin = Math.round(elapsed / 60000);
+          logger.error(`Job ${jobId}: ${elapsedMin}분 경과, 프로세스 없음 — 실패 처리`);
           this.store.update(jobId, {
             status: "failure",
             completedAt: new Date().toISOString(),
-            error: `파이프라인이 ${Math.round(elapsed / 60000)}분간 응답 없음`,
+            error: `파이프라인이 ${elapsedMin}분간 응답 없음`,
           });
           this.stuckAborted.add(jobId);
           this.running.delete(jobId);
+          this.killAndCleanupTask(jobId);
           setTimeout(() => this.processNext(), 0);
         }
       }
@@ -177,11 +221,27 @@ export class JobQueue {
   }
 
   /**
+   * 실행 중인 태스크를 kill하고 runningTasks에서 제거한다.
+   * 이미 task가 없으면 아무 작업도 하지 않는다.
+   */
+  private killAndCleanupTask(jobId: string): void {
+    const task = this.runningTasks.get(jobId);
+    if (task) {
+      this.runningTasks.delete(jobId);
+      task.kill().catch((err: unknown) => {
+        logger.warn(`Task kill failed for job ${jobId}: ${getErrorMessage(err)}`);
+      });
+    }
+  }
+
+  /**
    * Marks a job as stuck-aborted so executeJob can detect it after the handler returns.
+   * Task 기반 핸들러를 사용 중인 경우 task.kill()도 호출한다.
    */
   abortJob(jobId: string): boolean {
     if (this.running.has(jobId)) {
       this.stuckAborted.add(jobId);
+      this.killAndCleanupTask(jobId);
       return true;
     }
     return false;
@@ -687,7 +747,7 @@ export class JobQueue {
         return;
       }
 
-      const result = await this.handler(job);
+      const result = await this.runHandler(job);
 
       // Re-check after handler completes — stuck checker may have fired during execution
       const wasStuckAborted = this.stuckAborted.has(job.id);
@@ -705,7 +765,6 @@ export class JobQueue {
           completedAt: new Date().toISOString(),
           error: result.error,
         });
-        // Don't track project failure if it was stuck aborted
         if (!wasStuckAborted) {
           this.trackProjectFailure(job.repo);
         }
@@ -715,7 +774,6 @@ export class JobQueue {
           completedAt: new Date().toISOString(),
           prUrl: result.prUrl,
         });
-        // Don't track project success if it was stuck aborted
         if (!wasStuckAborted) {
           this.trackProjectSuccess(job.repo);
         }
@@ -725,12 +783,17 @@ export class JobQueue {
           completedAt: new Date().toISOString(),
           error: "Pipeline completed but no PR was created",
         });
-        // Don't track project failure if it was stuck aborted
         if (!wasStuckAborted) {
           this.trackProjectFailure(job.repo);
         }
       }
     } catch (error: unknown) {
+      // stuck-abort 후 task.kill()이 예외를 발생시키는 경우 — 이미 스토어 업데이트됨
+      if (this.stuckAborted.has(job.id)) {
+        this.stuckAborted.delete(job.id);
+        logger.warn(`Job ${job.id} threw after stuck-abort — ignoring`);
+        return;
+      }
       this.store.update(job.id, {
         status: "failure",
         completedAt: new Date().toISOString(),
@@ -738,10 +801,38 @@ export class JobQueue {
       });
       this.trackProjectFailure(job.repo);
     } finally {
+      this.runningTasks.delete(job.id);
       this.running.delete(job.id);
       this.removeJobFromRepo(job.id, job.repo);
       // Process next in queue (defer via setImmediate to avoid deep call stacks)
       setImmediate(() => this.processNext());
     }
+  }
+
+  /**
+   * handler 타입을 판별하여 실행하고 JobResult를 반환한다.
+   * TaskHandler인 경우 AQMTask를 runningTasks에 등록하고 lifecycle 이벤트를 구독한다.
+   */
+  private async runHandler(job: Job): Promise<JobResult> {
+    const handlerResult = await this.handler(job);
+
+    if (isJobTaskHandle(handlerResult)) {
+      // Task 기반 핸들러 — task 참조 저장 및 lifecycle 이벤트 연동
+      const handle = handlerResult;
+      this.runningTasks.set(job.id, handle.task);
+
+      // killed 이벤트: stuck 감지 외부에서 kill된 경우 stuckAborted로 표시
+      handle.task.on?.("killed", () => {
+        logger.info(`Task killed for job ${job.id}`);
+        if (!this.stuckAborted.has(job.id)) {
+          this.stuckAborted.add(job.id);
+        }
+      });
+
+      return handle.run();
+    }
+
+    // 레거시 JobHandler — 직접 결과 반환
+    return handlerResult;
   }
 }

--- a/src/tasks/aqm-task.ts
+++ b/src/tasks/aqm-task.ts
@@ -23,7 +23,7 @@ export enum TaskStatus {
  * 지원하는 태스크 타입
  * 향후 CodexTask, GeminiTask 등 확장 가능
  */
-export type AQMTaskType = "claude" | "codex" | "gemini" | "validation";
+export type AQMTaskType = "claude" | "codex" | "gemini" | "validation" | "git";
 
 /**
  * 태스크 라이프사이클 이벤트 타입

--- a/src/tasks/git-task.ts
+++ b/src/tasks/git-task.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from "crypto";
+import { EventEmitter } from "events";
+import type { GitConfig, WorktreeConfig } from "../types/config.js";
+import {
+  type AQMTask,
+  TaskStatus,
+  type AQMTaskSummary,
+  type BaseTaskOptions,
+  type TaskLifecycleEvent,
+  type TaskEventListener,
+} from "./aqm-task.js";
+import {
+  syncBaseBranch,
+  createWorkBranch,
+  pushBranch,
+  type BranchInfo,
+} from "../git/branch-manager.js";
+import {
+  createWorktree,
+  removeWorktree,
+  type WorktreeInfo,
+} from "../git/worktree-manager.js";
+import { autoCommitIfDirty } from "../git/commit-helper.js";
+
+/**
+ * GitTask가 지원하는 git 작업 파라미터 (discriminated union)
+ */
+export type GitTaskParams =
+  | {
+      operation: "syncBaseBranch";
+      gitConfig: GitConfig;
+    }
+  | {
+      operation: "createWorkBranch";
+      gitConfig: GitConfig;
+      issueNumber: number;
+      issueTitle: string;
+    }
+  | {
+      operation: "createWorktree";
+      gitConfig: GitConfig;
+      worktreeConfig: WorktreeConfig;
+      branchName: string;
+      issueNumber: number;
+      slug: string;
+      repoSlug?: string;
+    }
+  | {
+      operation: "removeWorktree";
+      gitConfig: GitConfig;
+      worktreePath: string;
+      force?: boolean;
+    }
+  | {
+      operation: "pushBranch";
+      gitConfig: GitConfig;
+      branchName: string;
+    }
+  | {
+      operation: "autoCommit";
+      gitPath: string;
+      commitMsg: string;
+    };
+
+/**
+ * GitTask 실행 결과 (discriminated union)
+ */
+export type GitTaskResult =
+  | { operation: "syncBaseBranch" }
+  | { operation: "createWorkBranch"; branch: BranchInfo }
+  | { operation: "createWorktree"; worktree: WorktreeInfo }
+  | { operation: "removeWorktree" }
+  | { operation: "pushBranch" }
+  | { operation: "autoCommit"; commitHash: string | undefined };
+
+/**
+ * GitTask 생성 옵션
+ */
+export interface GitTaskOptions extends BaseTaskOptions {
+  /** 실행할 git 작업 파라미터 */
+  params: GitTaskParams;
+}
+
+/**
+ * Git 작업(worktree, branch, commit)을 AQMTask 인터페이스로 래핑하는 구현체
+ */
+export class GitTask implements AQMTask {
+  public readonly id: string;
+  public readonly type = "git" as const;
+
+  private _status: TaskStatus = TaskStatus.PENDING;
+  private _startedAt?: Date;
+  private _completedAt?: Date;
+  private _result?: GitTaskResult;
+  private _killed = false;
+  private readonly _options: GitTaskOptions;
+  private readonly _emitter = new EventEmitter();
+
+  constructor(options: GitTaskOptions) {
+    this.id = options.id ?? randomUUID();
+    this._options = { ...options, id: this.id };
+  }
+
+  get status(): TaskStatus {
+    return this._status;
+  }
+
+  on(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.on(event, listener);
+  }
+
+  off(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.off(event, listener);
+  }
+
+  once(event: TaskLifecycleEvent, listener: TaskEventListener): void {
+    this._emitter.once(event, listener);
+  }
+
+  async run(): Promise<GitTaskResult> {
+    if (this._status !== TaskStatus.PENDING) {
+      throw new Error(`Task ${this.id} is already ${this._status} and cannot be run again`);
+    }
+
+    this._status = TaskStatus.RUNNING;
+    this._startedAt = new Date();
+    this._emitter.emit("started");
+
+    try {
+      const result = await this._execute();
+
+      // 실행 중 kill()이 호출되었으면 KILLED로 처리
+      if (this._killed) {
+        this._completedAt = new Date();
+        this._status = TaskStatus.KILLED;
+        this._emitter.emit("killed");
+        throw new Error(`Task ${this.id} was killed`);
+      }
+
+      this._completedAt = new Date();
+      this._status = TaskStatus.SUCCESS;
+      this._result = result;
+      this._emitter.emit("completed");
+      return result;
+    } catch (err: unknown) {
+      if (this._status !== TaskStatus.KILLED) {
+        this._completedAt = new Date();
+        this._status = TaskStatus.FAILED;
+        this._emitter.emit("failed");
+      }
+      throw err;
+    }
+  }
+
+  private async _execute(): Promise<GitTaskResult> {
+    const { params } = this._options;
+    const cwd = this._options.cwd ?? process.cwd();
+
+    switch (params.operation) {
+      case "syncBaseBranch":
+        await syncBaseBranch(params.gitConfig, { cwd });
+        return { operation: "syncBaseBranch" };
+
+      case "createWorkBranch": {
+        const branch = await createWorkBranch(
+          params.gitConfig,
+          params.issueNumber,
+          params.issueTitle,
+          { cwd }
+        );
+        return { operation: "createWorkBranch", branch };
+      }
+
+      case "createWorktree": {
+        const worktree = await createWorktree(
+          params.gitConfig,
+          params.worktreeConfig,
+          params.branchName,
+          params.issueNumber,
+          params.slug,
+          { cwd },
+          params.repoSlug
+        );
+        return { operation: "createWorktree", worktree };
+      }
+
+      case "removeWorktree":
+        await removeWorktree(params.gitConfig, params.worktreePath, {
+          cwd,
+          force: params.force,
+        });
+        return { operation: "removeWorktree" };
+
+      case "pushBranch":
+        await pushBranch(params.gitConfig, params.branchName, { cwd });
+        return { operation: "pushBranch" };
+
+      case "autoCommit": {
+        const commitHash = await autoCommitIfDirty(
+          params.gitPath,
+          cwd,
+          params.commitMsg
+        );
+        return { operation: "autoCommit", commitHash };
+      }
+    }
+  }
+
+  async kill(): Promise<void> {
+    if (this._status === TaskStatus.PENDING) {
+      this._killed = true;
+      this._status = TaskStatus.KILLED;
+      this._completedAt = new Date();
+      this._emitter.emit("killed");
+      return;
+    }
+
+    if (this._status === TaskStatus.RUNNING) {
+      // git 작업은 중단 불가 — 완료 후 KILLED로 전환되도록 플래그 설정
+      this._killed = true;
+    }
+  }
+
+  toJSON(): AQMTaskSummary {
+    const durationMs =
+      this._completedAt && this._startedAt
+        ? this._completedAt.getTime() - this._startedAt.getTime()
+        : undefined;
+
+    return {
+      id: this.id,
+      type: this.type,
+      status: this.status,
+      startedAt: this._startedAt?.toISOString(),
+      completedAt: this._completedAt?.toISOString(),
+      durationMs,
+      metadata: {
+        ...this._options.metadata,
+        operation: this._options.params.operation,
+      },
+    };
+  }
+
+  getResult(): GitTaskResult | undefined {
+    return this._result;
+  }
+}

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -36,3 +36,9 @@ export {
   GitTaskParams,
   GitTaskResult,
 } from "./git-task.js";
+
+// 태스크 팩토리 (JobType → 태스크 인스턴스 생성)
+export {
+  createTask,
+  TaskCreationParams,
+} from "./task-factory.js";

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -28,3 +28,11 @@ export {
   ValidationTaskType,
   ValidationResult,
 } from "./validation-task.js";
+
+// Git 태스크 구현체 (worktree, branch, commit)
+export {
+  GitTask,
+  GitTaskOptions,
+  GitTaskParams,
+  GitTaskResult,
+} from "./git-task.js";

--- a/src/tasks/task-factory.ts
+++ b/src/tasks/task-factory.ts
@@ -1,0 +1,30 @@
+import type { AQMTask } from "./aqm-task.js";
+import { ClaudeTask, type ClaudeTaskOptions } from "./claude-task.js";
+import { ValidationTask, type ValidationTaskOptions } from "./validation-task.js";
+import { GitTask, type GitTaskOptions } from "./git-task.js";
+
+/**
+ * 태스크 생성 파라미터 (discriminated union)
+ * type 필드로 어떤 태스크를 생성할지 결정한다.
+ */
+export type TaskCreationParams =
+  | { type: "claude"; options: ClaudeTaskOptions }
+  | { type: "validation"; options: ValidationTaskOptions }
+  | { type: "git"; options: GitTaskOptions };
+
+/**
+ * JobType에 따라 ClaudeTask / ValidationTask / GitTask 인스턴스를 생성한다.
+ *
+ * @param params - 태스크 타입과 해당 옵션을 포함하는 discriminated union
+ * @returns 생성된 AQMTask 인스턴스
+ */
+export function createTask(params: TaskCreationParams): AQMTask {
+  switch (params.type) {
+    case "claude":
+      return new ClaudeTask(params.options);
+    case "validation":
+      return new ValidationTask(params.options);
+    case "git":
+      return new GitTask(params.options);
+  }
+}

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { JobQueue, JobHandler } from "../../src/queue/job-queue.js";
+import { JobQueue, JobHandler, TaskHandler, JobTaskHandle } from "../../src/queue/job-queue.js";
+import { TaskStatus, type AQMTaskSummary } from "../../src/tasks/aqm-task.js";
 import { JobStore } from "../../src/queue/job-store.js";
 import { mkdirSync, rmSync } from "fs";
 import { join } from "path";
@@ -1570,6 +1571,213 @@ describe("JobQueue", () => {
 
       await new Promise(r => setTimeout(r, 400));
       expect(handler).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("Phase 4: 직렬화/역직렬화 — Task 스냅샷 추적 및 Resume 지원", () => {
+    /** 테스트용 최소 AQMTask mock 생성 헬퍼 */
+    function makeMockTask(id: string, initialStatus: TaskStatus = TaskStatus.PENDING) {
+      const listeners: Record<string, Array<() => void>> = {};
+      const task = {
+        id,
+        type: "claude" as const,
+        get status() { return initialStatus; },
+        kill: vi.fn().mockResolvedValue(undefined),
+        toJSON: vi.fn((): AQMTaskSummary => ({
+          id,
+          type: "claude",
+          status: initialStatus,
+          startedAt: undefined,
+          completedAt: undefined,
+          durationMs: undefined,
+          metadata: { prompt: "test prompt" },
+        })),
+        on: vi.fn((event: string, listener: () => void) => {
+          if (!listeners[event]) listeners[event] = [];
+          listeners[event].push(listener);
+        }),
+        off: vi.fn(),
+        once: vi.fn(),
+        emit: (event: string) => {
+          (listeners[event] ?? []).forEach(fn => fn());
+        },
+      };
+      return task;
+    }
+
+    it("getTaskSnapshot: TaskHandler 미사용 시 undefined 반환", () => {
+      const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
+      const queue = new JobQueue(store, 1, handler);
+
+      expect(queue.getTaskSnapshot("nonexistent-job-id")).toBeUndefined();
+    });
+
+    it("getTaskSnapshot: TaskHandler 사용 시 스냅샷 저장 및 조회", async () => {
+      const mockTask = makeMockTask("task-1");
+
+      const taskHandler: TaskHandler = vi.fn().mockReturnValue({
+        task: mockTask,
+        run: vi.fn().mockResolvedValue({ prUrl: "https://pr/1" }),
+      } as JobTaskHandle);
+
+      const queue = new JobQueue(store, 1, taskHandler);
+      const job = queue.enqueue(10, "test/repo");
+
+      // 잡이 실행될 때까지 대기
+      await new Promise(r => setTimeout(r, 50));
+
+      // 스냅샷이 저장되어 있어야 함
+      const snapshot = queue.getTaskSnapshot(job!.id);
+      expect(snapshot).toBeDefined();
+      expect(snapshot?.id).toBe("task-1");
+      expect(snapshot?.type).toBe("claude");
+    });
+
+    it("getTaskSnapshot: lifecycle 이벤트 발생 시 스냅샷 업데이트", async () => {
+      let capturedStatus: TaskStatus = TaskStatus.PENDING;
+      const mockTask = makeMockTask("task-lifecycle");
+      // toJSON이 호출될 때마다 현재 capturedStatus 반환
+      mockTask.toJSON.mockImplementation((): AQMTaskSummary => ({
+        id: "task-lifecycle",
+        type: "claude",
+        status: capturedStatus,
+        metadata: {},
+      }));
+
+      let resolveRun!: (v: { prUrl: string }) => void;
+      const runPromise = new Promise<{ prUrl: string }>(r => { resolveRun = r; });
+
+      const taskHandler: TaskHandler = vi.fn().mockReturnValue({
+        task: mockTask,
+        run: vi.fn().mockImplementation(async () => {
+          // started 이벤트 발생
+          capturedStatus = TaskStatus.RUNNING;
+          mockTask.emit("started");
+          await new Promise(r => setTimeout(r, 10));
+          // completed 이벤트 발생
+          capturedStatus = TaskStatus.SUCCESS;
+          mockTask.emit("completed");
+          return runPromise;
+        }),
+      } as JobTaskHandle);
+
+      resolveRun({ prUrl: "https://pr/lifecycle" });
+
+      const queue = new JobQueue(store, 1, taskHandler);
+      const job = queue.enqueue(20, "test/repo");
+
+      await new Promise(r => setTimeout(r, 80));
+
+      // completed 이벤트 후 스냅샷이 SUCCESS 상태여야 함
+      const snapshot = queue.getTaskSnapshot(job!.id);
+      expect(snapshot).toBeDefined();
+      expect(snapshot?.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("serializeActiveTasks: 실행 중인 Task 스냅샷 직렬화", async () => {
+      let holdRunning!: () => void;
+      const runHeld = new Promise<void>(r => { holdRunning = r; });
+
+      const mockTask = makeMockTask("task-active");
+
+      const taskHandler: TaskHandler = vi.fn().mockReturnValue({
+        task: mockTask,
+        run: vi.fn().mockImplementation(async () => {
+          await runHeld;
+          return { prUrl: "https://pr/active" };
+        }),
+      } as JobTaskHandle);
+
+      const queue = new JobQueue(store, 1, taskHandler);
+      queue.enqueue(30, "test/repo");
+
+      // 잡이 실행 중인 동안 직렬화
+      await new Promise(r => setTimeout(r, 30));
+      const snapshots = queue.serializeActiveTasks();
+
+      expect(Object.keys(snapshots).length).toBe(1);
+      const snapshot = Object.values(snapshots)[0];
+      expect(snapshot.id).toBe("task-active");
+
+      // 정리
+      holdRunning();
+    });
+
+    it("serializeActiveTasks: 실행 중인 Task 없을 때 빈 객체 반환", () => {
+      const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
+      const queue = new JobQueue(store, 1, handler);
+
+      expect(queue.serializeActiveTasks()).toEqual({});
+    });
+
+    it("loadTaskSnapshots: 스냅샷 주입 후 getTaskSnapshot으로 조회 가능", () => {
+      const handler: JobHandler = vi.fn();
+      const queue = new JobQueue(store, 1, handler);
+
+      const snapshot: AQMTaskSummary = {
+        id: "restored-task-id",
+        type: "claude",
+        status: TaskStatus.PENDING,
+        metadata: { prompt: "restored prompt" },
+      };
+
+      queue.loadTaskSnapshots({ "job-abc": snapshot });
+
+      const retrieved = queue.getTaskSnapshot("job-abc");
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.id).toBe("restored-task-id");
+      expect(retrieved?.type).toBe("claude");
+      expect(retrieved?.metadata?.prompt).toBe("restored prompt");
+    });
+
+    it("loadTaskSnapshots: 복수 스냅샷 주입 및 개별 조회", () => {
+      const handler: JobHandler = vi.fn();
+      const queue = new JobQueue(store, 1, handler);
+
+      const snapshots: Record<string, AQMTaskSummary> = {
+        "job-1": { id: "task-1", type: "claude", status: TaskStatus.FAILED, metadata: {} },
+        "job-2": { id: "task-2", type: "validation", status: TaskStatus.KILLED, metadata: {} },
+      };
+
+      queue.loadTaskSnapshots(snapshots);
+
+      expect(queue.getTaskSnapshot("job-1")?.id).toBe("task-1");
+      expect(queue.getTaskSnapshot("job-2")?.id).toBe("task-2");
+      expect(queue.getTaskSnapshot("job-3")).toBeUndefined();
+    });
+
+    it("직렬화/역직렬화 Round-trip: serializeActiveTasks → loadTaskSnapshots → getTaskSnapshot", async () => {
+      let holdRunning!: () => void;
+      const runHeld = new Promise<void>(r => { holdRunning = r; });
+
+      const mockTask = makeMockTask("task-roundtrip");
+
+      const taskHandler: TaskHandler = vi.fn().mockReturnValue({
+        task: mockTask,
+        run: vi.fn().mockImplementation(async () => {
+          await runHeld;
+          return { prUrl: "https://pr/roundtrip" };
+        }),
+      } as JobTaskHandle);
+
+      // 서버 A: 잡 실행 중 직렬화
+      const queueA = new JobQueue(store, 1, taskHandler);
+      const jobA = queueA.enqueue(50, "test/repo");
+      await new Promise(r => setTimeout(r, 30));
+
+      const serialized = queueA.serializeActiveTasks();
+      holdRunning();
+
+      // 서버 B: 직렬화된 스냅샷 복원
+      const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
+      const queueB = new JobQueue(store, 1, handler);
+      queueB.loadTaskSnapshots(serialized);
+
+      // 복원된 스냅샷 조회
+      const restored = queueB.getTaskSnapshot(jobA!.id);
+      expect(restored).toBeDefined();
+      expect(restored?.id).toBe("task-roundtrip");
+      expect(restored?.type).toBe("claude");
     });
   });
 });

--- a/tests/tasks/git-task.test.ts
+++ b/tests/tasks/git-task.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GitTask, type GitTaskOptions, type GitTaskParams } from "../../src/tasks/git-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+import type { GitConfig, WorktreeConfig } from "../../src/types/config.js";
+
+vi.mock("../../src/git/branch-manager.js", () => ({
+  syncBaseBranch: vi.fn(),
+  createWorkBranch: vi.fn(),
+  pushBranch: vi.fn(),
+}));
+
+vi.mock("../../src/git/worktree-manager.js", () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock("../../src/git/commit-helper.js", () => ({
+  autoCommitIfDirty: vi.fn(),
+}));
+
+import {
+  syncBaseBranch,
+  createWorkBranch,
+  pushBranch,
+} from "../../src/git/branch-manager.js";
+import {
+  createWorktree,
+  removeWorktree,
+} from "../../src/git/worktree-manager.js";
+import { autoCommitIfDirty } from "../../src/git/commit-helper.js";
+
+const mockSyncBaseBranch = vi.mocked(syncBaseBranch);
+const mockCreateWorkBranch = vi.mocked(createWorkBranch);
+const mockPushBranch = vi.mocked(pushBranch);
+const mockCreateWorktree = vi.mocked(createWorktree);
+const mockRemoveWorktree = vi.mocked(removeWorktree);
+const mockAutoCommitIfDirty = vi.mocked(autoCommitIfDirty);
+
+const mockGitConfig: GitConfig = {
+  defaultBranch: "main",
+  remote: "origin",
+  worktreeBase: ".aq-worktrees",
+  branchPrefix: "aq/",
+  commitMsgTemplate: "[#{issue}] {title}",
+};
+
+const mockWorktreeConfig: WorktreeConfig = {
+  maxWorktrees: 5,
+};
+
+describe("GitTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("생성 및 기본 속성", () => {
+    it("auto-generated UUID id를 가진다", () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.id).toBeDefined();
+      expect(task.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("options.id가 지정되면 해당 id를 사용한다", () => {
+      const task = new GitTask({
+        id: "custom-git-id",
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.id).toBe("custom-git-id");
+    });
+
+    it("type이 'git'이다", () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.type).toBe("git");
+    });
+
+    it("초기 status가 PENDING이다", () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("서로 다른 인스턴스는 서로 다른 id를 가진다", () => {
+      const t1 = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const t2 = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(t1.id).not.toBe(t2.id);
+    });
+  });
+
+  describe("operation: syncBaseBranch", () => {
+    it("syncBaseBranch를 호출하고 결과를 반환한다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "syncBaseBranch" });
+      expect(mockSyncBaseBranch).toHaveBeenCalledWith(mockGitConfig, {
+        cwd: expect.any(String),
+      });
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("syncBaseBranch 실패 시 FAILED 상태가 된다", async () => {
+      mockSyncBaseBranch.mockRejectedValueOnce(new Error("git sync failed"));
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      await expect(task.run()).rejects.toThrow("git sync failed");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+  });
+
+  describe("operation: createWorkBranch", () => {
+    it("createWorkBranch를 호출하고 branch 결과를 반환한다", async () => {
+      const mockBranch = { name: "aq/42-fix-bug", baseBranch: "main" };
+      mockCreateWorkBranch.mockResolvedValueOnce(mockBranch);
+
+      const task = new GitTask({
+        params: {
+          operation: "createWorkBranch",
+          gitConfig: mockGitConfig,
+          issueNumber: 42,
+          issueTitle: "Fix bug",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "createWorkBranch", branch: mockBranch });
+      expect(mockCreateWorkBranch).toHaveBeenCalledWith(
+        mockGitConfig,
+        42,
+        "Fix bug",
+        { cwd: expect.any(String) }
+      );
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+  });
+
+  describe("operation: createWorktree", () => {
+    it("createWorktree를 호출하고 worktree 결과를 반환한다", async () => {
+      const mockWorktree = { path: ".aq-worktrees/42-fix", branch: "aq/42-fix" };
+      mockCreateWorktree.mockResolvedValueOnce(mockWorktree);
+
+      const task = new GitTask({
+        params: {
+          operation: "createWorktree",
+          gitConfig: mockGitConfig,
+          worktreeConfig: mockWorktreeConfig,
+          branchName: "aq/42-fix",
+          issueNumber: 42,
+          slug: "fix",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "createWorktree", worktree: mockWorktree });
+      expect(mockCreateWorktree).toHaveBeenCalledWith(
+        mockGitConfig,
+        mockWorktreeConfig,
+        "aq/42-fix",
+        42,
+        "fix",
+        { cwd: expect.any(String) },
+        undefined
+      );
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("repoSlug를 전달하면 createWorktree에 그대로 넘긴다", async () => {
+      const mockWorktree = { path: ".aq-worktrees/42-fix", branch: "aq/42-fix" };
+      mockCreateWorktree.mockResolvedValueOnce(mockWorktree);
+
+      const task = new GitTask({
+        params: {
+          operation: "createWorktree",
+          gitConfig: mockGitConfig,
+          worktreeConfig: mockWorktreeConfig,
+          branchName: "aq/42-fix",
+          issueNumber: 42,
+          slug: "fix",
+          repoSlug: "my-repo",
+        },
+      });
+
+      await task.run();
+
+      expect(mockCreateWorktree).toHaveBeenCalledWith(
+        mockGitConfig,
+        mockWorktreeConfig,
+        "aq/42-fix",
+        42,
+        "fix",
+        { cwd: expect.any(String) },
+        "my-repo"
+      );
+    });
+  });
+
+  describe("operation: removeWorktree", () => {
+    it("removeWorktree를 호출하고 결과를 반환한다", async () => {
+      mockRemoveWorktree.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: {
+          operation: "removeWorktree",
+          gitConfig: mockGitConfig,
+          worktreePath: "/path/to/worktree",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "removeWorktree" });
+      expect(mockRemoveWorktree).toHaveBeenCalledWith(
+        mockGitConfig,
+        "/path/to/worktree",
+        { cwd: expect.any(String), force: undefined }
+      );
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("force 옵션을 전달한다", async () => {
+      mockRemoveWorktree.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: {
+          operation: "removeWorktree",
+          gitConfig: mockGitConfig,
+          worktreePath: "/path/to/worktree",
+          force: true,
+        },
+      });
+
+      await task.run();
+
+      expect(mockRemoveWorktree).toHaveBeenCalledWith(
+        mockGitConfig,
+        "/path/to/worktree",
+        { cwd: expect.any(String), force: true }
+      );
+    });
+  });
+
+  describe("operation: pushBranch", () => {
+    it("pushBranch를 호출하고 결과를 반환한다", async () => {
+      mockPushBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: {
+          operation: "pushBranch",
+          gitConfig: mockGitConfig,
+          branchName: "aq/42-fix",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "pushBranch" });
+      expect(mockPushBranch).toHaveBeenCalledWith(mockGitConfig, "aq/42-fix", {
+        cwd: expect.any(String),
+      });
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+  });
+
+  describe("operation: autoCommit", () => {
+    it("autoCommitIfDirty를 호출하고 commitHash를 반환한다", async () => {
+      mockAutoCommitIfDirty.mockResolvedValueOnce("abc123");
+
+      const task = new GitTask({
+        params: {
+          operation: "autoCommit",
+          gitPath: "/repo/.git",
+          commitMsg: "test commit",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "autoCommit", commitHash: "abc123" });
+      expect(mockAutoCommitIfDirty).toHaveBeenCalledWith(
+        "/repo/.git",
+        expect.any(String),
+        "test commit"
+      );
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("commitHash가 undefined이어도 정상 처리한다", async () => {
+      mockAutoCommitIfDirty.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: {
+          operation: "autoCommit",
+          gitPath: "/repo/.git",
+          commitMsg: "no changes",
+        },
+      });
+
+      const result = await task.run();
+
+      expect(result).toEqual({ operation: "autoCommit", commitHash: undefined });
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+  });
+
+  describe("상태 전이", () => {
+    it("PENDING → RUNNING → SUCCESS 순서로 전이한다", async () => {
+      let statusDuringRun: TaskStatus | undefined;
+
+      mockSyncBaseBranch.mockImplementationOnce(async () => {
+        statusDuringRun = task.status;
+      });
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+      await task.run();
+
+      expect(statusDuringRun).toBe(TaskStatus.RUNNING);
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("오류 발생 시 PENDING → RUNNING → FAILED 순서로 전이한다", async () => {
+      mockSyncBaseBranch.mockRejectedValueOnce(new Error("fail"));
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+      await expect(task.run()).rejects.toThrow("fail");
+      expect(task.status).toBe(TaskStatus.FAILED);
+    });
+
+    it("이미 실행된 태스크를 다시 run하면 에러를 던진다", async () => {
+      mockSyncBaseBranch.mockResolvedValue(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      await task.run();
+
+      await expect(task.run()).rejects.toThrow(
+        /already SUCCESS and cannot be run again/
+      );
+    });
+  });
+
+  describe("kill()", () => {
+    it("PENDING 상태에서 kill하면 KILLED 상태가 된다", async () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      await task.kill();
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+    });
+
+    it("RUNNING 상태에서 kill하면 작업 완료 후 KILLED 상태가 된다", async () => {
+      let resolveRun!: () => void;
+      const runHeld = new Promise<void>((r) => { resolveRun = r; });
+
+      mockSyncBaseBranch.mockImplementationOnce(() => runHeld);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      const runPromise = task.run();
+
+      // 실행 시작 대기
+      await new Promise((r) => setTimeout(r, 10));
+      expect(task.status).toBe(TaskStatus.RUNNING);
+
+      // kill 플래그 설정
+      const killPromise = task.kill();
+
+      // 실행 완료 후 KILLED로 전환
+      resolveRun();
+      await expect(runPromise).rejects.toThrow(/was killed/);
+      await killPromise;
+
+      expect(task.status).toBe(TaskStatus.KILLED);
+    });
+
+    it("이미 SUCCESS 상태에서 kill을 호출해도 상태가 변경되지 않는다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      await task.run();
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+
+      await task.kill();
+      // SUCCESS 상태에서 kill해도 아무 일도 안 일어남
+      expect(task.status).toBe(TaskStatus.SUCCESS);
+    });
+
+    it("getResult()는 성공 후 결과를 반환한다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      expect(task.getResult()).toBeUndefined();
+
+      await task.run();
+
+      expect(task.getResult()).toEqual({ operation: "syncBaseBranch" });
+    });
+  });
+
+  describe("라이프사이클 이벤트", () => {
+    it("run 시작 시 started 이벤트를 발생시킨다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("성공 시 completed 이벤트를 발생시킨다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await task.run();
+
+      expect(completedFn).toHaveBeenCalledTimes(1);
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it("실패 시 failed 이벤트를 발생시킨다", async () => {
+      mockSyncBaseBranch.mockRejectedValueOnce(new Error("git error"));
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const completedFn = vi.fn();
+      const failedFn = vi.fn();
+      task.on("completed", completedFn);
+      task.on("failed", failedFn);
+
+      await expect(task.run()).rejects.toThrow("git error");
+
+      expect(failedFn).toHaveBeenCalledTimes(1);
+      expect(completedFn).not.toHaveBeenCalled();
+    });
+
+    it("PENDING 상태에서 kill 시 killed 이벤트를 발생시킨다", async () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const killedFn = vi.fn();
+      task.on("killed", killedFn);
+
+      await task.kill();
+
+      expect(killedFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("once 리스너는 한 번만 발생한다", async () => {
+      mockSyncBaseBranch.mockResolvedValue(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const onceFn = vi.fn();
+      task.once("started", onceFn);
+
+      await task.run();
+
+      expect(onceFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("off로 리스너를 제거하면 이벤트를 수신하지 않는다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+      const startedFn = vi.fn();
+      task.on("started", startedFn);
+      task.off("started", startedFn);
+
+      await task.run();
+
+      expect(startedFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("toJSON() 직렬화", () => {
+    it("PENDING 상태의 태스크를 직렬화한다", () => {
+      const task = new GitTask({
+        id: "git-task-123",
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      const json = task.toJSON();
+
+      expect(json).toMatchObject({
+        id: "git-task-123",
+        type: "git",
+        status: TaskStatus.PENDING,
+        startedAt: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+        metadata: { operation: "syncBaseBranch" },
+      });
+    });
+
+    it("성공 후 startedAt, completedAt, durationMs가 채워진다", async () => {
+      mockSyncBaseBranch.mockResolvedValueOnce(undefined);
+
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+      });
+
+      await task.run();
+
+      const json = task.toJSON();
+
+      expect(json.startedAt).toBeDefined();
+      expect(json.completedAt).toBeDefined();
+      expect(json.durationMs).toBeGreaterThanOrEqual(0);
+      expect(typeof json.durationMs).toBe("number");
+    });
+
+    it("operation 이름이 metadata에 포함된다", () => {
+      const operations: GitTaskParams["operation"][] = [
+        "syncBaseBranch",
+        "pushBranch",
+        "removeWorktree",
+        "autoCommit",
+      ];
+
+      for (const op of operations) {
+        let params: GitTaskParams;
+        if (op === "pushBranch") {
+          params = { operation: op, gitConfig: mockGitConfig, branchName: "test" };
+        } else if (op === "removeWorktree") {
+          params = { operation: op, gitConfig: mockGitConfig, worktreePath: "/path" };
+        } else if (op === "autoCommit") {
+          params = { operation: op, gitPath: "/repo/.git", commitMsg: "msg" };
+        } else {
+          params = { operation: op, gitConfig: mockGitConfig };
+        }
+
+        const task = new GitTask({ params });
+        expect(task.toJSON().metadata?.operation).toBe(op);
+      }
+    });
+
+    it("options.metadata가 toJSON()에 포함된다", () => {
+      const task = new GitTask({
+        params: { operation: "syncBaseBranch", gitConfig: mockGitConfig },
+        metadata: { issueNumber: 42, repo: "test/repo" },
+      });
+
+      const json = task.toJSON();
+
+      expect(json.metadata?.issueNumber).toBe(42);
+      expect(json.metadata?.repo).toBe("test/repo");
+      expect(json.metadata?.operation).toBe("syncBaseBranch");
+    });
+  });
+});

--- a/tests/tasks/task-factory.test.ts
+++ b/tests/tasks/task-factory.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTask, type TaskCreationParams } from "../../src/tasks/task-factory.js";
+import { ClaudeTask } from "../../src/tasks/claude-task.js";
+import { ValidationTask } from "../../src/tasks/validation-task.js";
+import { GitTask } from "../../src/tasks/git-task.js";
+import { TaskStatus } from "../../src/tasks/aqm-task.js";
+import type { ClaudeCliConfig } from "../../src/types/config.js";
+
+const mockClaudeConfig: ClaudeCliConfig = {
+  command: "claude",
+  args: [],
+  timeout: 60000,
+  maxTurns: 10,
+};
+
+describe("createTask 팩토리", () => {
+  describe("claude 타입", () => {
+    it("ClaudeTask 인스턴스를 반환한다", () => {
+      const params: TaskCreationParams = {
+        type: "claude",
+        options: {
+          prompt: "test prompt",
+          config: mockClaudeConfig,
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task).toBeInstanceOf(ClaudeTask);
+    });
+
+    it("생성된 ClaudeTask의 type이 'claude'이다", () => {
+      const params: TaskCreationParams = {
+        type: "claude",
+        options: {
+          prompt: "hello",
+          config: mockClaudeConfig,
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.type).toBe("claude");
+    });
+
+    it("초기 상태가 PENDING이다", () => {
+      const params: TaskCreationParams = {
+        type: "claude",
+        options: {
+          prompt: "hello",
+          config: mockClaudeConfig,
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+
+    it("options.id가 지정되면 해당 id를 사용한다", () => {
+      const params: TaskCreationParams = {
+        type: "claude",
+        options: {
+          id: "custom-claude-id",
+          prompt: "hello",
+          config: mockClaudeConfig,
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.id).toBe("custom-claude-id");
+    });
+  });
+
+  describe("validation 타입", () => {
+    it("ValidationTask 인스턴스를 반환한다", () => {
+      const params: TaskCreationParams = {
+        type: "validation",
+        options: {
+          validationType: "typecheck",
+          command: "npx",
+          args: ["tsc", "--noEmit"],
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task).toBeInstanceOf(ValidationTask);
+    });
+
+    it("생성된 ValidationTask의 type이 'validation'이다", () => {
+      const params: TaskCreationParams = {
+        type: "validation",
+        options: {
+          validationType: "lint",
+          command: "npx",
+          args: ["eslint", "src/"],
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.type).toBe("validation");
+    });
+
+    it("test 타입의 ValidationTask를 생성할 수 있다", () => {
+      const params: TaskCreationParams = {
+        type: "validation",
+        options: {
+          validationType: "test",
+          command: "npx",
+          args: ["vitest", "run"],
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task).toBeInstanceOf(ValidationTask);
+      expect(task.type).toBe("validation");
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+  });
+
+  describe("git 타입", () => {
+    it("GitTask 인스턴스를 반환한다", () => {
+      const params: TaskCreationParams = {
+        type: "git",
+        options: {
+          params: {
+            operation: "syncBaseBranch",
+            gitConfig: {
+              defaultBranch: "main",
+              remote: "origin",
+              worktreeBase: ".aq-worktrees",
+              branchPrefix: "aq/",
+              commitMsgTemplate: "[#{issue}] {title}",
+            },
+          },
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task).toBeInstanceOf(GitTask);
+    });
+
+    it("생성된 GitTask의 type이 'git'이다", () => {
+      const params: TaskCreationParams = {
+        type: "git",
+        options: {
+          params: {
+            operation: "pushBranch",
+            gitConfig: {
+              defaultBranch: "main",
+              remote: "origin",
+              worktreeBase: ".aq-worktrees",
+              branchPrefix: "aq/",
+              commitMsgTemplate: "[#{issue}] {title}",
+            },
+            branchName: "aq/123-test",
+          },
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.type).toBe("git");
+    });
+
+    it("초기 상태가 PENDING이다", () => {
+      const params: TaskCreationParams = {
+        type: "git",
+        options: {
+          params: {
+            operation: "autoCommit",
+            gitPath: "/repo/.git",
+            commitMsg: "test commit",
+          },
+        },
+      };
+
+      const task = createTask(params);
+
+      expect(task.status).toBe(TaskStatus.PENDING);
+    });
+  });
+
+  describe("공통 AQMTask 계약", () => {
+    it("모든 태스크 타입이 toJSON()을 구현한다", () => {
+      const claudeTask = createTask({
+        type: "claude",
+        options: { prompt: "test", config: mockClaudeConfig },
+      });
+      const validationTask = createTask({
+        type: "validation",
+        options: { validationType: "typecheck", command: "npx", args: ["tsc"] },
+      });
+      const gitTask = createTask({
+        type: "git",
+        options: {
+          params: {
+            operation: "syncBaseBranch",
+            gitConfig: {
+              defaultBranch: "main",
+              remote: "origin",
+              worktreeBase: ".aq-worktrees",
+              branchPrefix: "aq/",
+              commitMsgTemplate: "[#{issue}] {title}",
+            },
+          },
+        },
+      });
+
+      expect(typeof claudeTask.toJSON).toBe("function");
+      expect(typeof validationTask.toJSON).toBe("function");
+      expect(typeof gitTask.toJSON).toBe("function");
+
+      expect(claudeTask.toJSON().type).toBe("claude");
+      expect(validationTask.toJSON().type).toBe("validation");
+      expect(gitTask.toJSON().type).toBe("git");
+    });
+
+    it("모든 태스크 타입이 kill()을 구현한다", () => {
+      const tasks = [
+        createTask({ type: "claude", options: { prompt: "test", config: mockClaudeConfig } }),
+        createTask({ type: "validation", options: { validationType: "typecheck", command: "npx", args: ["tsc"] } }),
+        createTask({
+          type: "git",
+          options: {
+            params: {
+              operation: "syncBaseBranch",
+              gitConfig: {
+                defaultBranch: "main",
+                remote: "origin",
+                worktreeBase: ".aq-worktrees",
+                branchPrefix: "aq/",
+                commitMsgTemplate: "[#{issue}] {title}",
+              },
+            },
+          },
+        }),
+      ];
+
+      for (const task of tasks) {
+        expect(typeof task.kill).toBe("function");
+      }
+    });
+
+    it("각 createTask 호출마다 고유한 id를 생성한다", () => {
+      const t1 = createTask({ type: "claude", options: { prompt: "a", config: mockClaudeConfig } });
+      const t2 = createTask({ type: "claude", options: { prompt: "b", config: mockClaudeConfig } });
+
+      expect(t1.id).not.toBe(t2.id);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #425 — refactor: job-queue Task 팩토리 통합 — AQMTask 기반 실행

현재 job-queue.ts는 JobHandler 콜백 패턴으로 잡을 실행하며, AQMTask 추상화를 활용하지 않음. ClaudeTask, ValidationTask가 이미 존재하나 job-queue와 통합되지 않음. GitTask는 미구현. Task 기반 실행으로 전환하여 lifecycle 이벤트 연동, 직렬화/역직렬화를 통한 Resume 지원 필요.

## Requirements

- src/queue/job-queue.ts를 Task 팩토리 패턴으로 전환
- 잡 타입에 따라 ClaudeTask/ValidationTask/GitTask 생성
- Task lifecycle 이벤트(started/completed/failed/killed)를 Job 상태에 연결
- Resume용 toJSON/fromJSON 직렬화 구현
- 기존 잡 동작(enqueue, cancel, retry, stuck detection) 유지

## Implementation Phases

- Phase 0: GitTask 구현 — SUCCESS (70d828d2)
- Phase 1: Task 팩토리 생성 — SUCCESS (2c151cb5)
- Phase 2: job-queue Task 통합 — SUCCESS (f480ad3b)
- Phase 3: 직렬화/역직렬화 구현 — SUCCESS (7d6e62e5)
- Phase 4: 테스트 작성 및 검증 — SUCCESS (8d42326f)

## Risks

- 기존 JobHandler 인터페이스를 사용하는 코드 호환성
- Task kill 시 프로세스 정리 누락 가능성
- 직렬화 시 실행 중 상태 손실

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/425-refactor-job-queue-task-aqmtask` → `develop`
- **Tokens**: 250 input, 46101 output{{#stats.cacheCreationTokens}}, 460562 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 4705305 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #425