### PR TITLE
[AQ-#476] fix: 이슈 재라벨 시 이전 성공 잡 자동 archive — 재처리 차단 방지

### DIFF
--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -197,13 +197,10 @@ export class IssuePoller {
 
     for (const issue of issues) {
       if (this.store.shouldBlockRepickup(issue.number, repo)) {
-        // 차단 이유를 상태별로 구분하여 로그 출력
         const existingJob = this.store.findAnyByIssue(issue.number, repo);
         if (existingJob) {
           if (existingJob.status === "running" || existingJob.status === "queued") {
             logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 처리 중), 건너뜀`);
-          } else if (existingJob.status === "success") {
-            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (성공 완료된 잡 존재), 건너뜀`);
           } else {
             logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 존재), 건너뜀`);
           }

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -313,11 +313,9 @@ export class JobQueue {
     const existing = this.store.findAnyByIssue(issueNumber, repo);
     if (existing) {
       if (isSuccessJob(existing)) {
-        logger.warn(`Job for issue #${issueNumber} (${repo}) already completed successfully: ${existing.id}`);
-        return undefined;
-      }
-
-      if (isFailureJob(existing) || isCancelledJob(existing)) {
+        logger.info(`Auto-archiving existing success job ${existing.id} for issue #${issueNumber} (${repo})`);
+        this.store.archive(existing.id);
+      } else if (isFailureJob(existing) || isCancelledJob(existing)) {
         logger.info(`Auto-archiving existing ${existing.status} job ${existing.id} for issue #${issueNumber} (${repo})`);
         this.cleanupFailedJobArtifacts(issueNumber);
         this.store.archive(existing.id);

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -634,11 +634,11 @@ export class JobStore extends EventEmitter {
     const existingJob = this.findAnyByIssue(issueNumber, repo);
     if (!existingJob) return false;
 
-    // queued, running, success 상태의 잡이 있으면 차단
+    // queued, running 상태의 잡이 있으면 차단
+    // success는 재라벨 시 재처리를 허용하기 위해 차단하지 않음 (archive 후 재처리)
     // failure, cancelled, archived 상태는 재시도 가능하므로 차단하지 않음
     return existingJob.status === "queued" ||
-           existingJob.status === "running" ||
-           existingJob.status === "success";
+           existingJob.status === "running";
   }
 
   findFailedJobsForRetry(): Job[] {

--- a/tests/e2e/polling-integration.test.ts
+++ b/tests/e2e/polling-integration.test.ts
@@ -63,7 +63,11 @@ function makeJobStore(existingJobs: Array<{ issueNumber: number; repo: string; s
       return jobs.find(j => j.issueNumber === issueNumber && j.repo === repo && j.status !== "archived");
     }),
     shouldBlockRepickup: vi.fn((issueNumber: number, repo: string): boolean => {
-      return jobs.some(j => j.issueNumber === issueNumber && j.repo === repo && j.status === "success");
+      // success는 재라벨 재처리를 허용하기 위해 차단하지 않음 — queued/running만 차단
+      return jobs.some(
+        j => j.issueNumber === issueNumber && j.repo === repo &&
+          (j.status === "queued" || j.status === "running"),
+      );
     }),
     findFailedJobsForRetry: vi.fn((): Job[] => {
       const now = Date.now();
@@ -108,44 +112,39 @@ function makeJobStore(existingJobs: Array<{ issueNumber: number; repo: string; s
 function makeJobQueue(store: ReturnType<typeof makeJobStore>) {
   return {
     enqueue: vi.fn((issueNumber: number, repo: string): Job | undefined => {
-      // Check if success job exists (should block repickup)
-      if (store.shouldBlockRepickup(issueNumber, repo)) {
-        return undefined;
-      }
-
-      // Check for existing failed/cancelled jobs and auto-archive them
       const existing = store.findAnyByIssue(issueNumber, repo);
-      if (existing && (existing.status === "failure" || existing.status === "cancelled")) {
-        // Simulate the actual JobQueue logic for worktree cleanup
-        const dataDir = "/tmp/test-data"; // Mock data directory
+      if (existing) {
+        if (existing.status === "success") {
+          // 재라벨 시 success job auto-archive (checkpoint 정리 불필요)
+          store.archive(existing.id);
+        } else if (existing.status === "failure" || existing.status === "cancelled") {
+          // failed/cancelled: checkpoint 정리 후 archive
+          const dataDir = "/tmp/test-data";
 
-        try {
-          // Load checkpoint to check for worktree before removing
-          const checkpoint = mockLoadCheckpoint(dataDir, issueNumber);
-          if (checkpoint?.worktreePath) {
-            // Simulate worktree removal call
-            mockRemoveWorktree(
-              { gitPath: "git" }, // Mock git config
-              checkpoint.worktreePath,
-              { cwd: "/tmp/project", force: true }
-            );
+          try {
+            const checkpoint = mockLoadCheckpoint(dataDir, issueNumber);
+            if (checkpoint?.worktreePath) {
+              mockRemoveWorktree(
+                { gitPath: "git" },
+                checkpoint.worktreePath,
+                { cwd: "/tmp/project", force: true }
+              );
+            }
+          } catch (_checkpointErr) {
+            // error handling
           }
-        } catch (checkpointErr) {
-          // Simulate error handling
-        }
 
-        try {
-          // Remove checkpoint
-          mockRemoveCheckpoint(dataDir, issueNumber);
-        } catch (err) {
-          // Simulate error handling
-        }
+          try {
+            mockRemoveCheckpoint(dataDir, issueNumber);
+          } catch (_err) {
+            // error handling
+          }
 
-        // Archive the existing job
-        store.archive(existing.id);
-      } else if (existing) {
-        // Other statuses (queued, running) should still block
-        return undefined;
+          store.archive(existing.id);
+        } else {
+          // queued/running: 차단
+          return undefined;
+        }
       }
 
       return store.create(issueNumber, repo);
@@ -233,16 +232,16 @@ describe("E2E: polling integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2. Skips issues that have successful jobs (shouldBlockRepickup)
+  // 2. Skips issues with active (queued/running) jobs — shouldBlockRepickup
   // -------------------------------------------------------------------------
-  it("skips issues that already exist in the job store", async () => {
-    // Issue #10 already has a successful job
-    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "success" }]);
+  it("skips issues with queued or running jobs (active processing blocks re-pickup)", async () => {
+    // Issue #10 already has a queued job (active processing — should block)
+    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "queued" }]);
     const queue = makeJobQueue(store);
 
     mockRunCli.mockResolvedValue({
       stdout: makeGhIssueListResponse([
-        { number: 10, title: "Add feature A" }, // has successful job - should be blocked
+        { number: 10, title: "Add feature A" }, // has queued job - should be blocked
         { number: 12, title: "New issue C" },    // new - should be enqueued
       ]),
       stderr: "",
@@ -252,10 +251,38 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // Only the new issue should be enqueued
+    // Only the new issue should be enqueued (queued/running blocks re-pickup)
     expect(queue.enqueue).toHaveBeenCalledTimes(1);
     expect(queue.enqueue).toHaveBeenCalledWith(12, "test/repo");
     expect(queue.enqueue).not.toHaveBeenCalledWith(10, expect.anything());
+  });
+
+  // -------------------------------------------------------------------------
+  // 2b. Success jobs do NOT block — re-labeling triggers re-processing
+  // -------------------------------------------------------------------------
+  it("allows re-pickup of success jobs (re-label triggers new processing)", async () => {
+    // Issue #10 has a success job — re-labeling should trigger new processing
+    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "success" }]);
+    const queue = makeJobQueue(store);
+
+    mockRunCli.mockResolvedValue({
+      stdout: makeGhIssueListResponse([
+        { number: 10, title: "Add feature A" }, // has success job - should be re-enqueued
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    poller = new IssuePoller(makeConfig(), store as any, queue as any);
+    await (poller as any).poll();
+
+    // The success issue should be re-enqueued (success does not block re-pickup)
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    expect(queue.enqueue).toHaveBeenCalledWith(10, "test/repo");
+
+    // Original success job should be archived
+    const originalJob = store.get("aq-10-0");
+    expect(originalJob?.status).toBe("archived");
   });
 
   // -------------------------------------------------------------------------

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -179,7 +179,7 @@ describe("JobQueue", () => {
     expect(completedNewJob?.status).toBe("success");
   });
 
-  it("should prevent re-enqueue when successful job exists", async () => {
+  it("should auto-archive success job and allow re-enqueue", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
     const queue = new JobQueue(store, 1, handler);
 
@@ -189,9 +189,14 @@ describe("JobQueue", () => {
     const completed = store.get(successJob!.id);
     expect(completed?.status).toBe("success");
 
-    // Try to re-enqueue same issue - should be blocked
-    const blockedJob = queue.enqueue(789, "test/repo");
-    expect(blockedJob).toBeUndefined();
+    // Re-enqueue same issue - success job should be archived and new job created
+    const newJob = queue.enqueue(789, "test/repo");
+    expect(newJob).toBeDefined();
+    expect(newJob!.id).not.toBe(successJob!.id);
+
+    // Original success job should now be archived
+    const archivedJob = store.get(successJob!.id);
+    expect(archivedJob?.status).toBe("archived");
   });
 
   it("should cancel a pending job", () => {

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -104,12 +104,12 @@ describe("JobStore", () => {
       expect(result).toBe(false);
     });
 
-    it("should return true when a success job exists for the issue", () => {
+    it("should return false when a success job exists for the issue (allows re-pickup after relabel)", () => {
       const job = store.create(42, "test/repo");
       store.update(job.id, { status: "success", completedAt: new Date().toISOString() });
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it("should return false when only failure job exists for the issue", () => {
@@ -170,7 +170,7 @@ describe("JobStore", () => {
       expect(result).toBe(false);
     });
 
-    it("should return true when both success and other status jobs exist", () => {
+    it("should return false when success job exists (allows re-pickup after relabel)", () => {
       const job1 = store.create(42, "test/repo");
       store.update(job1.id, { status: "failure", completedAt: new Date().toISOString(), error: "Error 1" });
 
@@ -178,7 +178,7 @@ describe("JobStore", () => {
       store.update(job2.id, { status: "success", completedAt: new Date().toISOString() });
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves #476 — fix: 이슈 재라벨 시 이전 성공 잡 자동 archive — 재처리 차단 방지

현재 이슈가 재라벨링되어도 기존 success 상태 job이 있으면 재처리가 차단됨. `shouldBlockRepickup`과 `enqueue` 모두 success 상태를 차단하여 수동 DB 조작 없이는 재처리 불가능.

## Requirements

- webhook/poller에서 이슈 감지 시 해당 이슈의 기존 success 잡을 자동 archive 처리
- 이슈 재라벨만으로 재처리 가능하도록 (수동 DB 조작 불필요)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: job-store.ts 수정 — SUCCESS (92c43f74)
- Phase 1: job-queue.ts 수정 — SUCCESS (6b391b92)
- Phase 2: issue-poller.ts 로그 정리 — SUCCESS (6b391b92)
- Phase 3: 테스트 수정 — SUCCESS (11729097)
- Phase 4: 검증 — SUCCESS (11729097)

## Risks

- 기존 success job 보존이 필요한 사용 사례가 있을 경우 동작 변경됨 (의도된 변경)
- archive된 job이 많아질 수 있음 (정상 동작)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/476-fix-archive` → `develop`
- **Tokens**: 195 input, 27528 output{{#stats.cacheCreationTokens}}, 280952 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2839278 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #476