### PR TITLE
[AQ-#478] fix: 재시작 시 project pause 자동 해제 — 메모리 상태 초기화

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -228,6 +228,10 @@ export class JobQueue {
    * Running jobs are reset to queued and re-enqueued.
    */
   recover(): number {
+    // 재시작 시 메모리 상태 초기화 — pause 상태 자동 해제
+    this.projectErrorState.clear();
+    logger.info("재시작: projectErrorState 초기화 완료 (project pause 해제)");
+
     const jobs = this.store.list();
     let recovered = 0;
 

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1573,6 +1573,91 @@ describe("JobQueue", () => {
     });
   });
 
+  describe("recover", () => {
+    it("should clear projectErrorState on recover (paused project is resumed)", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 1, handler);
+
+      // Pause a project
+      queue.pauseProject("test/repo", 60000); // 1분 pause
+      expect(queue.isProjectPaused("test/repo")).toBe(true);
+      expect(queue.getProjectStatus("test/repo")?.pausedUntil).toBeGreaterThan(Date.now());
+
+      // recover() 호출 시 projectErrorState 초기화
+      queue.recover();
+
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+      expect(queue.getProjectStatus("test/repo")).toBeNull();
+    });
+
+    it("should clear consecutiveFailures on recover", async () => {
+      const handler: JobHandler = vi.fn()
+        .mockRejectedValueOnce(new Error("failure 1"))
+        .mockRejectedValueOnce(new Error("failure 2"));
+
+      const queue = new JobQueue(store, 1, handler);
+
+      // 두 번 실패하여 consecutiveFailures = 2
+      const job1 = queue.enqueue(1, "test/repo");
+      await new Promise(r => setTimeout(r, 50));
+      expect(store.get(job1!.id)?.status).toBe("failure");
+
+      const job2 = queue.enqueue(2, "test/repo");
+      await new Promise(r => setTimeout(r, 50));
+      expect(store.get(job2!.id)?.status).toBe("failure");
+
+      expect(queue.getProjectStatus("test/repo")?.consecutiveFailures).toBe(2);
+
+      // recover() 호출 후 projectErrorState 초기화
+      queue.recover();
+
+      expect(queue.getProjectStatus("test/repo")).toBeNull();
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+    });
+
+    it("should clear projectErrorState for multiple repos on recover", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 1, handler);
+
+      // 두 repo 모두 pause
+      queue.pauseProject("test/repo1", 60000);
+      queue.pauseProject("test/repo2", 60000);
+
+      expect(queue.isProjectPaused("test/repo1")).toBe(true);
+      expect(queue.isProjectPaused("test/repo2")).toBe(true);
+
+      queue.recover();
+
+      expect(queue.isProjectPaused("test/repo1")).toBe(false);
+      expect(queue.isProjectPaused("test/repo2")).toBe(false);
+      expect(queue.getProjectStatus("test/repo1")).toBeNull();
+      expect(queue.getProjectStatus("test/repo2")).toBeNull();
+    });
+
+    it("should still recover queued and running jobs after clearing projectErrorState", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 0, handler); // concurrency=0: 잡이 즉시 실행되지 않도록
+
+      // 스토어에 queued/running 잡 직접 생성
+      const queuedJob = store.create(10, "test/repo");
+      const runningJob = store.create(20, "test/repo2");
+      store.update(runningJob.id, { status: "running", startedAt: new Date().toISOString() });
+
+      // project pause 설정
+      queue.pauseProject("test/repo", 60000);
+
+      const recovered = queue.recover();
+
+      // projectErrorState 초기화됨
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+
+      // queued/running 잡 복구
+      expect(recovered).toBe(2);
+      expect(store.get(queuedJob.id)?.status).toBe("queued");
+      expect(store.get(runningJob.id)?.status).toBe("queued"); // running → queued로 리셋
+    });
+  });
+
   describe("Priority Queue", () => {
     it("should execute jobs in priority order: high -> normal -> low", async () => {
       const executionOrder: number[] = [];


### PR DESCRIPTION
## Summary

Resolves #478 — fix: 재시작 시 project pause 자동 해제 — 메모리 상태 초기화

서버 재시작 시 projectErrorState(메모리 Map)가 명시적으로 초기화되지 않아, 재시작 시 pause 해제 동작이 불명확함. recover() 메서드에서 queued/running 잡은 복구하지만 projectErrorState 초기화 로직이 없음.

## Requirements

- 서버 재시작 시 projectErrorState 명시적 초기화로 pause 자동 해제
- recover() 메서드에서 초기화 수행 및 로깅
- 기존 테스트 통과 + 새 동작 테스트 추가

## Implementation Phases

- Phase 0: recover()에 projectErrorState 초기화 추가 — SUCCESS (ddc55b94)
- Phase 1: 테스트 추가 — SUCCESS (447409a4)

## Risks

- 기존 테스트에서 recover() 관련 mock이 있을 경우 수정 필요 가능

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/478-fix-project-pause` → `develop`
- **Tokens**: 83 input, 8761 output{{#stats.cacheCreationTokens}}, 175139 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1104983 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #478