### PR TITLE
[AQ-#504] docs: API 문서 + 트러블슈팅 가이드 작성

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,35 @@ const eventSource = new EventSource('/api/events?token=uuid-session-token');
 - `404` - 작업을 찾을 수 없음
 - `400` - 실패/취소되지 않은 작업은 재시도 불가
 
+### PUT /api/jobs/:id/priority
+작업 우선순위를 변경합니다.
+
+**요청 본문:**
+```json
+{
+  "priority": "high"
+}
+```
+
+**우선순위 값:** `high`, `normal`, `low`
+
+**응답:**
+```json
+{
+  "id": "job-uuid",
+  "issueNumber": 123,
+  "repo": "owner/repo",
+  "status": "queued",
+  "priority": "high",
+  "createdAt": "2026-04-04T10:00:00Z"
+}
+```
+
+**에러:**
+- `400` - 유효하지 않은 우선순위 값 또는 요청 본문
+- `404` - 작업을 찾을 수 없음
+- `500` - 우선순위 업데이트 실패
+
 ### DELETE /api/jobs/:id
 완료된 작업을 삭제합니다.
 
@@ -369,6 +398,40 @@ const eventSource = new EventSource('/api/events?token=uuid-session-token');
   "timeRange": "30d"
 }
 ```
+
+---
+
+## Claude Profile API
+
+### GET /api/claude-profile
+Claude CLI 프로파일 및 모델 설정 정보를 조회합니다.
+
+**응답:**
+```json
+{
+  "profile": "default",
+  "configDir": "/home/user/.claude-default",
+  "cliVersion": "1.0.0",
+  "model": "claude-sonnet-4-5",
+  "models": {
+    "plan": "claude-opus-4-5",
+    "phase": "claude-sonnet-4-5",
+    "review": "claude-sonnet-4-5",
+    "fallback": "claude-haiku-4-5"
+  },
+  "maxTurns": 60,
+  "timeout": 180000
+}
+```
+
+**필드 설명:**
+- `profile` - Claude 프로파일 이름 (`CLAUDE_CONFIG_DIR` 환경변수 기반)
+- `configDir` - Claude 설정 디렉토리 경로
+- `cliVersion` - 설치된 Claude CLI 버전
+- `model` - 기본 모델
+- `models` - 단계별 모델 설정 (plan/phase/review/fallback)
+- `maxTurns` - Claude CLI 최대 턴 수
+- `timeout` - Claude CLI 타임아웃 (ms)
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -946,14 +946,20 @@ src/
   store/              # 영속성 레이어 (SQLite 기반 DB)
     database.ts         # DB 연결 및 마이그레이션
     queries.ts          # 통계/비용 쿼리
+  automation/         # 자동화 규칙 및 스케줄링
+    rule-engine.ts      # 규칙 기반 자동화 엔진
+    scheduler.ts        # 작업 스케줄러
   hooks/              # 이벤트 훅 시스템
     hook-registry.ts    # 훅 등록 관리
     hook-executor.ts    # 훅 실행기
-    pattern-store.ts    # 패턴 기반 훅 저장소
   learning/           # 실행 결과 학습 및 패턴 수집
+    pattern-store.ts    # 패턴 기반 학습 데이터 저장소
   tasks/              # 작업 추상화 레이어
     aqm-task.ts         # AQM 내부 작업
     claude-task.ts      # Claude CLI 작업 래퍼
+    git-task.ts         # Git 작업 래퍼
+    task-factory.ts     # 작업 생성 팩토리
+    validation-task.ts  # 검증 작업 래퍼
   update/             # self-updater
   polling/            # 이슈 폴러
   utils/              # CLI 러너, 로거, slug


### PR DESCRIPTION
## Summary

Resolves #504 — docs: API 문서 + 트러블슈팅 가이드 작성

대시보드 API 문서(docs/api.md)에 2개 엔드포인트 누락, 아키텍처 문서(docs/architecture.md)에 현재 모듈 구조 미반영. 트러블슈팅 가이드(docs/troubleshooting.md)는 이미 잘 작성되어 있어 검토 후 필요시 보완.

## Requirements

- docs/api.md에 PUT /api/jobs/:id/priority 엔드포인트 문서 추가
- docs/api.md에 GET /api/claude-profile 엔드포인트 문서 추가
- docs/architecture.md에 현재 src/ 모듈 구조 반영 (pipeline, review, safety, automation 등)
- docs/troubleshooting.md 검토 및 필요시 보완
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: API 및 아키텍처 문서 업데이트 — SUCCESS (b8040990)

## Risks

- 아키텍처 문서가 크므로 전체 구조 파악 필요
- API 엔드포인트 구현 코드에서 요청/응답 스키마 정확히 추출 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/504-docs-api` → `develop`
- **Tokens**: 99 input, 12226 output{{#stats.cacheCreationTokens}}, 151513 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1316078 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #504