### PR TITLE
[AQ-#480] fix: 체크포인트 복원 시 비활성화 상태 스킵 — CI_CHECKING 등 무효 상태 방지

### DIFF
--- a/src/pipeline/pipeline-context.ts
+++ b/src/pipeline/pipeline-context.ts
@@ -56,6 +56,17 @@ export const STATE_ORDER: PipelineState[] = [
   "DONE",
 ];
 
+/**
+ * 비활성화된 기능 상태를 정규화한다.
+ * CI_CHECKING/CI_FIXING은 현재 비활성화된 상태이므로 체크포인트 복원 시 DONE으로 전진한다.
+ */
+export function normalizeCheckpointState(state: PipelineState): PipelineState {
+  if (state === "CI_CHECKING" || state === "CI_FIXING") {
+    return "DONE";
+  }
+  return state;
+}
+
 export function isPastState(checkpointState: PipelineState, current: PipelineState): boolean {
   const checkpointIdx = STATE_ORDER.indexOf(checkpointState);
   const currentIdx = STATE_ORDER.indexOf(current);
@@ -84,8 +95,10 @@ export async function initializePipelineState(
   const resumeFrom = input.resumeFrom;
   const logger = getLogger();
 
+  const restoredState = resumeFrom ? normalizeCheckpointState(resumeFrom.state) : "RECEIVED";
+
   const runtime: PipelineRuntime = {
-    state: resumeFrom?.state ?? "RECEIVED",
+    state: restoredState,
     worktreePath: resumeFrom?.worktreePath,
     branchName: resumeFrom?.branchName,
     projectRoot: input.projectRoot ?? resumeFrom?.projectRoot ?? "",
@@ -96,8 +109,11 @@ export async function initializePipelineState(
   };
 
   if (resumeFrom) {
-    logger.info(`Resuming pipeline from state: ${resumeFrom.state}`);
-    input.jobLogger?.setProgress(progressForState(resumeFrom.state));
+    if (restoredState !== resumeFrom.state) {
+      logger.info(`Checkpoint state normalized: ${resumeFrom.state} → ${restoredState} (disabled feature state)`);
+    }
+    logger.info(`Resuming pipeline from state: ${restoredState}`);
+    input.jobLogger?.setProgress(progressForState(restoredState));
   }
 
   return runtime;

--- a/tests/pipeline/pipeline-context.test.ts
+++ b/tests/pipeline/pipeline-context.test.ts
@@ -3,6 +3,7 @@ import {
   initializePipelineState,
   transitionState,
   isPastState,
+  normalizeCheckpointState,
   STATE_ORDER,
   type PipelineRuntime,
   type OrchestratorInput,
@@ -132,6 +133,65 @@ describe("pipeline-context", () => {
 
     it("should return false for same states", () => {
       expect(isPastState("VALIDATED", "VALIDATED")).toBe(false);
+    });
+  });
+
+  describe("normalizeCheckpointState", () => {
+    it("should normalize CI_CHECKING to DONE", () => {
+      expect(normalizeCheckpointState("CI_CHECKING")).toBe("DONE");
+    });
+
+    it("should normalize CI_FIXING to DONE", () => {
+      expect(normalizeCheckpointState("CI_FIXING")).toBe("DONE");
+    });
+
+    it("should not modify other states", () => {
+      expect(normalizeCheckpointState("DONE")).toBe("DONE");
+      expect(normalizeCheckpointState("VALIDATED")).toBe("VALIDATED");
+      expect(normalizeCheckpointState("DRAFT_PR_CREATED")).toBe("DRAFT_PR_CREATED");
+      expect(normalizeCheckpointState("REVIEWING")).toBe("REVIEWING");
+    });
+  });
+
+  describe("initializePipelineState — checkpoint normalization", () => {
+    it("should normalize CI_CHECKING to DONE when resuming", async () => {
+      const input: OrchestratorInput = {
+        issueNumber: 123,
+        repo: "owner/repo",
+        config: mockConfig,
+        resumeFrom: {
+          state: "CI_CHECKING",
+          worktreePath: "/test/worktree",
+          branchName: "feature-branch",
+          projectRoot: "/test/project",
+          plan: undefined,
+          phaseResults: undefined,
+        },
+      };
+
+      const runtime = await initializePipelineState(input, mockConfig);
+
+      expect(runtime.state).toBe("DONE");
+    });
+
+    it("should normalize CI_FIXING to DONE when resuming", async () => {
+      const input: OrchestratorInput = {
+        issueNumber: 123,
+        repo: "owner/repo",
+        config: mockConfig,
+        resumeFrom: {
+          state: "CI_FIXING",
+          worktreePath: "/test/worktree",
+          branchName: "feature-branch",
+          projectRoot: "/test/project",
+          plan: undefined,
+          phaseResults: undefined,
+        },
+      };
+
+      const runtime = await initializePipelineState(input, mockConfig);
+
+      expect(runtime.state).toBe("DONE");
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves #480 — fix: 체크포인트 복원 시 비활성화 상태 스킵 — CI_CHECKING 등 무효 상태 방지

체크포인트가 CI_CHECKING 또는 CI_FIXING 상태로 저장되어 있는데, CI 체크 기능이 비활성화된 경우 해당 상태로 복원하면 파이프라인이 무효 상태에서 시작됨. 비활성화된 기능 상태로 복원 시 다음 유효 상태(DONE)로 전진해야 함.

## Requirements

- 체크포인트에서 복원 시 CI_CHECKING, CI_FIXING 등 비활성화된 기능 상태이면 해당 단계 스킵
- 비활성화된 기능의 상태로 복원되면 다음 유효 상태로 전진
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase 0: 체크포인트 상태 정규화 구현 — SUCCESS (08e7bb75)

## Risks

- 기존 체크포인트 복원 로직 변경으로 인한 사이드 이펙트 (완화: 기존 테스트 유지)
- 향후 CI 기능 활성화 시 로직 재검토 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/480-fix-ci-checking` → `develop`
- **Tokens**: 106 input, 10915 output{{#stats.cacheCreationTokens}}, 122275 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 890715 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #480