### PR TITLE
[AQ-#479] fix: Plan 순환 의존성 검증 — validatePlan에 cycle 체크 추가

### DIFF
--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { readFileSync, existsSync } from "fs";
 import * as ts from "typescript";
 import { renderTemplate, loadTemplate, buildDynamicSection, TemplateVariables } from "../prompt/template-renderer.js";
+import { detectCircularDependencies, validatePhaseDependencies } from "./phase-scheduler.js";
 import { runClaude, extractJson } from "../claude/claude-runner.js";
 import { configForTask, configForTaskWithMode } from "../claude/model-router.js";
 import type { ClaudeCliConfig } from "../types/config.js";
@@ -413,6 +414,18 @@ function validatePlan(plan: Plan): void {
     phase.verificationCriteria = phase.verificationCriteria ?? [];
     phase.dependsOn = phase.dependsOn ?? [];
   });
+
+  // Validate phase dependencies (self-dependency, non-existent refs)
+  const depValidation = validatePhaseDependencies(plan.phases);
+  if (!depValidation.valid) {
+    throw new Error(`Invalid phase dependencies: ${depValidation.errors.join("; ")}`);
+  }
+
+  // Detect circular dependencies (A→B→A etc.)
+  const cycle = detectCircularDependencies(plan.phases);
+  if (cycle.length > 0) {
+    throw new Error(`Circular dependency detected in plan phases: ${cycle.join(" → ")}`);
+  }
 }
 
 /**

--- a/tests/pipeline/plan-generator.test.ts
+++ b/tests/pipeline/plan-generator.test.ts
@@ -1351,4 +1351,153 @@ Plan 생성 정확도를 높이기 위해 수집된 추가 컨텍스트입니다
       expect(mockRunClaude).toHaveBeenCalledTimes(models.length);
     });
   });
+
+  describe("validatePlan circular dependency detection", () => {
+    const baseClaudeConfig = {
+      path: "claude",
+      model: "test",
+      maxTurns: 1,
+      timeout: 1000,
+      additionalArgs: [] as string[],
+    };
+
+    const basePlanFields = {
+      mode: "code" as const,
+      issueNumber: 1,
+      title: "Test",
+      problemDefinition: "Test problem",
+      requirements: ["Requirement A"],
+      affectedFiles: [],
+      risks: [],
+      verificationPoints: [],
+      stopConditions: [],
+    };
+
+    it("should throw when a phase depends on itself", async () => {
+      const selfDepPlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "Self-referencing phase",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(selfDepPlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(selfDepPlan);
+
+      await expect(
+        generatePlan({
+          issue: { number: 1, title: "Test", body: "", labels: [] },
+          repo: { owner: "test", name: "repo" },
+          branch: { base: "main", work: "ax/1-test" },
+          repoStructure: "",
+          claudeConfig: baseClaudeConfig,
+          promptsDir,
+          cwd: testDir,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should throw when phases have A→B→A circular dependency", async () => {
+      const cyclePlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "Depends on B",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [1],
+          },
+          {
+            index: 1,
+            name: "Phase B",
+            description: "Depends on A",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(cyclePlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(cyclePlan);
+
+      await expect(
+        generatePlan({
+          issue: { number: 1, title: "Test", body: "", labels: [] },
+          repo: { owner: "test", name: "repo" },
+          branch: { base: "main", work: "ax/1-test" },
+          repoStructure: "",
+          claudeConfig: baseClaudeConfig,
+          promptsDir,
+          cwd: testDir,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should pass when phase dependencies are valid (linear chain)", async () => {
+      const validPlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "No dependencies",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [],
+          },
+          {
+            index: 1,
+            name: "Phase B",
+            description: "Depends on A",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(validPlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(validPlan);
+
+      const result = await generatePlan({
+        issue: { number: 1, title: "Test", body: "", labels: [] },
+        repo: { owner: "test", name: "repo" },
+        branch: { base: "main", work: "ax/1-test" },
+        repoStructure: "",
+        claudeConfig: baseClaudeConfig,
+        promptsDir,
+        cwd: testDir,
+      });
+
+      expect(result.plan.phases).toHaveLength(2);
+      expect(result.plan.phases[1].dependsOn).toEqual([0]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #479 — fix: Plan 순환 의존성 검증 — validatePlan에 cycle 체크 추가

plan-generator.ts의 validatePlan() 함수가 Phase 간 순환 의존성을 검증하지 않아, 잘못된 dependsOn 설정이 포함된 Plan이 생성될 수 있다. phase-scheduler.ts에 이미 detectCircularDependencies()와 validatePhaseDependencies()가 구현되어 있으므로, 이를 활용하여 validatePlan에서 조기에 에러를 감지해야 한다.

## Requirements

- validatePlan()에서 자기 자신 의존(dependsOn에 자신 index) 감지 시 에러 throw
- validatePlan()에서 Phase 간 순환 의존(A→B→A) 감지 시 에러 throw
- phase-scheduler.ts의 기존 detectCircularDependencies, validatePhaseDependencies 함수 재활용
- 순환 의존성 체크에 대한 단위 테스트 추가

## Implementation Phases

- Phase 0: validatePlan 순환 의존성 체크 추가 — SUCCESS (48a44024)
- Phase 1: 순환 의존성 검증 테스트 추가 — SUCCESS (686e935d)

## Risks

- 기존 validatePlan 호출부에 영향 없음 (에러 throw 방식 동일)
- phase-scheduler 함수 import 추가로 인한 순환 참조 가능성 낮음 (plan-generator → phase-scheduler 단방향)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/479-fix-plan-validateplan-cycle` → `develop`
- **Tokens**: 104 input, 13445 output{{#stats.cacheCreationTokens}}, 168553 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1380600 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #479