### PR TITLE
[AQ-#461] feat: instanceLabel config 추가 + 이슈 필터링 — 개인화된 라벨로 이슈 감지

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -132,6 +132,7 @@ export const DEFAULT_CONFIG: AQConfig = {
     },
     stopConditions: ["STOP", "ABORT", "SAFETY_VIOLATION"],
     allowedLabels: [],
+    instanceLabel: "ai-quartermaster",
     rollbackStrategy: "failed-only",
     feasibilityCheck: {
       enabled: true,

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -279,6 +279,7 @@ const safetyConfigSchema = z.object({
   timeouts: timeoutsConfigSchema,
   stopConditions: z.array(z.string()),
   allowedLabels: z.array(z.string()),
+  instanceLabel: z.string().optional(),
   rollbackStrategy: z.enum(["none", "all", "failed-only"]),
   strict: z.boolean().default(true),
   rules: safetyRulesSchema.default({ allow: [], deny: [] }),

--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -7,6 +7,7 @@ import { checkPrConflict, commentOnIssue, listOpenPrs } from "../github/pr-creat
 import type { PrConflictInfo } from "../types/pipeline.js";
 import { SelfUpdater, UpdateInfo } from "../update/self-updater.js";
 import { getErrorMessage } from "../utils/error-utils.js";
+import { getTriggerLabels } from "../safety/label-filter.js";
 
 const logger = getLogger();
 
@@ -85,7 +86,7 @@ export class IssuePoller {
 
   private async poll(): Promise<void> {
     const projects = this.config.projects ?? [];
-    const triggerLabels = this.config.safety.allowedLabels;
+    const triggerLabels = getTriggerLabels(this.config.safety.instanceLabel, this.config.safety.allowedLabels);
     const ghPath = this.config.commands.ghCli.path;
     const ghTimeout = this.config.commands.ghCli.timeout;
 

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -11,3 +11,18 @@ export function isAllowedLabel(
   }
   return issueLabels.some(label => allowedLabels.includes(label));
 }
+
+/**
+ * Determines effective trigger labels.
+ * If instanceLabel is set, uses only that label (single-label mode).
+ * Otherwise falls back to allowedLabels.
+ */
+export function getTriggerLabels(
+  instanceLabel: string | undefined,
+  allowedLabels: string[]
+): string[] {
+  if (instanceLabel !== undefined && instanceLabel !== "") {
+    return [instanceLabel];
+  }
+  return allowedLabels;
+}

--- a/src/server/webhook-server.ts
+++ b/src/server/webhook-server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { verifyWebhookSignature } from "./webhook-validator.js";
 import { dispatchEvent, GitHubIssueEvent } from "./event-dispatcher.js";
+import { getTriggerLabels } from "../safety/label-filter.js";
 import { getLogger } from "../utils/logger.js";
 import type { AQConfig } from "../types/config.js";
 import type { JobStore } from "../queue/job-store.js";
@@ -41,10 +42,14 @@ export function createWebhookApp(options: WebhookServerOptions): Hono {
     }
 
     // Dispatch
+    const triggerLabels = getTriggerLabels(
+      options.config.safety.instanceLabel,
+      options.config.safety.allowedLabels
+    );
     const result = dispatchEvent(
       eventType,
       payload,
-      options.config.safety.allowedLabels,
+      triggerLabels,
       options.config,
       options.store
     );

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -159,6 +159,7 @@ export interface SafetyConfig {
   timeouts: TimeoutsConfig;
   stopConditions: string[];
   allowedLabels: string[];
+  instanceLabel?: string;
   rollbackStrategy: "none" | "all" | "failed-only";
   feasibilityCheck: FeasibilityCheckConfig;
   strict: boolean;

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -345,4 +345,22 @@ describe("validateConfig", () => {
 
     expect(() => validateConfig(invalidConfig)).toThrow();
   });
+
+  it("should accept config with instanceLabel set", () => {
+    const configWithInstanceLabel = updateNested(validConfig, "safety", {
+      instanceLabel: "aqm",
+    });
+
+    const result = validateConfig(configWithInstanceLabel);
+    expect(result.safety.instanceLabel).toBe("aqm");
+  });
+
+  it("should accept config without instanceLabel (optional field)", () => {
+    const configWithoutInstanceLabel = updateNested(validConfig, "safety", {
+      instanceLabel: undefined,
+    });
+
+    const result = validateConfig(configWithoutInstanceLabel);
+    expect(result.safety.instanceLabel).toBeUndefined();
+  });
 });

--- a/tests/polling/issue-poller.test.ts
+++ b/tests/polling/issue-poller.test.ts
@@ -854,4 +854,49 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(400, "test/repo");
     });
   });
+
+  describe("instanceLabel 설정 기반 라벨 필터링", () => {
+    it("instanceLabel 설정 시 해당 라벨만으로 폴링해야 한다", async () => {
+      const config = makeConfig({
+        safety: {
+          instanceLabel: "aqm",
+          allowedLabels: ["bug", "feature"],
+        },
+      });
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockRunCli.mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+      mockListOpenPrs.mockResolvedValue([]);
+
+      await (poller as any).poll();
+
+      const labelArgs = mockRunCli.mock.calls.map(
+        (call) => call[1][call[1].indexOf("--label") + 1]
+      );
+      expect(labelArgs).toContain("aqm");
+      expect(labelArgs).not.toContain("bug");
+      expect(labelArgs).not.toContain("feature");
+    });
+
+    it("instanceLabel 미설정 시 allowedLabels로 폴링해야 한다", async () => {
+      const config = makeConfig({
+        safety: {
+          allowedLabels: ["bug", "feature"],
+        },
+      });
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockRunCli.mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+      mockListOpenPrs.mockResolvedValue([]);
+
+      await (poller as any).poll();
+
+      const labelArgs = mockRunCli.mock.calls.map(
+        (call) => call[1][call[1].indexOf("--label") + 1]
+      );
+      expect(labelArgs).toContain("bug");
+      expect(labelArgs).toContain("feature");
+      expect(labelArgs).not.toContain("aqm");
+    });
+  });
 });

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isAllowedLabel } from "../../src/safety/label-filter.js";
+import { isAllowedLabel, getTriggerLabels } from "../../src/safety/label-filter.js";
 
 describe("isAllowedLabel", () => {
   it("should return true when allowedLabels is empty", () => {
@@ -26,5 +26,22 @@ describe("isAllowedLabel", () => {
     expect(isAllowedLabel(["feature-request"], ["feature"])).toBe(false);
     expect(isAllowedLabel(["bug-fix"], ["bug"])).toBe(false);
     expect(isAllowedLabel(["feature"], ["feature"])).toBe(true);
+  });
+});
+
+describe("getTriggerLabels", () => {
+  it("should return [instanceLabel] when instanceLabel is set", () => {
+    expect(getTriggerLabels("aqm", ["bug", "feature"])).toEqual(["aqm"]);
+    expect(getTriggerLabels("my-bot", [])).toEqual(["my-bot"]);
+  });
+
+  it("should return allowedLabels when instanceLabel is undefined", () => {
+    expect(getTriggerLabels(undefined, ["bug", "feature"])).toEqual(["bug", "feature"]);
+    expect(getTriggerLabels(undefined, [])).toEqual([]);
+  });
+
+  it("should return allowedLabels when instanceLabel is empty string", () => {
+    expect(getTriggerLabels("", ["bug", "feature"])).toEqual(["bug", "feature"]);
+    expect(getTriggerLabels("", [])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Resolves #461 — feat: instanceLabel config 추가 + 이슈 필터링 — 개인화된 라벨로 이슈 감지

현재 AQM은 `safety.allowedLabels` 배열로 이슈를 필터링한다. 개인화된 단일 라벨(`instanceLabel`)로 이슈를 감지하는 기능이 필요하다. instanceLabel 설정 시 해당 라벨만으로 필터링하고, 미설정 시 기존 allowedLabels 동작을 유지해야 한다.

## Requirements

- general.instanceLabel 필드 추가 (optional string, 기본값: ai-quartermaster)
- config 3곳 동시 수정: types/config.ts, defaults.ts, validator.ts
- webhook handler에서 instanceLabel 우선 사용하여 이슈 필터링
- poller에서 instanceLabel 우선 사용하여 이슈 필터링
- instanceLabel 미설정 시 기존 safety.allowedLabels 동작 유지 (하위 호환)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: Config 3곳 동시 수정 — SUCCESS (32635547)
- Phase 1: 라벨 필터링 유틸 수정 — SUCCESS (b6d60f3a)
- Phase 2: Webhook Handler 수정 — SUCCESS (7fdf70f2)
- Phase 3: Poller 수정 — SUCCESS (7fdf70f2)
- Phase 4: 테스트 및 검증 — SUCCESS (146ffd1e)

## Risks

- 기존 allowedLabels 의존 코드에서 동작 변경 가능성 - Phase 1-3에서 하위 호환성 유지 필수
- 테스트 mock에서 config 구조 변경 반영 필요

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/461-feat-instancelabel-config` → `develop`
- **Tokens**: 219 input, 23116 output{{#stats.cacheCreationTokens}}, 292873 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2683806 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #461