### PR TITLE
[AQ-#483] fix: instanceLabel 설정 시 allowedLabels에 자동 포함 — 이중 설정 방지

### DIFF
--- a/src/pipeline/pipeline-phases.ts
+++ b/src/pipeline/pipeline-phases.ts
@@ -167,7 +167,8 @@ export async function executeInitialSetupPhases(
       worktreePath: runtime.worktreePath,
       branchName: runtime.branchName,
       dataDir,
-    }
+    },
+    config.general.instanceLabel
   );
 
   const { issue, checkpoint } = issueResult;

--- a/src/pipeline/pipeline-setup.ts
+++ b/src/pipeline/pipeline-setup.ts
@@ -134,7 +134,8 @@ export async function fetchAndValidateIssue(
     worktreePath?: string;
     branchName?: string;
     dataDir: string;
-  }
+  },
+  instanceLabel?: string
 ): Promise<IssueSetupResult> {
 
   // === RECEIVED → VALIDATED ===
@@ -161,7 +162,7 @@ export async function fetchAndValidateIssue(
     jl?.setProgress(PROGRESS_ISSUE_VALIDATED);
 
     // === Safety: validate issue labels ===
-    validateIssue(issue, project.safety);
+    validateIssue(issue, project.safety, instanceLabel);
 
     if (setupContext) {
       saveCheckpoint(setupContext.dataDir, issueNumber, {

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -1,15 +1,22 @@
 /**
  * Checks if the issue has at least one allowed label.
  * Returns true if allowedLabels is empty (all labels allowed).
+ * instanceLabel, if set, is implicitly treated as an allowed label.
  */
 export function isAllowedLabel(
   issueLabels: string[],
-  allowedLabels: string[]
+  allowedLabels: string[],
+  instanceLabel?: string
 ): boolean {
-  if (allowedLabels.length === 0) {
+  const effectiveAllowed =
+    instanceLabel !== undefined && instanceLabel !== ""
+      ? [...allowedLabels, instanceLabel]
+      : allowedLabels;
+
+  if (effectiveAllowed.length === 0) {
     return true;
   }
-  return issueLabels.some(label => allowedLabels.includes(label));
+  return issueLabels.some(label => effectiveAllowed.includes(label));
 }
 
 /**

--- a/src/safety/safety-checker.ts
+++ b/src/safety/safety-checker.ts
@@ -21,12 +21,14 @@ export interface SafetyContext {
 
 /**
  * Pre-pipeline validation: check labels and repo allowance.
+ * instanceLabel, if set, is treated as an implicit allowed label.
  */
 export function validateIssue(
   issue: GitHubIssue,
-  safetyConfig: SafetyConfig
+  safetyConfig: SafetyConfig,
+  instanceLabel?: string
 ): void {
-  if (!isAllowedLabel(issue.labels, safetyConfig.allowedLabels)) {
+  if (!isAllowedLabel(issue.labels, safetyConfig.allowedLabels, instanceLabel)) {
     throw new SafetyViolationError(
       "LabelFilter",
       `Issue labels [${issue.labels.join(", ")}] do not match allowed labels [${safetyConfig.allowedLabels.join(", ")}]`

--- a/tests/pipeline/pipeline-setup.test.ts
+++ b/tests/pipeline/pipeline-setup.test.ts
@@ -284,7 +284,7 @@ describe("fetchAndValidateIssue", () => {
       ghPath: "gh",
       timeout: 10000,
     });
-    expect(mockValidateIssue).toHaveBeenCalledWith(makeIssue(), project.safety);
+    expect(mockValidateIssue).toHaveBeenCalledWith(makeIssue(), project.safety, undefined);
     expect(mockDetectModeFromLabels).toHaveBeenCalledWith(["bug"], "code");
     expect(mockDetectExecutionModeFromLabels).toHaveBeenCalledWith(["bug"], "standard");
     expect(mockSaveCheckpoint).toHaveBeenCalled();

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -27,6 +27,25 @@ describe("isAllowedLabel", () => {
     expect(isAllowedLabel(["bug-fix"], ["bug"])).toBe(false);
     expect(isAllowedLabel(["feature"], ["feature"])).toBe(true);
   });
+
+  it("should return true when issueLabels contains instanceLabel", () => {
+    expect(isAllowedLabel(["aqm-by"], ["ai-quartermaster"], "aqm-by")).toBe(true);
+    expect(isAllowedLabel(["aqm-by", "bug"], ["ai-quartermaster"], "aqm-by")).toBe(true);
+  });
+
+  it("should not require double-config when instanceLabel matches", () => {
+    // instanceLabel=aqm-by, allowedLabels does not include it — should still pass
+    expect(isAllowedLabel(["aqm-by"], [], "aqm-by")).toBe(true);
+  });
+
+  it("should return false when instanceLabel is set but issue has neither instanceLabel nor allowedLabels", () => {
+    expect(isAllowedLabel(["unrelated"], ["ai-quartermaster"], "aqm-by")).toBe(false);
+  });
+
+  it("should ignore instanceLabel when it is empty string", () => {
+    expect(isAllowedLabel(["bug"], [], "")).toBe(true); // empty allowedLabels → allow all
+    expect(isAllowedLabel(["bug"], ["feature"], "")).toBe(false);
+  });
 });
 
 describe("getTriggerLabels", () => {

--- a/tests/safety/safety-checker.test.ts
+++ b/tests/safety/safety-checker.test.ts
@@ -89,7 +89,8 @@ describe("safety-checker", () => {
 
       expect(mockIsAllowedLabel).toHaveBeenCalledWith(
         ["enhancement", "bug"],
-        ["enhancement", "bug", "feature"]
+        ["enhancement", "bug", "feature"],
+        undefined
       );
     });
 


### PR DESCRIPTION
## Summary

Resolves #483 — fix: instanceLabel 설정 시 allowedLabels에 자동 포함 — 이중 설정 방지

instanceLabel을 aqm-by로 설정해도 allowedLabels에 ai-quartermaster만 있으면 safety 체크에서 거부됨. isAllowedLabel() 함수가 instanceLabel을 인식하지 못해 이중 설정이 필요한 설계 결함.

## Requirements

- instanceLabel이 설정되면 allowedLabels에 자동으로 포함 (safety 체크 통과)
- isAllowedLabel()에서 instanceLabel도 허용 라벨로 인정
- config에 allowedLabels 별도 추가 불필요

## Implementation Phases

- Phase 0: isAllowedLabel에 instanceLabel 지원 추가 — SUCCESS (7d8c30bb)

## Risks

- validateIssue 호출부에서 instanceLabel 접근 가능 여부 - project.general.instanceLabel로 접근 가능 확인됨

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/483-fix-instancelabel-allowedlabels` → `develop`
- **Tokens**: 175 input, 15960 output{{#stats.cacheCreationTokens}}, 93743 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1844764 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #483