### PR TITLE
[AQ-#482] refactor: 기본 라벨명 ai-quartermaster → aqm 축약

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,45 @@
 - 소스 48개 / 테스트 21개 (104 tests) / typecheck clean
 - GitHub: https://github.com/happytalkrz/AI-Quartermaster
 
+## 마이그레이션 가이드
+
+### v0.3.x → v0.4.0: 기본 라벨명 변경 (`ai-quartermaster` → `aqm`)
+
+기본 인스턴스 라벨이 `ai-quartermaster`에서 `aqm`으로 변경되었습니다.
+
+#### 영향 범위
+
+`config.yml`에서 `label`을 명시하지 않은 경우, 기본값이 변경됩니다.
+
+| 항목 | 이전 | 이후 |
+|------|------|------|
+| 기본 `label` 값 | `ai-quartermaster` | `aqm` |
+
+#### 기존 사용자 대응
+
+**방법 1 (권장):** GitHub 리포지토리에서 라벨명을 `aqm`으로 변경
+
+```bash
+# 기존 라벨 삭제 후 새 라벨 생성
+gh label delete "ai-quartermaster" --repo <owner>/<repo>
+gh label create "aqm" --color "#0075ca" --repo <owner>/<repo>
+```
+
+**방법 2:** `config.yml`에 기존 라벨명을 명시하여 유지
+
+```yaml
+# config.yml
+label: ai-quartermaster  # 기존 라벨명 유지
+```
+
+#### 확인 방법
+
+```bash
+aqm config show  # 현재 설정의 label 값 확인
+```
+
+---
+
 ## 커밋 히스토리
 
 ```

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -132,7 +132,7 @@ export const DEFAULT_CONFIG: AQConfig = {
       prCreation: 60000,
     },
     stopConditions: ["STOP", "ABORT", "SAFETY_VIOLATION"],
-    allowedLabels: [],
+    allowedLabels: ["aqm"],
     rollbackStrategy: "failed-only",
     feasibilityCheck: {
       enabled: true,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -3,7 +3,7 @@ import { AQConfig } from "../types/config.js";
 export const DEFAULT_CONFIG: AQConfig = {
   general: {
     projectName: "ai-quartermaster",
-    instanceLabel: "ai-quartermaster",
+    instanceLabel: "aqm",
     logLevel: "info",
     logDir: "logs",
     dryRun: false,

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -18,7 +18,7 @@ const prConfig = {
   draft: true,
   titleTemplate: "[AQ-#{issueNumber}] {title}",
   bodyTemplate: "pr-body.md",
-  labels: ["ai-quartermaster"],
+  labels: ["aqm"],
   assignees: [],
   reviewers: [],
   linkIssue: true,
@@ -147,7 +147,7 @@ describe("closeIssue", () => {
           "--title", "[AQ-#{issueNumber}] {title}",
           "--body", expect.stringContaining("Closes #42"),
           "--draft",
-          "--label", "ai-quartermaster",
+          "--label", "aqm",
         ]),
         { cwd: "/tmp", timeout: 30000 }
       );

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -18,24 +18,24 @@ const makePayload = (action: string, labels: string[]) => ({
 
 describe("dispatchEvent", () => {
   it("should process issues.labeled with matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(true);
     expect(result.issueNumber).toBe(42);
     expect(result.repo).toBe("test/repo");
   });
 
   it("should ignore non-issues events", () => {
-    const result = dispatchEvent("push", makePayload("labeled", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("push", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
   it("should ignore non-labeled actions", () => {
-    const result = dispatchEvent("issues", makePayload("opened", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("opened", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
   it("should ignore when no matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["bug"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("labeled", ["bug"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Resolves #482 — refactor: 기본 라벨명 ai-quartermaster → aqm 축약

현재 기본 인스턴스 라벨이 `ai-quartermaster`로 너무 길어 GitHub 라벨 관리 및 가독성에 불편함. `aqm`으로 축약하여 간결하게 개선하되, 기존 사용자의 하위 호환성을 고려해야 함.

## Requirements

- instanceLabel 기본값을 ai-quartermaster에서 aqm으로 변경
- 테스트 픽스처의 라벨명을 aqm으로 업데이트
- 하위 호환성: 기존 ai-quartermaster 라벨 사용자를 위한 마이그레이션 가이드 문서화
- npx tsc --noEmit 통과
- npx vitest run 전체 통과

## Implementation Phases

- Phase 0: 기본값 변경 — SUCCESS (5ea75307)
- Phase 1: 테스트 업데이트 — SUCCESS (0266e88c)
- Phase 2: 마이그레이션 문서 — SUCCESS (0266e88c)
- Phase 3: 최종 검증 — SUCCESS (0266e88c)

## Risks

- 기존 ai-quartermaster 라벨 사용자가 업데이트 후 이슈 트리거 실패 가능 → 문서로 명시 설정 안내

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/482-refactor-ai-quartermaster-aqm` → `develop`
- **Tokens**: 108 input, 10735 output{{#stats.cacheCreationTokens}}, 182679 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 832895 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #482