### PR TITLE
[AQ-#481] feat: 이슈 작성자 기반 필터링 — instanceOwners 배열로 허용 사용자 관리

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -4,6 +4,7 @@ export const DEFAULT_CONFIG: AQConfig = {
   general: {
     projectName: "ai-quartermaster",
     instanceLabel: "ai-quartermaster",
+    instanceOwners: [],
     logLevel: "info",
     logDir: "logs",
     dryRun: false,

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -144,6 +144,7 @@ const mergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
 const generalConfigSchema = z.object({
   projectName: z.string().min(1, "projectName must be a non-empty string"),
   instanceLabel: z.string().optional(),
+  instanceOwners: z.array(z.string()).optional(),
   logLevel: logLevelSchema,
   logDir: z.string(),
   dryRun: z.boolean(),

--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -151,6 +151,35 @@ export class IssuePoller {
     }
   }
 
+  private async fetchIssues(
+    repo: string,
+    label: string,
+    ghPath: string,
+    timeout: number,
+    author: string | undefined
+  ): Promise<RawIssue[]> {
+    const args: string[] = [
+      "issue", "list",
+      "--repo", repo,
+      "--label", label,
+      "--state", "open",
+      "--json", "number,title,labels",
+      "--limit", "100",
+    ];
+
+    if (author !== undefined) {
+      args.push("--author", author);
+    }
+
+    const result = await runCli(ghPath, args, { timeout });
+
+    if (result.exitCode !== 0) {
+      throw new Error(`이슈 목록 조회 실패 (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+    }
+
+    return JSON.parse(result.stdout) as RawIssue[];
+  }
+
   private async pollProjectLabel(
     repo: string,
     label: string,
@@ -158,29 +187,41 @@ export class IssuePoller {
     timeout: number
   ): Promise<void> {
     let issues: RawIssue[];
+    const owners = this.config.general.instanceOwners ?? [];
+
     try {
-      const result = await runCli(
-        ghPath,
-        [
-          "issue", "list",
-          "--repo", repo,
-          "--label", label,
-          "--state", "open",
-          "--json", "number,title,labels",
-          "--limit", "100",
-        ],
-        { timeout }
-      );
+      if (owners.length === 0) {
+        issues = await this.fetchIssues(repo, label, ghPath, timeout, undefined);
+        this.resetPollingErrors(repo);
+      } else {
+        const perOwnerResults = await Promise.allSettled(
+          owners.map(owner => this.fetchIssues(repo, label, ghPath, timeout, owner))
+        );
 
-      if (result.exitCode !== 0) {
-        logger.warn(`이슈 목록 조회 실패 (${repo}, label=${label}): ${result.stderr || result.stdout}`);
-        this.trackPollingFailure(repo, `이슈 목록 조회 실패 (exit ${result.exitCode})`);
-        return;
+        const merged = new Map<number, RawIssue>();
+        let allFailed = true;
+
+        for (let i = 0; i < perOwnerResults.length; i++) {
+          const result = perOwnerResults[i];
+          if (result.status === "rejected") {
+            const errorMsg = getErrorMessage(result.reason);
+            logger.warn(`이슈 목록 조회 실패 (${repo}, label=${label}, author=${owners[i]}): ${errorMsg}`);
+            this.trackPollingFailure(repo, errorMsg);
+          } else {
+            allFailed = false;
+            for (const issue of result.value) {
+              merged.set(issue.number, issue);
+            }
+          }
+        }
+
+        if (allFailed) {
+          return;
+        }
+
+        this.resetPollingErrors(repo);
+        issues = Array.from(merged.values());
       }
-
-      issues = JSON.parse(result.stdout) as RawIssue[];
-      // Polling success - reset error count
-      this.resetPollingErrors(repo);
     } catch (err: unknown) {
       const errorMsg = getErrorMessage(err);
       logger.warn(`폴링 중 오류 (${repo}, label=${label}): ${errorMsg}`);

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -13,6 +13,20 @@ export function isAllowedLabel(
 }
 
 /**
+ * Checks if the issue author is an allowed owner.
+ * Returns true if instanceOwners is empty (all owners allowed).
+ */
+export function isAllowedOwner(
+  issueAuthor: string,
+  instanceOwners: string[]
+): boolean {
+  if (instanceOwners.length === 0) {
+    return true;
+  }
+  return instanceOwners.includes(issueAuthor);
+}
+
+/**
  * Determines effective trigger labels.
  * If instanceLabel is set, uses only that label (single-label mode).
  * Otherwise falls back to allowedLabels.

--- a/src/server/event-dispatcher.ts
+++ b/src/server/event-dispatcher.ts
@@ -3,6 +3,7 @@ import { listConfiguredRepos } from "../config/project-resolver.js";
 import type { AQConfig } from "../types/config.js";
 import { parseDependencies, checkCircularDependency } from "../queue/dependency-resolver.js";
 import type { JobStore } from "../queue/job-store.js";
+import { isAllowedOwner } from "../safety/label-filter.js";
 
 const logger = getLogger();
 
@@ -65,6 +66,18 @@ export function dispatchEvent(
       shouldProcess: false,
       reason: `No matching trigger label. Issue labels: [${issueLabels.join(", ")}], trigger: [${triggerLabels.join(", ")}]`,
     };
+  }
+
+  // Check if issue author is an allowed owner (when config is provided)
+  if (config) {
+    const instanceOwners = config.general.instanceOwners ?? [];
+    const author = payload.issue.user.login;
+    if (!isAllowedOwner(author, instanceOwners)) {
+      return {
+        shouldProcess: false,
+        reason: `Issue author @${author} is not in instanceOwners`,
+      };
+    }
   }
 
   // Check if repo is configured (when config is provided)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -23,6 +23,7 @@ export interface SkillContent {
 export interface GeneralConfig {
   projectName: string;
   instanceLabel?: string;
+  instanceOwners?: string[];
   logLevel: LogLevel;
   logDir: string;
   dryRun: boolean;

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isAllowedLabel, getTriggerLabels } from "../../src/safety/label-filter.js";
+import { isAllowedLabel, isAllowedOwner, getTriggerLabels } from "../../src/safety/label-filter.js";
 
 describe("isAllowedLabel", () => {
   it("should return true when allowedLabels is empty", () => {
@@ -26,6 +26,29 @@ describe("isAllowedLabel", () => {
     expect(isAllowedLabel(["feature-request"], ["feature"])).toBe(false);
     expect(isAllowedLabel(["bug-fix"], ["bug"])).toBe(false);
     expect(isAllowedLabel(["feature"], ["feature"])).toBe(true);
+  });
+});
+
+describe("isAllowedOwner", () => {
+  it("should return true when instanceOwners is empty (allow all)", () => {
+    expect(isAllowedOwner("alice", [])).toBe(true);
+    expect(isAllowedOwner("", [])).toBe(true);
+  });
+
+  it("should return true when author is in instanceOwners", () => {
+    expect(isAllowedOwner("alice", ["alice", "bob"])).toBe(true);
+    expect(isAllowedOwner("bob", ["alice", "bob"])).toBe(true);
+  });
+
+  it("should return false when author is not in instanceOwners", () => {
+    expect(isAllowedOwner("charlie", ["alice", "bob"])).toBe(false);
+    expect(isAllowedOwner("", ["alice", "bob"])).toBe(false);
+  });
+
+  it("should be case-sensitive", () => {
+    expect(isAllowedOwner("Alice", ["alice"])).toBe(false);
+    expect(isAllowedOwner("alice", ["Alice"])).toBe(false);
+    expect(isAllowedOwner("alice", ["alice"])).toBe(true);
   });
 });
 

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -1,20 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { dispatchEvent } from "../../src/server/event-dispatcher.js";
+import type { AQConfig } from "../../src/types/config.js";
 
-const makePayload = (action: string, labels: string[]) => ({
+const makePayload = (action: string, labels: string[], author = "user") => ({
   action,
   issue: {
     number: 42,
     title: "Test",
     body: "Body",
     labels: labels.map(name => ({ name })),
-    user: { login: "user" },
+    user: { login: author },
   },
   repository: {
     full_name: "test/repo",
     default_branch: "main",
   },
 });
+
+const makeConfig = (instanceOwners: string[]): AQConfig => ({
+  general: { instanceOwners },
+  git: { allowedRepos: ["test/repo"] },
+  projects: [],
+} as unknown as AQConfig);
 
 describe("dispatchEvent", () => {
   it("should process issues.labeled with matching label", () => {
@@ -42,5 +49,35 @@ describe("dispatchEvent", () => {
   it("should process when triggerLabels is empty (allow all)", () => {
     const result = dispatchEvent("issues", makePayload("labeled", ["anything"]), []);
     expect(result.shouldProcess).toBe(true);
+  });
+
+  describe("owner filtering", () => {
+    it("should process when instanceOwners is empty (allow all authors)", () => {
+      const config = makeConfig([]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "anyone"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it("should process when author is in instanceOwners", () => {
+      const config = makeConfig(["alice", "bob"]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "alice"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it("should reject when author is not in instanceOwners", () => {
+      const config = makeConfig(["alice", "bob"]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toContain("charlie");
+      expect(result.reason).toContain("instanceOwners");
+    });
+
+    it("should reject before repo check when owner is not allowed", () => {
+      const config = makeConfig(["alice"]);
+      // charlie is not in instanceOwners — should fail on owner check
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toMatch(/instanceOwners/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #481 — feat: 이슈 작성자 기반 필터링 — instanceOwners 배열로 허용 사용자 관리

현재 AQM은 라벨(instanceLabel, allowedLabels) 기반으로만 이슈를 필터링한다. 특정 사용자가 작성한 이슈만 처리하도록 제한하는 기능이 없어, 멀티테넌트 환경에서 의도치 않은 이슈 처리가 발생할 수 있다. instanceOwners 배열을 추가하여 허용된 사용자의 이슈만 처리하고, instanceLabel과 AND 조건으로 결합하여 보다 정교한 필터링을 지원해야 한다.

## Requirements

- GeneralConfig에 instanceOwners: string[] (optional) 필드 추가
- config 3곳 동시 수정: types/config.ts, defaults.ts, validator.ts
- webhook handler에서 issue.user.login이 instanceOwners에 포함된 경우만 처리
- poller에서 GitHub API --author 파라미터로 필터링
- instanceOwners 비어있으면 기존 동작 유지 (모든 사용자 허용)
- instanceLabel과 AND 조건: 라벨 + 작성자 둘 다 만족해야 처리
- 둘 다 미설정 시 allowedLabels 기본 동작 유지

## Implementation Phases

- Phase 0: Config 3곳 동시 수정 — SUCCESS (b4940615)
- Phase 1: Owner 필터 유틸리티 함수 — SUCCESS (6fb16000)
- Phase 2: Webhook event-dispatcher 필터링 — SUCCESS (45ed8990)
- Phase 3: Poller --author 필터링 — SUCCESS (45ed8990)
- Phase 4: 테스트 추가 — SUCCESS (f78e4c20)

## Risks

- GitHub CLI --author는 단일 사용자만 지원 → 여러 owner 시 다중 API 호출 필요 (API rate limit 주의)
- poller에서 owner별 병렬 호출 시 결과 중복 제거 필요
- 기존 instanceLabel 동작과의 호환성 유지 필수

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/481-feat-instanceowners` → `develop`
- **Tokens**: 222 input, 22477 output{{#stats.cacheCreationTokens}}, 258186 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2449828 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #481