### PR TITLE
[AQ-#463] feat: 대시보드 인스턴스 표시 + Settings에서 라벨 변경

### DIFF
--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -143,6 +143,7 @@ const mergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
 
 const generalConfigSchema = z.object({
   projectName: z.string().min(1, "projectName must be a non-empty string"),
+  instanceLabel: z.string().optional(),
   logLevel: logLevelSchema,
   logDir: z.string(),
   dryRun: z.boolean(),

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -301,6 +301,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 <header class="sticky top-0 z-50 flex justify-between items-center px-6 h-16 w-full bg-[#0d1117] dark:bg-[#0d1117] border-b border-[#30363d]">
   <div class="flex items-center gap-8">
     <span class="font-headline font-bold text-primary-container text-lg uppercase tracking-wider">AI Quartermaster</span>
+    <span id="instance-label" class="hidden font-mono text-xs text-outline uppercase tracking-widest opacity-70 border border-outline-variant/30 px-2 py-0.5 rounded"></span>
     <nav class="hidden md:flex gap-6">
       <a class="font-body font-bold tracking-tight text-sm text-primary-container border-b-2 border-primary-container py-5 cursor-pointer" data-nav="dashboard" data-i18n="dashboard">Dashboard</a>
       <a class="font-body font-bold tracking-tight text-sm text-slate-400 hover:text-slate-200 transition-colors py-5 cursor-pointer" data-nav="logs" data-i18n="logs">Logs</a>

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -560,6 +560,9 @@ function connectSSE() {
         var label = data.changes.general.instanceLabel || data.changes.general.projectName || '';
         updateInstanceLabel(label);
       }
+      if (currentView === 'settings') {
+        loadSettings();
+      }
     } catch (_) {}
   });
   es.onerror = function() {

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -81,6 +81,32 @@ function toggleTheme() {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   Instance Label
+   ══════════════════════════════════════════════════════════════ */
+function updateInstanceLabel(label) {
+  var el = document.getElementById('instance-label');
+  if (!el) return;
+  if (label) {
+    el.textContent = label;
+    el.classList.remove('hidden');
+  } else {
+    el.classList.add('hidden');
+  }
+}
+
+function loadInstanceLabel() {
+  apiFetch('/api/config')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.config && data.config.general) {
+        var label = data.config.general.instanceLabel || data.config.general.projectName || '';
+        updateInstanceLabel(label);
+      }
+    })
+    .catch(function() {});
+}
+
+/* ══════════════════════════════════════════════════════════════
    Settings
    ══════════════════════════════════════════════════════════════ */
 var currentConfig = null; // 현재 설정 데이터 저장
@@ -527,6 +553,15 @@ function connectSSE() {
   es.onmessage = function(e) {
     try { handleData(JSON.parse(e.data)); } catch (_) {}
   };
+  es.addEventListener('configChanged', function(e) {
+    try {
+      var data = JSON.parse(e.data);
+      if (data.changes && data.changes.general) {
+        var label = data.changes.general.instanceLabel || data.changes.general.projectName || '';
+        updateInstanceLabel(label);
+      }
+    } catch (_) {}
+  });
   es.onerror = function() {
     setConnState('disconnected');
     es.close();
@@ -731,6 +766,9 @@ loadVersionInfo();
 
 // Initialize project selection
 initProjectSelection();
+
+// Load instance label for header
+loadInstanceLabel();
 
 connectSSE();
 

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -654,13 +654,18 @@ function renderTabForm(tabName, data) {
   container.innerHTML = html;
 }
 
+var FIELD_DISPLAY_LABELS = {
+  'general.instanceLabel': 'Instance Label',
+};
+
 function renderFormField(key, value, configPath) {
   var fieldId = 'field-' + configPath.replace(/\./g, '-');
   var isMasked = typeof value === 'string' && value.includes('********');
   var isReadonly = isMasked;
+  var displayLabel = FIELD_DISPLAY_LABELS[configPath] || key;
 
   var html = '<label class="block">';
-  html += '<span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-2">' + esc(key) + '</span>';
+  html += '<span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-2">' + esc(displayLabel) + '</span>';
 
   if (typeof value === 'boolean') {
     html += renderCheckboxInput(fieldId, value, configPath, isReadonly);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -19,6 +19,7 @@ const mergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
 
 const generalConfigUpdateSchema = z.object({
   projectName: z.string().min(1),
+  instanceLabel: z.string(),
   logLevel: logLevelSchema,
   logDir: z.string(),
   dryRun: z.boolean(),

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -22,6 +22,7 @@ export interface SkillContent {
 
 export interface GeneralConfig {
   projectName: string;
+  instanceLabel?: string;
   logLevel: LogLevel;
   logDir: string;
   dryRun: boolean;


### PR DESCRIPTION
## Summary

Resolves #463 — feat: 대시보드 인스턴스 표시 + Settings에서 라벨 변경

현재 대시보드에서 어떤 AQM 인스턴스인지 구분이 어렵고, instanceLabel을 변경하려면 config.yml을 직접 수정해야 함. 대시보드 헤더에 인스턴스명을 표시하고, Settings 페이지에서 직접 변경 가능하도록 UI를 추가해야 함.

## Requirements

- 대시보드 헤더에 인스턴스명 표시 (예: AQM - by)
- Settings 페이지에서 instanceLabel 입력 필드 제공
- PUT /api/config로 저장 시 hot reload 적용
- SSE를 통해 실시간 UI 업데이트

## Implementation Phases

- Phase 0: 헤더에 인스턴스명 표시 — SUCCESS (f9e52a2a)
- Phase 1: Settings UI에 instanceLabel 필드 추가 — SUCCESS (fcac9e8e)
- Phase 2: API에서 instanceLabel 처리 — SUCCESS (18a8ffcf)
- Phase 3: 실시간 업데이트 연동 — SUCCESS (ffe28dbc)

## Risks

- instanceLabel config 이슈가 선행 완료되어야 함 (types/config.ts, defaults.ts, validator.ts)
- UpdateConfigRequestSchema에 instanceLabel 필드가 없으면 API 검증 실패

## Pipeline Stats

- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/463-feat-settings` → `develop`
- **Tokens**: 297 input, 36720 output{{#stats.cacheCreationTokens}}, 277222 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 4378703 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #463