### PR TITLE
v0.4.0: 안정성 + 프로세스 관리 + 인스턴스 개인화 강화

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -199,6 +199,8 @@ case "${1:-}" in
     PID=$(find_server_pid "$PORT")
     if [ $? -eq 0 ] && [ -n "$PID" ]; then
       echo "서버 중지 중... (PID: $PID, Port: $PORT)"
+      # Kill child processes first (graceful)
+      pkill -TERM -P "$PID" 2>/dev/null
       kill "$PID" 2>/dev/null
       # Wait for graceful shutdown
       for i in $(seq 1 10); do
@@ -210,6 +212,7 @@ case "${1:-}" in
       # Force kill if still running
       if kill -0 "$PID" 2>/dev/null; then
         echo "강제 종료 시도 중..."
+        pkill -KILL -P "$PID" 2>/dev/null
         kill -9 "$PID" 2>/dev/null
       fi
       rm -f "$AQM_PID_FILE"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,45 @@
 - 소스 48개 / 테스트 21개 (104 tests) / typecheck clean
 - GitHub: https://github.com/happytalkrz/AI-Quartermaster
 
+## 마이그레이션 가이드
+
+### v0.3.x → v0.4.0: 기본 라벨명 변경 (`ai-quartermaster` → `aqm`)
+
+기본 인스턴스 라벨이 `ai-quartermaster`에서 `aqm`으로 변경되었습니다.
+
+#### 영향 범위
+
+`config.yml`에서 `label`을 명시하지 않은 경우, 기본값이 변경됩니다.
+
+| 항목 | 이전 | 이후 |
+|------|------|------|
+| 기본 `label` 값 | `ai-quartermaster` | `aqm` |
+
+#### 기존 사용자 대응
+
+**방법 1 (권장):** GitHub 리포지토리에서 라벨명을 `aqm`으로 변경
+
+```bash
+# 기존 라벨 삭제 후 새 라벨 생성
+gh label delete "ai-quartermaster" --repo <owner>/<repo>
+gh label create "aqm" --color "#0075ca" --repo <owner>/<repo>
+```
+
+**방법 2:** `config.yml`에 기존 라벨명을 명시하여 유지
+
+```yaml
+# config.yml
+label: ai-quartermaster  # 기존 라벨명 유지
+```
+
+#### 확인 방법
+
+```bash
+aqm config show  # 현재 설정의 label 값 확인
+```
+
+---
+
 ## 커밋 히스토리
 
 ```

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -132,7 +132,7 @@ export const DEFAULT_CONFIG: AQConfig = {
       prCreation: 60000,
     },
     stopConditions: ["STOP", "ABORT", "SAFETY_VIOLATION"],
-    allowedLabels: [],
+    allowedLabels: ["aqm"],
     rollbackStrategy: "failed-only",
     feasibilityCheck: {
       enabled: true,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -4,6 +4,7 @@ export const DEFAULT_CONFIG: AQConfig = {
   general: {
     projectName: "ai-quartermaster",
     instanceLabel: "ai-quartermaster",
+    instanceOwners: [],
     logLevel: "info",
     logDir: "logs",
     dryRun: false,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -3,7 +3,7 @@ import { AQConfig } from "../types/config.js";
 export const DEFAULT_CONFIG: AQConfig = {
   general: {
     projectName: "ai-quartermaster",
-    instanceLabel: "ai-quartermaster",
+    instanceLabel: "aqm",
     logLevel: "info",
     logDir: "logs",
     dryRun: false,

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -144,6 +144,7 @@ const mergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
 const generalConfigSchema = z.object({
   projectName: z.string().min(1, "projectName must be a non-empty string"),
   instanceLabel: z.string().optional(),
+  instanceOwners: z.array(z.string()).optional(),
   logLevel: logLevelSchema,
   logDir: z.string(),
   dryRun: z.boolean(),

--- a/src/pipeline/pipeline-context.ts
+++ b/src/pipeline/pipeline-context.ts
@@ -56,6 +56,17 @@ export const STATE_ORDER: PipelineState[] = [
   "DONE",
 ];
 
+/**
+ * 비활성화된 기능 상태를 정규화한다.
+ * CI_CHECKING/CI_FIXING은 현재 비활성화된 상태이므로 체크포인트 복원 시 DONE으로 전진한다.
+ */
+export function normalizeCheckpointState(state: PipelineState): PipelineState {
+  if (state === "CI_CHECKING" || state === "CI_FIXING") {
+    return "DONE";
+  }
+  return state;
+}
+
 export function isPastState(checkpointState: PipelineState, current: PipelineState): boolean {
   const checkpointIdx = STATE_ORDER.indexOf(checkpointState);
   const currentIdx = STATE_ORDER.indexOf(current);
@@ -84,8 +95,10 @@ export async function initializePipelineState(
   const resumeFrom = input.resumeFrom;
   const logger = getLogger();
 
+  const restoredState = resumeFrom ? normalizeCheckpointState(resumeFrom.state) : "RECEIVED";
+
   const runtime: PipelineRuntime = {
-    state: resumeFrom?.state ?? "RECEIVED",
+    state: restoredState,
     worktreePath: resumeFrom?.worktreePath,
     branchName: resumeFrom?.branchName,
     projectRoot: input.projectRoot ?? resumeFrom?.projectRoot ?? "",
@@ -96,8 +109,11 @@ export async function initializePipelineState(
   };
 
   if (resumeFrom) {
-    logger.info(`Resuming pipeline from state: ${resumeFrom.state}`);
-    input.jobLogger?.setProgress(progressForState(resumeFrom.state));
+    if (restoredState !== resumeFrom.state) {
+      logger.info(`Checkpoint state normalized: ${resumeFrom.state} → ${restoredState} (disabled feature state)`);
+    }
+    logger.info(`Resuming pipeline from state: ${restoredState}`);
+    input.jobLogger?.setProgress(progressForState(restoredState));
   }
 
   return runtime;

--- a/src/pipeline/pipeline-phases.ts
+++ b/src/pipeline/pipeline-phases.ts
@@ -167,7 +167,8 @@ export async function executeInitialSetupPhases(
       worktreePath: runtime.worktreePath,
       branchName: runtime.branchName,
       dataDir,
-    }
+    },
+    config.general.instanceLabel
   );
 
   const { issue, checkpoint } = issueResult;

--- a/src/pipeline/pipeline-setup.ts
+++ b/src/pipeline/pipeline-setup.ts
@@ -134,7 +134,8 @@ export async function fetchAndValidateIssue(
     worktreePath?: string;
     branchName?: string;
     dataDir: string;
-  }
+  },
+  instanceLabel?: string
 ): Promise<IssueSetupResult> {
 
   // === RECEIVED → VALIDATED ===
@@ -161,7 +162,7 @@ export async function fetchAndValidateIssue(
     jl?.setProgress(PROGRESS_ISSUE_VALIDATED);
 
     // === Safety: validate issue labels ===
-    validateIssue(issue, project.safety);
+    validateIssue(issue, project.safety, instanceLabel);
 
     if (setupContext) {
       saveCheckpoint(setupContext.dataDir, issueNumber, {

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { readFileSync, existsSync } from "fs";
 import * as ts from "typescript";
 import { renderTemplate, loadTemplate, buildDynamicSection, TemplateVariables } from "../prompt/template-renderer.js";
+import { detectCircularDependencies, validatePhaseDependencies } from "./phase-scheduler.js";
 import { runClaude, extractJson } from "../claude/claude-runner.js";
 import { configForTask, configForTaskWithMode } from "../claude/model-router.js";
 import type { ClaudeCliConfig } from "../types/config.js";
@@ -413,6 +414,18 @@ function validatePlan(plan: Plan): void {
     phase.verificationCriteria = phase.verificationCriteria ?? [];
     phase.dependsOn = phase.dependsOn ?? [];
   });
+
+  // Validate phase dependencies (self-dependency, non-existent refs)
+  const depValidation = validatePhaseDependencies(plan.phases);
+  if (!depValidation.valid) {
+    throw new Error(`Invalid phase dependencies: ${depValidation.errors.join("; ")}`);
+  }
+
+  // Detect circular dependencies (A→B→A etc.)
+  const cycle = detectCircularDependencies(plan.phases);
+  if (cycle.length > 0) {
+    throw new Error(`Circular dependency detected in plan phases: ${cycle.join(" → ")}`);
+  }
 }
 
 /**

--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -151,6 +151,35 @@ export class IssuePoller {
     }
   }
 
+  private async fetchIssues(
+    repo: string,
+    label: string,
+    ghPath: string,
+    timeout: number,
+    author: string | undefined
+  ): Promise<RawIssue[]> {
+    const args: string[] = [
+      "issue", "list",
+      "--repo", repo,
+      "--label", label,
+      "--state", "open",
+      "--json", "number,title,labels",
+      "--limit", "100",
+    ];
+
+    if (author !== undefined) {
+      args.push("--author", author);
+    }
+
+    const result = await runCli(ghPath, args, { timeout });
+
+    if (result.exitCode !== 0) {
+      throw new Error(`이슈 목록 조회 실패 (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+    }
+
+    return JSON.parse(result.stdout) as RawIssue[];
+  }
+
   private async pollProjectLabel(
     repo: string,
     label: string,
@@ -158,29 +187,41 @@ export class IssuePoller {
     timeout: number
   ): Promise<void> {
     let issues: RawIssue[];
+    const owners = this.config.general.instanceOwners ?? [];
+
     try {
-      const result = await runCli(
-        ghPath,
-        [
-          "issue", "list",
-          "--repo", repo,
-          "--label", label,
-          "--state", "open",
-          "--json", "number,title,labels",
-          "--limit", "100",
-        ],
-        { timeout }
-      );
+      if (owners.length === 0) {
+        issues = await this.fetchIssues(repo, label, ghPath, timeout, undefined);
+        this.resetPollingErrors(repo);
+      } else {
+        const perOwnerResults = await Promise.allSettled(
+          owners.map(owner => this.fetchIssues(repo, label, ghPath, timeout, owner))
+        );
 
-      if (result.exitCode !== 0) {
-        logger.warn(`이슈 목록 조회 실패 (${repo}, label=${label}): ${result.stderr || result.stdout}`);
-        this.trackPollingFailure(repo, `이슈 목록 조회 실패 (exit ${result.exitCode})`);
-        return;
+        const merged = new Map<number, RawIssue>();
+        let allFailed = true;
+
+        for (let i = 0; i < perOwnerResults.length; i++) {
+          const result = perOwnerResults[i];
+          if (result.status === "rejected") {
+            const errorMsg = getErrorMessage(result.reason);
+            logger.warn(`이슈 목록 조회 실패 (${repo}, label=${label}, author=${owners[i]}): ${errorMsg}`);
+            this.trackPollingFailure(repo, errorMsg);
+          } else {
+            allFailed = false;
+            for (const issue of result.value) {
+              merged.set(issue.number, issue);
+            }
+          }
+        }
+
+        if (allFailed) {
+          return;
+        }
+
+        this.resetPollingErrors(repo);
+        issues = Array.from(merged.values());
       }
-
-      issues = JSON.parse(result.stdout) as RawIssue[];
-      // Polling success - reset error count
-      this.resetPollingErrors(repo);
     } catch (err: unknown) {
       const errorMsg = getErrorMessage(err);
       logger.warn(`폴링 중 오류 (${repo}, label=${label}): ${errorMsg}`);

--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -197,13 +197,10 @@ export class IssuePoller {
 
     for (const issue of issues) {
       if (this.store.shouldBlockRepickup(issue.number, repo)) {
-        // 차단 이유를 상태별로 구분하여 로그 출력
         const existingJob = this.store.findAnyByIssue(issue.number, repo);
         if (existingJob) {
           if (existingJob.status === "running" || existingJob.status === "queued") {
             logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 처리 중), 건너뜀`);
-          } else if (existingJob.status === "success") {
-            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (성공 완료된 잡 존재), 건너뜀`);
           } else {
             logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 존재), 건너뜀`);
           }

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -228,6 +228,10 @@ export class JobQueue {
    * Running jobs are reset to queued and re-enqueued.
    */
   recover(): number {
+    // 재시작 시 메모리 상태 초기화 — pause 상태 자동 해제
+    this.projectErrorState.clear();
+    logger.info("재시작: projectErrorState 초기화 완료 (project pause 해제)");
+
     const jobs = this.store.list();
     let recovered = 0;
 

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -313,11 +313,9 @@ export class JobQueue {
     const existing = this.store.findAnyByIssue(issueNumber, repo);
     if (existing) {
       if (isSuccessJob(existing)) {
-        logger.warn(`Job for issue #${issueNumber} (${repo}) already completed successfully: ${existing.id}`);
-        return undefined;
-      }
-
-      if (isFailureJob(existing) || isCancelledJob(existing)) {
+        logger.info(`Auto-archiving existing success job ${existing.id} for issue #${issueNumber} (${repo})`);
+        this.store.archive(existing.id);
+      } else if (isFailureJob(existing) || isCancelledJob(existing)) {
         logger.info(`Auto-archiving existing ${existing.status} job ${existing.id} for issue #${issueNumber} (${repo})`);
         this.cleanupFailedJobArtifacts(issueNumber);
         this.store.archive(existing.id);

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -634,11 +634,11 @@ export class JobStore extends EventEmitter {
     const existingJob = this.findAnyByIssue(issueNumber, repo);
     if (!existingJob) return false;
 
-    // queued, running, success 상태의 잡이 있으면 차단
+    // queued, running 상태의 잡이 있으면 차단
+    // success는 재라벨 시 재처리를 허용하기 위해 차단하지 않음 (archive 후 재처리)
     // failure, cancelled, archived 상태는 재시도 가능하므로 차단하지 않음
     return existingJob.status === "queued" ||
-           existingJob.status === "running" ||
-           existingJob.status === "success";
+           existingJob.status === "running";
   }
 
   findFailedJobsForRetry(): Job[] {

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -13,6 +13,20 @@ export function isAllowedLabel(
 }
 
 /**
+ * Checks if the issue author is an allowed owner.
+ * Returns true if instanceOwners is empty (all owners allowed).
+ */
+export function isAllowedOwner(
+  issueAuthor: string,
+  instanceOwners: string[]
+): boolean {
+  if (instanceOwners.length === 0) {
+    return true;
+  }
+  return instanceOwners.includes(issueAuthor);
+}
+
+/**
  * Determines effective trigger labels.
  * If instanceLabel is set, uses only that label (single-label mode).
  * Otherwise falls back to allowedLabels.

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -1,15 +1,22 @@
 /**
  * Checks if the issue has at least one allowed label.
  * Returns true if allowedLabels is empty (all labels allowed).
+ * instanceLabel, if set, is implicitly treated as an allowed label.
  */
 export function isAllowedLabel(
   issueLabels: string[],
-  allowedLabels: string[]
+  allowedLabels: string[],
+  instanceLabel?: string
 ): boolean {
-  if (allowedLabels.length === 0) {
+  const effectiveAllowed =
+    instanceLabel !== undefined && instanceLabel !== ""
+      ? [...allowedLabels, instanceLabel]
+      : allowedLabels;
+
+  if (effectiveAllowed.length === 0) {
     return true;
   }
-  return issueLabels.some(label => allowedLabels.includes(label));
+  return issueLabels.some(label => effectiveAllowed.includes(label));
 }
 
 /**

--- a/src/safety/safety-checker.ts
+++ b/src/safety/safety-checker.ts
@@ -21,12 +21,14 @@ export interface SafetyContext {
 
 /**
  * Pre-pipeline validation: check labels and repo allowance.
+ * instanceLabel, if set, is treated as an implicit allowed label.
  */
 export function validateIssue(
   issue: GitHubIssue,
-  safetyConfig: SafetyConfig
+  safetyConfig: SafetyConfig,
+  instanceLabel?: string
 ): void {
-  if (!isAllowedLabel(issue.labels, safetyConfig.allowedLabels)) {
+  if (!isAllowedLabel(issue.labels, safetyConfig.allowedLabels, instanceLabel)) {
     throw new SafetyViolationError(
       "LabelFilter",
       `Issue labels [${issue.labels.join(", ")}] do not match allowed labels [${safetyConfig.allowedLabels.join(", ")}]`

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context, type Next } from "hono";
 import { randomUUID } from "crypto";
 import { readFileSync } from "fs";
-import { resolve, normalize } from "path";
+import { resolve, normalize, basename } from "path";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig, updateConfigSection, addProjectToConfig, removeProjectFromConfig, updateProjectInConfig } from "../config/loader.js";
@@ -1033,6 +1033,35 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     } catch (error: unknown) {
       return c.json({ error: `버전 정보 조회 실패: ${getErrorMessage(error)}` }, 500);
     }
+  });
+
+  // Claude profile
+  api.get("/api/claude-profile", async (c) => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR || "";
+    const profile = configDir ? basename(configDir).replace(/^\.claude-?/, "") || "default" : "default";
+    const config = loadConfig(projectRoot);
+    const models = config.commands.claudeCli.models;
+
+    let cliVersion = "unknown";
+    try {
+      const result = await runCli(config.commands.claudeCli.path, ["--version"], { timeout: 5000 });
+      if (result.exitCode === 0) cliVersion = result.stdout.trim();
+    } catch { /* ignore */ }
+
+    return c.json({
+      profile,
+      configDir,
+      cliVersion,
+      model: config.commands.claudeCli.model,
+      models: {
+        plan: models?.plan,
+        phase: models?.phase,
+        review: models?.review,
+        fallback: models?.fallback,
+      },
+      maxTurns: config.commands.claudeCli.maxTurns,
+      timeout: config.commands.claudeCli.timeout,
+    });
   });
 
   // Perform self-update

--- a/src/server/event-dispatcher.ts
+++ b/src/server/event-dispatcher.ts
@@ -3,6 +3,7 @@ import { listConfiguredRepos } from "../config/project-resolver.js";
 import type { AQConfig } from "../types/config.js";
 import { parseDependencies, checkCircularDependency } from "../queue/dependency-resolver.js";
 import type { JobStore } from "../queue/job-store.js";
+import { isAllowedOwner } from "../safety/label-filter.js";
 
 const logger = getLogger();
 
@@ -65,6 +66,18 @@ export function dispatchEvent(
       shouldProcess: false,
       reason: `No matching trigger label. Issue labels: [${issueLabels.join(", ")}], trigger: [${triggerLabels.join(", ")}]`,
     };
+  }
+
+  // Check if issue author is an allowed owner (when config is provided)
+  if (config) {
+    const instanceOwners = config.general.instanceOwners ?? [];
+    const author = payload.issue.user.login;
+    if (!isAllowedOwner(author, instanceOwners)) {
+      return {
+        shouldProcess: false,
+        reason: `Issue author @${author} is not in instanceOwners`,
+      };
+    }
   }
 
   // Check if repo is configured (when config is provided)

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -350,6 +350,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
   <div class="mb-6 px-2">
     <div class="text-xs font-headline font-bold text-primary tracking-widest uppercase opacity-60" data-i18n="commandHQ">Command HQ</div>
     <div class="text-[10px] font-mono text-outline uppercase">AQM</div>
+    <div id="claude-profile-label" class="text-[9px] font-mono text-outline/50 uppercase"></div>
   </div>
   <nav class="flex-1 space-y-1" id="sidebar-nav">
     <a class="nav-item-active flex items-center gap-3 rounded-md font-bold px-4 py-3 font-headline text-sm cursor-pointer" data-nav="dashboard">

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -106,6 +106,18 @@ function loadInstanceLabel() {
     .catch(function() {});
 }
 
+function loadClaudeProfile() {
+  apiFetch('/api/claude-profile')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var el = document.getElementById('claude-profile-label');
+      if (el && data.profile) {
+        el.textContent = data.profile;
+      }
+    })
+    .catch(function() {});
+}
+
 /* ══════════════════════════════════════════════════════════════
    Settings
    ══════════════════════════════════════════════════════════════ */
@@ -807,8 +819,9 @@ loadVersionInfo();
 // Initialize project selection
 initProjectSelection();
 
-// Load instance label for header
+// Load instance label and Claude profile for header
 loadInstanceLabel();
+loadClaudeProfile();
 
 connectSSE();
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -23,6 +23,7 @@ export interface SkillContent {
 export interface GeneralConfig {
   projectName: string;
   instanceLabel?: string;
+  instanceOwners?: string[];
   logLevel: LogLevel;
   logDir: string;
   dryRun: boolean;

--- a/tests/e2e/polling-integration.test.ts
+++ b/tests/e2e/polling-integration.test.ts
@@ -63,7 +63,11 @@ function makeJobStore(existingJobs: Array<{ issueNumber: number; repo: string; s
       return jobs.find(j => j.issueNumber === issueNumber && j.repo === repo && j.status !== "archived");
     }),
     shouldBlockRepickup: vi.fn((issueNumber: number, repo: string): boolean => {
-      return jobs.some(j => j.issueNumber === issueNumber && j.repo === repo && j.status === "success");
+      // success는 재라벨 재처리를 허용하기 위해 차단하지 않음 — queued/running만 차단
+      return jobs.some(
+        j => j.issueNumber === issueNumber && j.repo === repo &&
+          (j.status === "queued" || j.status === "running"),
+      );
     }),
     findFailedJobsForRetry: vi.fn((): Job[] => {
       const now = Date.now();
@@ -108,44 +112,39 @@ function makeJobStore(existingJobs: Array<{ issueNumber: number; repo: string; s
 function makeJobQueue(store: ReturnType<typeof makeJobStore>) {
   return {
     enqueue: vi.fn((issueNumber: number, repo: string): Job | undefined => {
-      // Check if success job exists (should block repickup)
-      if (store.shouldBlockRepickup(issueNumber, repo)) {
-        return undefined;
-      }
-
-      // Check for existing failed/cancelled jobs and auto-archive them
       const existing = store.findAnyByIssue(issueNumber, repo);
-      if (existing && (existing.status === "failure" || existing.status === "cancelled")) {
-        // Simulate the actual JobQueue logic for worktree cleanup
-        const dataDir = "/tmp/test-data"; // Mock data directory
+      if (existing) {
+        if (existing.status === "success") {
+          // 재라벨 시 success job auto-archive (checkpoint 정리 불필요)
+          store.archive(existing.id);
+        } else if (existing.status === "failure" || existing.status === "cancelled") {
+          // failed/cancelled: checkpoint 정리 후 archive
+          const dataDir = "/tmp/test-data";
 
-        try {
-          // Load checkpoint to check for worktree before removing
-          const checkpoint = mockLoadCheckpoint(dataDir, issueNumber);
-          if (checkpoint?.worktreePath) {
-            // Simulate worktree removal call
-            mockRemoveWorktree(
-              { gitPath: "git" }, // Mock git config
-              checkpoint.worktreePath,
-              { cwd: "/tmp/project", force: true }
-            );
+          try {
+            const checkpoint = mockLoadCheckpoint(dataDir, issueNumber);
+            if (checkpoint?.worktreePath) {
+              mockRemoveWorktree(
+                { gitPath: "git" },
+                checkpoint.worktreePath,
+                { cwd: "/tmp/project", force: true }
+              );
+            }
+          } catch (_checkpointErr) {
+            // error handling
           }
-        } catch (checkpointErr) {
-          // Simulate error handling
-        }
 
-        try {
-          // Remove checkpoint
-          mockRemoveCheckpoint(dataDir, issueNumber);
-        } catch (err) {
-          // Simulate error handling
-        }
+          try {
+            mockRemoveCheckpoint(dataDir, issueNumber);
+          } catch (_err) {
+            // error handling
+          }
 
-        // Archive the existing job
-        store.archive(existing.id);
-      } else if (existing) {
-        // Other statuses (queued, running) should still block
-        return undefined;
+          store.archive(existing.id);
+        } else {
+          // queued/running: 차단
+          return undefined;
+        }
       }
 
       return store.create(issueNumber, repo);
@@ -233,16 +232,16 @@ describe("E2E: polling integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2. Skips issues that have successful jobs (shouldBlockRepickup)
+  // 2. Skips issues with active (queued/running) jobs — shouldBlockRepickup
   // -------------------------------------------------------------------------
-  it("skips issues that already exist in the job store", async () => {
-    // Issue #10 already has a successful job
-    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "success" }]);
+  it("skips issues with queued or running jobs (active processing blocks re-pickup)", async () => {
+    // Issue #10 already has a queued job (active processing — should block)
+    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "queued" }]);
     const queue = makeJobQueue(store);
 
     mockRunCli.mockResolvedValue({
       stdout: makeGhIssueListResponse([
-        { number: 10, title: "Add feature A" }, // has successful job - should be blocked
+        { number: 10, title: "Add feature A" }, // has queued job - should be blocked
         { number: 12, title: "New issue C" },    // new - should be enqueued
       ]),
       stderr: "",
@@ -252,10 +251,38 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // Only the new issue should be enqueued
+    // Only the new issue should be enqueued (queued/running blocks re-pickup)
     expect(queue.enqueue).toHaveBeenCalledTimes(1);
     expect(queue.enqueue).toHaveBeenCalledWith(12, "test/repo");
     expect(queue.enqueue).not.toHaveBeenCalledWith(10, expect.anything());
+  });
+
+  // -------------------------------------------------------------------------
+  // 2b. Success jobs do NOT block — re-labeling triggers re-processing
+  // -------------------------------------------------------------------------
+  it("allows re-pickup of success jobs (re-label triggers new processing)", async () => {
+    // Issue #10 has a success job — re-labeling should trigger new processing
+    const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "success" }]);
+    const queue = makeJobQueue(store);
+
+    mockRunCli.mockResolvedValue({
+      stdout: makeGhIssueListResponse([
+        { number: 10, title: "Add feature A" }, // has success job - should be re-enqueued
+      ]),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    poller = new IssuePoller(makeConfig(), store as any, queue as any);
+    await (poller as any).poll();
+
+    // The success issue should be re-enqueued (success does not block re-pickup)
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    expect(queue.enqueue).toHaveBeenCalledWith(10, "test/repo");
+
+    // Original success job should be archived
+    const originalJob = store.get("aq-10-0");
+    expect(originalJob?.status).toBe("archived");
   });
 
   // -------------------------------------------------------------------------

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -18,7 +18,7 @@ const prConfig = {
   draft: true,
   titleTemplate: "[AQ-#{issueNumber}] {title}",
   bodyTemplate: "pr-body.md",
-  labels: ["ai-quartermaster"],
+  labels: ["aqm"],
   assignees: [],
   reviewers: [],
   linkIssue: true,
@@ -147,7 +147,7 @@ describe("closeIssue", () => {
           "--title", "[AQ-#{issueNumber}] {title}",
           "--body", expect.stringContaining("Closes #42"),
           "--draft",
-          "--label", "ai-quartermaster",
+          "--label", "aqm",
         ]),
         { cwd: "/tmp", timeout: 30000 }
       );

--- a/tests/pipeline/pipeline-context.test.ts
+++ b/tests/pipeline/pipeline-context.test.ts
@@ -3,6 +3,7 @@ import {
   initializePipelineState,
   transitionState,
   isPastState,
+  normalizeCheckpointState,
   STATE_ORDER,
   type PipelineRuntime,
   type OrchestratorInput,
@@ -132,6 +133,65 @@ describe("pipeline-context", () => {
 
     it("should return false for same states", () => {
       expect(isPastState("VALIDATED", "VALIDATED")).toBe(false);
+    });
+  });
+
+  describe("normalizeCheckpointState", () => {
+    it("should normalize CI_CHECKING to DONE", () => {
+      expect(normalizeCheckpointState("CI_CHECKING")).toBe("DONE");
+    });
+
+    it("should normalize CI_FIXING to DONE", () => {
+      expect(normalizeCheckpointState("CI_FIXING")).toBe("DONE");
+    });
+
+    it("should not modify other states", () => {
+      expect(normalizeCheckpointState("DONE")).toBe("DONE");
+      expect(normalizeCheckpointState("VALIDATED")).toBe("VALIDATED");
+      expect(normalizeCheckpointState("DRAFT_PR_CREATED")).toBe("DRAFT_PR_CREATED");
+      expect(normalizeCheckpointState("REVIEWING")).toBe("REVIEWING");
+    });
+  });
+
+  describe("initializePipelineState — checkpoint normalization", () => {
+    it("should normalize CI_CHECKING to DONE when resuming", async () => {
+      const input: OrchestratorInput = {
+        issueNumber: 123,
+        repo: "owner/repo",
+        config: mockConfig,
+        resumeFrom: {
+          state: "CI_CHECKING",
+          worktreePath: "/test/worktree",
+          branchName: "feature-branch",
+          projectRoot: "/test/project",
+          plan: undefined,
+          phaseResults: undefined,
+        },
+      };
+
+      const runtime = await initializePipelineState(input, mockConfig);
+
+      expect(runtime.state).toBe("DONE");
+    });
+
+    it("should normalize CI_FIXING to DONE when resuming", async () => {
+      const input: OrchestratorInput = {
+        issueNumber: 123,
+        repo: "owner/repo",
+        config: mockConfig,
+        resumeFrom: {
+          state: "CI_FIXING",
+          worktreePath: "/test/worktree",
+          branchName: "feature-branch",
+          projectRoot: "/test/project",
+          plan: undefined,
+          phaseResults: undefined,
+        },
+      };
+
+      const runtime = await initializePipelineState(input, mockConfig);
+
+      expect(runtime.state).toBe("DONE");
     });
   });
 

--- a/tests/pipeline/pipeline-setup.test.ts
+++ b/tests/pipeline/pipeline-setup.test.ts
@@ -284,7 +284,7 @@ describe("fetchAndValidateIssue", () => {
       ghPath: "gh",
       timeout: 10000,
     });
-    expect(mockValidateIssue).toHaveBeenCalledWith(makeIssue(), project.safety);
+    expect(mockValidateIssue).toHaveBeenCalledWith(makeIssue(), project.safety, undefined);
     expect(mockDetectModeFromLabels).toHaveBeenCalledWith(["bug"], "code");
     expect(mockDetectExecutionModeFromLabels).toHaveBeenCalledWith(["bug"], "standard");
     expect(mockSaveCheckpoint).toHaveBeenCalled();

--- a/tests/pipeline/plan-generator.test.ts
+++ b/tests/pipeline/plan-generator.test.ts
@@ -1351,4 +1351,153 @@ Plan 생성 정확도를 높이기 위해 수집된 추가 컨텍스트입니다
       expect(mockRunClaude).toHaveBeenCalledTimes(models.length);
     });
   });
+
+  describe("validatePlan circular dependency detection", () => {
+    const baseClaudeConfig = {
+      path: "claude",
+      model: "test",
+      maxTurns: 1,
+      timeout: 1000,
+      additionalArgs: [] as string[],
+    };
+
+    const basePlanFields = {
+      mode: "code" as const,
+      issueNumber: 1,
+      title: "Test",
+      problemDefinition: "Test problem",
+      requirements: ["Requirement A"],
+      affectedFiles: [],
+      risks: [],
+      verificationPoints: [],
+      stopConditions: [],
+    };
+
+    it("should throw when a phase depends on itself", async () => {
+      const selfDepPlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "Self-referencing phase",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(selfDepPlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(selfDepPlan);
+
+      await expect(
+        generatePlan({
+          issue: { number: 1, title: "Test", body: "", labels: [] },
+          repo: { owner: "test", name: "repo" },
+          branch: { base: "main", work: "ax/1-test" },
+          repoStructure: "",
+          claudeConfig: baseClaudeConfig,
+          promptsDir,
+          cwd: testDir,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should throw when phases have A→B→A circular dependency", async () => {
+      const cyclePlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "Depends on B",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [1],
+          },
+          {
+            index: 1,
+            name: "Phase B",
+            description: "Depends on A",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(cyclePlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(cyclePlan);
+
+      await expect(
+        generatePlan({
+          issue: { number: 1, title: "Test", body: "", labels: [] },
+          repo: { owner: "test", name: "repo" },
+          branch: { base: "main", work: "ax/1-test" },
+          repoStructure: "",
+          claudeConfig: baseClaudeConfig,
+          promptsDir,
+          cwd: testDir,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("should pass when phase dependencies are valid (linear chain)", async () => {
+      const validPlan = {
+        ...basePlanFields,
+        phases: [
+          {
+            index: 0,
+            name: "Phase A",
+            description: "No dependencies",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [],
+          },
+          {
+            index: 1,
+            name: "Phase B",
+            description: "Depends on A",
+            targetFiles: [],
+            commitStrategy: "single",
+            verificationCriteria: [],
+            dependsOn: [0],
+          },
+        ],
+      };
+
+      mockRunClaude.mockResolvedValue({
+        success: true,
+        output: JSON.stringify(validPlan),
+        durationMs: 100,
+      });
+      mockExtractJson.mockReturnValue(validPlan);
+
+      const result = await generatePlan({
+        issue: { number: 1, title: "Test", body: "", labels: [] },
+        repo: { owner: "test", name: "repo" },
+        branch: { base: "main", work: "ax/1-test" },
+        repoStructure: "",
+        claudeConfig: baseClaudeConfig,
+        promptsDir,
+        cwd: testDir,
+      });
+
+      expect(result.plan.phases).toHaveLength(2);
+      expect(result.plan.phases[1].dependsOn).toEqual([0]);
+    });
+  });
 });

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -1573,6 +1573,91 @@ describe("JobQueue", () => {
     });
   });
 
+  describe("recover", () => {
+    it("should clear projectErrorState on recover (paused project is resumed)", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 1, handler);
+
+      // Pause a project
+      queue.pauseProject("test/repo", 60000); // 1분 pause
+      expect(queue.isProjectPaused("test/repo")).toBe(true);
+      expect(queue.getProjectStatus("test/repo")?.pausedUntil).toBeGreaterThan(Date.now());
+
+      // recover() 호출 시 projectErrorState 초기화
+      queue.recover();
+
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+      expect(queue.getProjectStatus("test/repo")).toBeNull();
+    });
+
+    it("should clear consecutiveFailures on recover", async () => {
+      const handler: JobHandler = vi.fn()
+        .mockRejectedValueOnce(new Error("failure 1"))
+        .mockRejectedValueOnce(new Error("failure 2"));
+
+      const queue = new JobQueue(store, 1, handler);
+
+      // 두 번 실패하여 consecutiveFailures = 2
+      const job1 = queue.enqueue(1, "test/repo");
+      await new Promise(r => setTimeout(r, 50));
+      expect(store.get(job1!.id)?.status).toBe("failure");
+
+      const job2 = queue.enqueue(2, "test/repo");
+      await new Promise(r => setTimeout(r, 50));
+      expect(store.get(job2!.id)?.status).toBe("failure");
+
+      expect(queue.getProjectStatus("test/repo")?.consecutiveFailures).toBe(2);
+
+      // recover() 호출 후 projectErrorState 초기화
+      queue.recover();
+
+      expect(queue.getProjectStatus("test/repo")).toBeNull();
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+    });
+
+    it("should clear projectErrorState for multiple repos on recover", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 1, handler);
+
+      // 두 repo 모두 pause
+      queue.pauseProject("test/repo1", 60000);
+      queue.pauseProject("test/repo2", 60000);
+
+      expect(queue.isProjectPaused("test/repo1")).toBe(true);
+      expect(queue.isProjectPaused("test/repo2")).toBe(true);
+
+      queue.recover();
+
+      expect(queue.isProjectPaused("test/repo1")).toBe(false);
+      expect(queue.isProjectPaused("test/repo2")).toBe(false);
+      expect(queue.getProjectStatus("test/repo1")).toBeNull();
+      expect(queue.getProjectStatus("test/repo2")).toBeNull();
+    });
+
+    it("should still recover queued and running jobs after clearing projectErrorState", () => {
+      const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
+      const queue = new JobQueue(store, 0, handler); // concurrency=0: 잡이 즉시 실행되지 않도록
+
+      // 스토어에 queued/running 잡 직접 생성
+      const queuedJob = store.create(10, "test/repo");
+      const runningJob = store.create(20, "test/repo2");
+      store.update(runningJob.id, { status: "running", startedAt: new Date().toISOString() });
+
+      // project pause 설정
+      queue.pauseProject("test/repo", 60000);
+
+      const recovered = queue.recover();
+
+      // projectErrorState 초기화됨
+      expect(queue.isProjectPaused("test/repo")).toBe(false);
+
+      // queued/running 잡 복구
+      expect(recovered).toBe(2);
+      expect(store.get(queuedJob.id)?.status).toBe("queued");
+      expect(store.get(runningJob.id)?.status).toBe("queued"); // running → queued로 리셋
+    });
+  });
+
   describe("Priority Queue", () => {
     it("should execute jobs in priority order: high -> normal -> low", async () => {
       const executionOrder: number[] = [];

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -179,7 +179,7 @@ describe("JobQueue", () => {
     expect(completedNewJob?.status).toBe("success");
   });
 
-  it("should prevent re-enqueue when successful job exists", async () => {
+  it("should auto-archive success job and allow re-enqueue", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
     const queue = new JobQueue(store, 1, handler);
 
@@ -189,9 +189,14 @@ describe("JobQueue", () => {
     const completed = store.get(successJob!.id);
     expect(completed?.status).toBe("success");
 
-    // Try to re-enqueue same issue - should be blocked
-    const blockedJob = queue.enqueue(789, "test/repo");
-    expect(blockedJob).toBeUndefined();
+    // Re-enqueue same issue - success job should be archived and new job created
+    const newJob = queue.enqueue(789, "test/repo");
+    expect(newJob).toBeDefined();
+    expect(newJob!.id).not.toBe(successJob!.id);
+
+    // Original success job should now be archived
+    const archivedJob = store.get(successJob!.id);
+    expect(archivedJob?.status).toBe("archived");
   });
 
   it("should cancel a pending job", () => {

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -104,12 +104,12 @@ describe("JobStore", () => {
       expect(result).toBe(false);
     });
 
-    it("should return true when a success job exists for the issue", () => {
+    it("should return false when a success job exists for the issue (allows re-pickup after relabel)", () => {
       const job = store.create(42, "test/repo");
       store.update(job.id, { status: "success", completedAt: new Date().toISOString() });
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it("should return false when only failure job exists for the issue", () => {
@@ -170,7 +170,7 @@ describe("JobStore", () => {
       expect(result).toBe(false);
     });
 
-    it("should return true when both success and other status jobs exist", () => {
+    it("should return false when success job exists (allows re-pickup after relabel)", () => {
       const job1 = store.create(42, "test/repo");
       store.update(job1.id, { status: "failure", completedAt: new Date().toISOString(), error: "Error 1" });
 
@@ -178,7 +178,7 @@ describe("JobStore", () => {
       store.update(job2.id, { status: "success", completedAt: new Date().toISOString() });
 
       const result = store.shouldBlockRepickup(42, "test/repo");
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
   });
 

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -27,6 +27,25 @@ describe("isAllowedLabel", () => {
     expect(isAllowedLabel(["bug-fix"], ["bug"])).toBe(false);
     expect(isAllowedLabel(["feature"], ["feature"])).toBe(true);
   });
+
+  it("should return true when issueLabels contains instanceLabel", () => {
+    expect(isAllowedLabel(["aqm-by"], ["ai-quartermaster"], "aqm-by")).toBe(true);
+    expect(isAllowedLabel(["aqm-by", "bug"], ["ai-quartermaster"], "aqm-by")).toBe(true);
+  });
+
+  it("should not require double-config when instanceLabel matches", () => {
+    // instanceLabel=aqm-by, allowedLabels does not include it — should still pass
+    expect(isAllowedLabel(["aqm-by"], [], "aqm-by")).toBe(true);
+  });
+
+  it("should return false when instanceLabel is set but issue has neither instanceLabel nor allowedLabels", () => {
+    expect(isAllowedLabel(["unrelated"], ["ai-quartermaster"], "aqm-by")).toBe(false);
+  });
+
+  it("should ignore instanceLabel when it is empty string", () => {
+    expect(isAllowedLabel(["bug"], [], "")).toBe(true); // empty allowedLabels → allow all
+    expect(isAllowedLabel(["bug"], ["feature"], "")).toBe(false);
+  });
 });
 
 describe("getTriggerLabels", () => {

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isAllowedLabel, getTriggerLabels } from "../../src/safety/label-filter.js";
+import { isAllowedLabel, isAllowedOwner, getTriggerLabels } from "../../src/safety/label-filter.js";
 
 describe("isAllowedLabel", () => {
   it("should return true when allowedLabels is empty", () => {
@@ -26,6 +26,29 @@ describe("isAllowedLabel", () => {
     expect(isAllowedLabel(["feature-request"], ["feature"])).toBe(false);
     expect(isAllowedLabel(["bug-fix"], ["bug"])).toBe(false);
     expect(isAllowedLabel(["feature"], ["feature"])).toBe(true);
+  });
+});
+
+describe("isAllowedOwner", () => {
+  it("should return true when instanceOwners is empty (allow all)", () => {
+    expect(isAllowedOwner("alice", [])).toBe(true);
+    expect(isAllowedOwner("", [])).toBe(true);
+  });
+
+  it("should return true when author is in instanceOwners", () => {
+    expect(isAllowedOwner("alice", ["alice", "bob"])).toBe(true);
+    expect(isAllowedOwner("bob", ["alice", "bob"])).toBe(true);
+  });
+
+  it("should return false when author is not in instanceOwners", () => {
+    expect(isAllowedOwner("charlie", ["alice", "bob"])).toBe(false);
+    expect(isAllowedOwner("", ["alice", "bob"])).toBe(false);
+  });
+
+  it("should be case-sensitive", () => {
+    expect(isAllowedOwner("Alice", ["alice"])).toBe(false);
+    expect(isAllowedOwner("alice", ["Alice"])).toBe(false);
+    expect(isAllowedOwner("alice", ["alice"])).toBe(true);
   });
 });
 

--- a/tests/safety/safety-checker.test.ts
+++ b/tests/safety/safety-checker.test.ts
@@ -89,7 +89,8 @@ describe("safety-checker", () => {
 
       expect(mockIsAllowedLabel).toHaveBeenCalledWith(
         ["enhancement", "bug"],
-        ["enhancement", "bug", "feature"]
+        ["enhancement", "bug", "feature"],
+        undefined
       );
     });
 

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -18,24 +18,24 @@ const makePayload = (action: string, labels: string[]) => ({
 
 describe("dispatchEvent", () => {
   it("should process issues.labeled with matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(true);
     expect(result.issueNumber).toBe(42);
     expect(result.repo).toBe("test/repo");
   });
 
   it("should ignore non-issues events", () => {
-    const result = dispatchEvent("push", makePayload("labeled", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("push", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
   it("should ignore non-labeled actions", () => {
-    const result = dispatchEvent("issues", makePayload("opened", ["ai-quartermaster"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("opened", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
   it("should ignore when no matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["bug"]), ["ai-quartermaster"]);
+    const result = dispatchEvent("issues", makePayload("labeled", ["bug"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -1,20 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { dispatchEvent } from "../../src/server/event-dispatcher.js";
+import type { AQConfig } from "../../src/types/config.js";
 
-const makePayload = (action: string, labels: string[]) => ({
+const makePayload = (action: string, labels: string[], author = "user") => ({
   action,
   issue: {
     number: 42,
     title: "Test",
     body: "Body",
     labels: labels.map(name => ({ name })),
-    user: { login: "user" },
+    user: { login: author },
   },
   repository: {
     full_name: "test/repo",
     default_branch: "main",
   },
 });
+
+const makeConfig = (instanceOwners: string[]): AQConfig => ({
+  general: { instanceOwners },
+  git: { allowedRepos: ["test/repo"] },
+  projects: [],
+} as unknown as AQConfig);
 
 describe("dispatchEvent", () => {
   it("should process issues.labeled with matching label", () => {
@@ -42,5 +49,35 @@ describe("dispatchEvent", () => {
   it("should process when triggerLabels is empty (allow all)", () => {
     const result = dispatchEvent("issues", makePayload("labeled", ["anything"]), []);
     expect(result.shouldProcess).toBe(true);
+  });
+
+  describe("owner filtering", () => {
+    it("should process when instanceOwners is empty (allow all authors)", () => {
+      const config = makeConfig([]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "anyone"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it("should process when author is in instanceOwners", () => {
+      const config = makeConfig(["alice", "bob"]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "alice"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it("should reject when author is not in instanceOwners", () => {
+      const config = makeConfig(["alice", "bob"]);
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toContain("charlie");
+      expect(result.reason).toContain("instanceOwners");
+    });
+
+    it("should reject before repo check when owner is not allowed", () => {
+      const config = makeConfig(["alice"]);
+      // charlie is not in instanceOwners — should fail on owner check
+      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toMatch(/instanceOwners/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

v0.3.3 이후 누적된 8개 PR + claude-profile API를 포함하는 릴리즈.

### 새 기능
- **instanceOwners**: 이슈 작성자 기반 필터링 — 허용 사용자 관리 (#491)
- **claude-profile API**: 현재 프로필/모델/CLI 버전 조회 엔드포인트

### 버그 수정
- instanceLabel 설정 시 allowedLabels에 자동 포함 — 이중 설정 방지 (#490)
- 이슈 재라벨 시 이전 성공 잡 자동 archive — 재처리 차단 방지 (#488)
- 체크포인트 복원 시 비활성화 상태 스킵 — CI_CHECKING 등 무효 상태 방지 (#487)
- Plan 순환 의존성 검증 — validatePlan에 cycle 체크 추가 (#486)
- aqm stop 시 자식 프로세스 그룹 kill — 좀비 방지 (#485)
- 재시작 시 project pause 자동 해제 — 메모리 상태 초기화 (#484)

### 리팩터링
- 기본 라벨명 ai-quartermaster → aqm 축약 (#489)

### 포함된 이전 릴리즈
- v0.3.3: 설정 저장 수정 + Task 팩토리 통합
- v0.3.2: 개인화 + 우선순위 + 자동화 규칙
- v0.3.1: automations 기반 + Task 추상화
- v0.3.0: AQM 기능 대량 추가 + 안정화

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 전체 통과
- [x] 대시보드 정상 로드 확인
- [x] 이슈 → 파이프라인 E2E 흐름 확인