### PR TITLE
[AQ-#503] fix: SSE 메모리 누수 점검 + 폴링 최적화

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from "./utils/error-utils.js";
 import { JobStore } from "./queue/job-store.js";
 import { JobQueue } from "./queue/job-queue.js";
 import { createWebhookApp, startServer } from "./server/webhook-server.js";
-import { createDashboardRoutes } from "./server/dashboard-api.js";
+import { createDashboardRoutes, cleanupDashboardResources } from "./server/dashboard-api.js";
 import { createHealthRoutes } from "./server/health.js";
 import { writePidFile, cleanupStalePid, removePidFile, readPidFile } from "./server/pid-manager.js";
 import { notifySuccess, notifyFailure } from "./notification/notifier.js";
@@ -433,6 +433,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
     poller?.stop();
     scheduler.stop();
     configWatcher.stopWatching();
+    cleanupDashboardResources();
     await queue.shutdown(30000);
     cleanup();
     process.exit(0);

--- a/src/config/config-watcher.ts
+++ b/src/config/config-watcher.ts
@@ -16,6 +16,7 @@ export class ConfigWatcher extends EventEmitter {
   private localConfigPath: string;
   private watchers: Map<string, FSWatcher> = new Map();
   private debounceTimer: NodeJS.Timeout | null = null;
+  private pendingRestartTimers: Set<NodeJS.Timeout> = new Set();
   private pendingChanges: Set<string> = new Set();
   private errorCounts: Map<string, number> = new Map();
   private readonly maxErrorRetries = 3;
@@ -63,6 +64,12 @@ export class ConfigWatcher extends EventEmitter {
         logger.warn(`Error closing watcher for ${path}: ${err}`);
       }
     }
+
+    // Cancel all pending restart timers
+    for (const timer of this.pendingRestartTimers) {
+      clearTimeout(timer);
+    }
+    this.pendingRestartTimers.clear();
 
     // Clear all maps and sets
     this.watchers.clear();
@@ -215,9 +222,11 @@ export class ConfigWatcher extends EventEmitter {
     // Attempt to restart the watcher if we haven't exceeded retry limit
     if (errorCount <= this.maxErrorRetries) {
       logger.info(`Attempting to restart watcher for ${filePath} in ${this.errorRetryDelay}ms`);
-      setTimeout(() => {
+      const timer = setTimeout(() => {
+        this.pendingRestartTimers.delete(timer);
         this.restartWatcher(filePath, type);
       }, this.errorRetryDelay);
+      this.pendingRestartTimers.add(timer);
     } else {
       logger.error(`Maximum retry attempts exceeded for ${filePath}. Disabling watcher for this file.`);
       this.errorCounts.delete(filePath); // Clean up error count


### PR DESCRIPTION
## Summary

Resolves #503 — fix: SSE 메모리 누수 점검 + 폴링 최적화

1. **SSE cleanup 미호출**: `cleanupDashboardResources()` 함수가 정의되어 있지만 `gracefulShutdown`에서 호출되지 않아 서버 종료 시 SSE 클라이언트 연결이 정리되지 않음
2. **config-watcher setTimeout 누수**: `handleWatcherError`에서 `setTimeout`으로 watcher 재시작을 예약하는데, `stopWatching()` 호출 시 이 pending timeout들이 취소되지 않음
3. **job-store 캐시**: 이미 `maxJobs` + `prune()` + auto-prune 구현됨 (수정 불필요)
4. **동적 폴링**: 이미 `IDLE_THRESHOLD_MS` + `lastActivityAt` 구현됨 (수정 불필요)

## Requirements

- gracefulShutdown에서 cleanupDashboardResources() 호출하여 SSE 클라이언트 정리
- config-watcher의 pending restart setTimeout 추적 및 stopWatching에서 취소
- 기존 동작 유지 (regression 방지)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: SSE cleanup 통합 — SUCCESS (0503860a)
- Phase 1: config-watcher setTimeout 정리 — SUCCESS (0503860a)
- Phase 2: 빌드 및 테스트 검증 — SUCCESS (0503860a)

## Risks

- gracefulShutdown 순서 의존성: cleanupDashboardResources 호출 시점이 다른 cleanup과 충돌 가능
- config-watcher setTimeout 취소 시 아직 실행 중인 restartWatcher 로직 중단

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/503-fix-sse` → `develop`
- **Tokens**: 179 input, 14796 output{{#stats.cacheCreationTokens}}, 209293 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2021208 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #503