### PR TITLE
[AQ-#477] fix: aqm stop 시 자식 프로세스 그룹 kill — 좀비 방지

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -199,6 +199,8 @@ case "${1:-}" in
     PID=$(find_server_pid "$PORT")
     if [ $? -eq 0 ] && [ -n "$PID" ]; then
       echo "서버 중지 중... (PID: $PID, Port: $PORT)"
+      # Kill child processes first (graceful)
+      pkill -TERM -P "$PID" 2>/dev/null
       kill "$PID" 2>/dev/null
       # Wait for graceful shutdown
       for i in $(seq 1 10); do
@@ -210,6 +212,7 @@ case "${1:-}" in
       # Force kill if still running
       if kill -0 "$PID" 2>/dev/null; then
         echo "강제 종료 시도 중..."
+        pkill -KILL -P "$PID" 2>/dev/null
         kill -9 "$PID" 2>/dev/null
       fi
       rm -f "$AQM_PID_FILE"


### PR DESCRIPTION
## Summary

Resolves #477 — fix: aqm stop 시 자식 프로세스 그룹 kill — 좀비 방지

현재 `aqm stop` 명령어는 서버 PID만 종료하고 자식 프로세스(Claude CLI 등)는 정리하지 않음. 이로 인해 재시작 시 이전 프로세스가 잔존하거나 좀비 프로세스 발생 가능.

## Requirements

- 서버 PID뿐 아니라 자식 프로세스 그룹 전체 kill
- pkill -P 또는 프로세스 그룹 kill 방식 사용
- 재시작 시 이전 프로세스 잔존 방지
- graceful shutdown 후 force kill 순서 유지

## Implementation Phases

- Phase 0: 자식 프로세스 그룹 kill 구현 — SUCCESS (4871bd0a)

## Risks

- pkill이 없는 환경에서 fallback 필요 (대부분의 Linux/macOS에는 있음)
- 자식 프로세스가 다른 세션에 있을 경우 kill 안 될 수 있음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/477-fix-aqm-stop-kill` → `develop`
- **Tokens**: 39 input, 3742 output{{#stats.cacheCreationTokens}}, 82616 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 229553 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #477