### PR TITLE
[AQ-#495] feat: Settings에서 instanceOwners 편집 UI 추가

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -302,6 +302,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
   <div class="flex items-center gap-8">
     <span class="font-headline font-bold text-primary-container text-lg uppercase tracking-wider">AI Quartermaster</span>
     <span id="instance-label" class="hidden font-mono text-xs text-outline uppercase tracking-widest opacity-70 border border-outline-variant/30 px-2 py-0.5 rounded"></span>
+    <span id="instance-owners" class="hidden font-mono text-xs text-outline tracking-wide opacity-70 px-2 py-0.5"></span>
     <nav class="hidden md:flex gap-6">
       <a class="font-body font-bold tracking-tight text-sm text-primary-container border-b-2 border-primary-container py-5 cursor-pointer" data-nav="dashboard" data-i18n="dashboard">Dashboard</a>
       <a class="font-body font-bold tracking-tight text-sm text-slate-400 hover:text-slate-200 transition-colors py-5 cursor-pointer" data-nav="logs" data-i18n="logs">Logs</a>

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -94,6 +94,17 @@ function updateInstanceLabel(label) {
   }
 }
 
+function updateInstanceOwners(owners) {
+  var el = document.getElementById('instance-owners');
+  if (!el) return;
+  if (Array.isArray(owners) && owners.length > 0) {
+    el.textContent = owners.join(', ');
+    el.classList.remove('hidden');
+  } else {
+    el.classList.add('hidden');
+  }
+}
+
 function loadInstanceLabel() {
   apiFetch('/api/config')
     .then(function(r) { return r.json(); })
@@ -101,6 +112,7 @@ function loadInstanceLabel() {
       if (data.config && data.config.general) {
         var label = data.config.general.instanceLabel || data.config.general.projectName || '';
         updateInstanceLabel(label);
+        updateInstanceOwners(data.config.general.instanceOwners);
       }
     })
     .catch(function() {});
@@ -589,6 +601,7 @@ function connectSSE() {
       if (data.changes && data.changes.general) {
         var label = data.changes.general.instanceLabel || data.changes.general.projectName || '';
         updateInstanceLabel(label);
+        updateInstanceOwners(data.changes.general.instanceOwners);
       }
       if (currentView === 'settings') {
         loadSettings();

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -258,6 +258,10 @@ function getInputValue(input) {
     case 'number':
       return parseInt(input.value, 10) || 0;
     default:
+      // comma-array 타입 처리 (예: instanceOwners)
+      if (input.dataset.inputType === 'comma-array') {
+        return input.value.split(',').map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; });
+      }
       // textarea이고 JSON 데이터인 경우 파싱 시도
       if (input.tagName.toLowerCase() === 'textarea') {
         try {

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -661,6 +661,7 @@ function renderTabForm(tabName, data) {
 
 var FIELD_DISPLAY_LABELS = {
   'general.instanceLabel': 'Instance Label',
+  'general.instanceOwners': 'Instance Owners',
 };
 
 function renderFormField(key, value, configPath) {
@@ -677,7 +678,11 @@ function renderFormField(key, value, configPath) {
   } else if (typeof value === 'number') {
     html += renderNumberInput(fieldId, value, configPath, isReadonly);
   } else if (Array.isArray(value)) {
-    html += renderArrayInput(fieldId, value, configPath, isReadonly);
+    if (configPath === 'general.instanceOwners') {
+      html += renderInstanceOwnersInput(fieldId, value, configPath, isReadonly);
+    } else {
+      html += renderArrayInput(fieldId, value, configPath, isReadonly);
+    }
   } else if (typeof value === 'object' && value !== null) {
     html += renderObjectInput(fieldId, value, configPath, isReadonly);
   } else {
@@ -736,6 +741,23 @@ function renderCheckboxInput(fieldId, value, configPath, isReadonly) {
          'class="' + classes + '"' +
          (isReadonly ? ' disabled' : '') + '/>' +
          '</div>';
+}
+
+function renderInstanceOwnersInput(fieldId, value, configPath, isReadonly) {
+  var classes = buildInputClasses(
+    'w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none',
+    isReadonly
+  );
+  var commaSeparated = Array.isArray(value) ? value.join(', ') : '';
+
+  return '<input type="text" id="' + fieldId + '" ' +
+         'data-config-path="' + esc(configPath) + '" ' +
+         'data-input-type="comma-array" ' +
+         'value="' + esc(commaSeparated) + '" ' +
+         'placeholder="owner1, owner2, owner3" ' +
+         'class="' + classes + '"' +
+         (isReadonly ? ' readonly' : '') + '/>' +
+         '<div class="text-[10px] text-outline/50 mt-1">쉼표로 구분 (예: user1, user2)</div>';
 }
 
 function renderArrayInput(fieldId, value, configPath, isReadonly) {


### PR DESCRIPTION
## Summary

Resolves #495 — feat: Settings에서 instanceOwners 편집 UI 추가

Settings > General 탭에서 instanceOwners 배열을 편집할 수 있는 UI를 추가하고, 대시보드 상단에 owners 정보를 표시해야 한다. 현재 배열 필드는 JSON textarea로 렌더링되지만, instanceOwners는 사용자 친화적인 콤마 구분 텍스트 입력으로 제공되어야 한다.

## Requirements

- Settings > General 탭에 instanceOwners 입력 필드 추가 (콤마 구분 텍스트)
- instanceLabel 필드 옆에 배치
- 저장 시 콤마 구분 텍스트를 string[] 배열로 변환
- 빈 값이면 빈 배열 [] 처리 (전체 허용)
- 대시보드 상단 인스턴스 정보에 owners 표시
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: instanceOwners 콤마 구분 입력 UI — SUCCESS (6d80ca1a)
- Phase 1: 대시보드 상단 owners 표시 — SUCCESS (15e6a908)

## Risks

- 기존 배열 렌더링 로직과 충돌 가능성 - instanceOwners 필드만 특수 처리로 해결
- SSE configChanged 이벤트에서 owners 반영 누락 가능 - 기존 instanceLabel 처리 패턴 참조

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/495-feat-settings-instanceowners-ui` → `develop`
- **Tokens**: 143 input, 14462 output{{#stats.cacheCreationTokens}}, 172536 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1584017 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #495