### PR TITLE
[AQ-#513] refactor: JobStore.list() DB-level pagination 적용

### DIFF
--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { EventEmitter } from "events";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
-import { AQDatabase, DatabaseJob, DatabasePhase, DatabaseLog } from "../store/database.js";
+import { AQDatabase, DatabaseJob, DatabasePhase, DatabaseLog, ListJobsFilter } from "../store/database.js";
 import { JsonMigrator } from "./json-migrator.js";
 import type {
   Job,
@@ -30,6 +30,12 @@ export type {
   CancelledJob,
   ArchivedJob
 } from "../types/pipeline.js";
+
+export interface ListJobsOptions {
+  status?: JobStatus;
+  limit?: number;
+  offset?: number;
+}
 
 export class JobStore extends EventEmitter {
   private db: AQDatabase;
@@ -574,26 +580,46 @@ export class JobStore extends EventEmitter {
     return updatedJob;
   }
 
-  list(): Job[] {
-    const dbJobs = this.db.listJobs();
-    const allJobs = dbJobs.map(dbJob => this.dbJobToJob(dbJob));
+  list(options?: ListJobsOptions): Job[] {
+    const hasFilter = options && (options.status !== undefined || options.limit !== undefined || options.offset !== undefined);
 
-    // 캐시된 job들로 업데이트 (최신 상태 반영)
-    const cachedJobs = this.getCachedJobs();
+    if (!hasFilter) {
+      // 옵션 없음: 기존 동작 유지 (전체 로드 + 캐시 머지)
+      const dbJobs = this.db.listJobs();
+      const allJobs = dbJobs.map(dbJob => this.dbJobToJob(dbJob));
+
+      const jobMap = new Map<string, Job>();
+      for (const job of allJobs) {
+        jobMap.set(job.id, job);
+      }
+      for (const cachedJob of this.getCachedJobs()) {
+        jobMap.set(cachedJob.id, cachedJob);
+      }
+
+      return Array.from(jobMap.values())
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    }
+
+    // 옵션 있음: DB 레벨 필터링 사용
+    const filter: ListJobsFilter = {};
+    if (options.status !== undefined) filter.status = options.status;
+    if (options.limit !== undefined) filter.limit = options.limit;
+    if (options.offset !== undefined) filter.offset = options.offset;
+
+    const dbJobs = this.db.listJobsWithFilter(filter);
     const jobMap = new Map<string, Job>();
-
-    // 먼저 SQLite에서 가져온 모든 job을 맵에 추가
-    for (const job of allJobs) {
-      jobMap.set(job.id, job);
+    for (const dbJob of dbJobs) {
+      jobMap.set(dbJob.id, this.dbJobToJob(dbJob));
     }
 
-    // 캐시된 job으로 덮어쓰기 (더 최신 상태)
-    for (const cachedJob of cachedJobs) {
-      jobMap.set(cachedJob.id, cachedJob);
+    // 결과에 포함된 job 중 캐시에 있으면 최신 상태로 덮어쓰기
+    for (const [id, cachedJob] of this.cache) {
+      if (jobMap.has(id)) {
+        jobMap.set(id, cachedJob);
+      }
     }
 
-    return Array.from(jobMap.values())
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return Array.from(jobMap.values());
   }
 
   findByIssue(issueNumber: number, repo: string): Job | undefined {
@@ -611,23 +637,22 @@ export class JobStore extends EventEmitter {
   }
 
   findCompletedByIssue(issueNumber: number, repo: string): Job | undefined {
-    const allJobs = this.list();
-    for (const job of allJobs) {
-      if (job.issueNumber === issueNumber && job.repo === repo && job.status === "success") {
-        return job;
-      }
-    }
-    return undefined;
+    const dbJob = this.db.findJobByIssueWithStatus(issueNumber, repo, "success");
+    return dbJob ? this.dbJobToJob(dbJob) : undefined;
   }
 
   findAnyByIssue(issueNumber: number, repo: string): Job | undefined {
-    const allJobs = this.list();
-    for (const job of allJobs) {
-      if (job.issueNumber === issueNumber && job.repo === repo && job.status !== "archived") {
+    // 캐시 우선 조회 (running/queued 상태만 캐싱됨)
+    const cachedJobs = this.getCachedJobs();
+    for (const job of cachedJobs) {
+      if (job.issueNumber === issueNumber && job.repo === repo) {
         return job;
       }
     }
-    return undefined;
+
+    // 캐시 미스 시 DB에서 archived 제외 조회
+    const dbJob = this.db.findJobByIssueExcludingStatus(issueNumber, repo, "archived");
+    return dbJob ? this.dbJobToJob(dbJob) : undefined;
   }
 
   shouldBlockRepickup(issueNumber: number, repo: string): boolean {

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -108,6 +108,14 @@ export interface DatabaseLog {
   timestamp: string;
 }
 
+export interface ListJobsFilter {
+  status?: DatabaseJob["status"];
+  statuses?: DatabaseJob["status"][];
+  excludeStatus?: DatabaseJob["status"];
+  limit?: number;
+  offset?: number;
+}
+
 export class AQDatabase {
   private db: SQLite.Database;
 
@@ -300,6 +308,66 @@ export class AQDatabase {
 
     const rows = stmt.all() as JobRow[];
     return rows.map(row => this.mapRowToJob(row));
+  }
+
+  listJobsWithFilter(filter: ListJobsFilter): DatabaseJob[] {
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (filter.status) {
+      conditions.push("status = ?");
+      params.push(filter.status);
+    } else if (filter.statuses && filter.statuses.length > 0) {
+      const placeholders = filter.statuses.map(() => "?").join(", ");
+      conditions.push(`status IN (${placeholders})`);
+      for (const s of filter.statuses) params.push(s);
+    }
+
+    if (filter.excludeStatus) {
+      conditions.push("status != ?");
+      params.push(filter.excludeStatus);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const limitPart = filter.limit !== undefined ? "LIMIT ?" : "";
+    const offsetPart = filter.offset !== undefined ? "OFFSET ?" : "";
+
+    if (filter.limit !== undefined) params.push(filter.limit);
+    if (filter.offset !== undefined) params.push(filter.offset);
+
+    const stmt = this.db.prepare(`
+      SELECT * FROM jobs
+      ${whereClause}
+      ORDER BY created_at DESC
+      ${limitPart} ${offsetPart}
+    `);
+
+    const rows = stmt.all(...params) as JobRow[];
+    return rows.map(row => this.mapRowToJob(row));
+  }
+
+  findJobByIssueWithStatus(issueNumber: number, repo: string, status: DatabaseJob["status"]): DatabaseJob | undefined {
+    const stmt = this.db.prepare(`
+      SELECT * FROM jobs
+      WHERE issue_number = ? AND repo = ? AND status = ?
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+
+    const row = stmt.get(issueNumber, repo, status) as JobRow | undefined;
+    return row ? this.mapRowToJob(row) : undefined;
+  }
+
+  findJobByIssueExcludingStatus(issueNumber: number, repo: string, excludeStatus: DatabaseJob["status"]): DatabaseJob | undefined {
+    const stmt = this.db.prepare(`
+      SELECT * FROM jobs
+      WHERE issue_number = ? AND repo = ? AND status != ?
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+
+    const row = stmt.get(issueNumber, repo, excludeStatus) as JobRow | undefined;
+    return row ? this.mapRowToJob(row) : undefined;
   }
 
   findJobByIssue(issueNumber: number, repo: string): DatabaseJob | undefined {

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -1163,4 +1163,228 @@ describe("JobStore", () => {
       newStore.close();
     });
   });
+
+  describe("list() DB-level pagination and filtering", () => {
+    it("should return all jobs when no options provided", () => {
+      store.create(1, "test/repo");
+      store.create(2, "test/repo");
+      store.create(3, "test/repo");
+
+      const jobs = store.list();
+      expect(jobs.length).toBe(3);
+    });
+
+    it("should limit results when limit option is provided", () => {
+      for (let i = 1; i <= 5; i++) {
+        store.create(i, "test/repo");
+      }
+
+      const jobs = store.list({ limit: 3 });
+      expect(jobs.length).toBe(3);
+    });
+
+    it("should paginate with offset option", () => {
+      for (let i = 1; i <= 5; i++) {
+        store.create(i, "test/repo");
+      }
+
+      const firstPage = store.list({ limit: 2, offset: 0 });
+      const secondPage = store.list({ limit: 2, offset: 2 });
+
+      expect(firstPage.length).toBe(2);
+      expect(secondPage.length).toBe(2);
+
+      const firstPageIds = firstPage.map(j => j.id);
+      const secondPageIds = secondPage.map(j => j.id);
+      for (const id of secondPageIds) {
+        expect(firstPageIds).not.toContain(id);
+      }
+    });
+
+    it("should filter by status when status option is provided", () => {
+      const job1 = store.create(1, "test/repo");
+      const job2 = store.create(2, "test/repo");
+      store.update(job1.id, { status: "running", startedAt: new Date().toISOString() });
+      // job2 stays queued
+
+      const runningJobs = store.list({ status: "running" });
+      expect(runningJobs.length).toBe(1);
+      expect(runningJobs[0].id).toBe(job1.id);
+      expect(runningJobs[0].status).toBe("running");
+
+      const queuedJobs = store.list({ status: "queued" });
+      expect(queuedJobs.length).toBe(1);
+      expect(queuedJobs[0].id).toBe(job2.id);
+    });
+
+    it("should filter by success status", () => {
+      const job1 = store.create(1, "test/repo");
+      store.create(2, "test/repo");
+      store.update(job1.id, {
+        status: "success",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        prUrl: "https://github.com/test/pr/1"
+      });
+
+      const successJobs = store.list({ status: "success" });
+      expect(successJobs.length).toBe(1);
+      expect(successJobs[0].status).toBe("success");
+    });
+
+    it("should return empty array when no jobs match status filter", () => {
+      store.create(1, "test/repo");
+
+      const failureJobs = store.list({ status: "failure" });
+      expect(failureJobs.length).toBe(0);
+    });
+
+    it("should combine status filter and limit", () => {
+      for (let i = 1; i <= 4; i++) {
+        const job = store.create(i, "test/repo");
+        store.update(job.id, { status: "running", startedAt: new Date().toISOString() });
+      }
+      store.create(5, "test/repo"); // queued
+
+      const jobs = store.list({ status: "running", limit: 2 });
+      expect(jobs.length).toBe(2);
+      for (const job of jobs) {
+        expect(job.status).toBe("running");
+      }
+    });
+
+    it("should return jobs sorted by createdAt desc when no options", () => {
+      const job1 = store.create(1, "test/repo");
+      const job2 = store.create(2, "test/repo");
+      const job3 = store.create(3, "test/repo");
+
+      const jobs = store.list();
+      const ids = jobs.map(j => j.id);
+      expect(ids[0]).toBe(job3.id);
+      expect(ids[1]).toBe(job2.id);
+      expect(ids[2]).toBe(job1.id);
+    });
+
+    it("should reflect cache updates in filtered list", () => {
+      const job = store.create(1, "test/repo");
+      store.update(job.id, { status: "running", startedAt: new Date().toISOString() });
+
+      const running = store.list({ status: "running" });
+      expect(running.length).toBe(1);
+      expect(running[0].status).toBe("running");
+    });
+  });
+
+  describe("findCompletedByIssue / findAnyByIssue", () => {
+    it("findCompletedByIssue should return undefined when no success job exists", () => {
+      const job = store.create(10, "test/repo");
+      store.update(job.id, {
+        status: "failure",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        error: "some error"
+      });
+
+      const result = store.findCompletedByIssue(10, "test/repo");
+      expect(result).toBeUndefined();
+    });
+
+    it("findCompletedByIssue should return success job", () => {
+      const job = store.create(11, "test/repo");
+      store.update(job.id, {
+        status: "success",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        prUrl: "https://github.com/test/pr/11"
+      });
+
+      const result = store.findCompletedByIssue(11, "test/repo");
+      expect(result).toBeDefined();
+      expect(result?.status).toBe("success");
+      expect(result?.issueNumber).toBe(11);
+    });
+
+    it("findCompletedByIssue should respect repo boundary", () => {
+      const job = store.create(12, "other/repo");
+      store.update(job.id, {
+        status: "success",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        prUrl: "https://github.com/other/pr/1"
+      });
+
+      const result = store.findCompletedByIssue(12, "test/repo");
+      expect(result).toBeUndefined();
+    });
+
+    it("findAnyByIssue should return undefined when no job exists", () => {
+      const result = store.findAnyByIssue(20, "test/repo");
+      expect(result).toBeUndefined();
+    });
+
+    it("findAnyByIssue should return queued job from cache", () => {
+      const job = store.create(21, "test/repo");
+
+      const result = store.findAnyByIssue(21, "test/repo");
+      expect(result).toBeDefined();
+      expect(result?.id).toBe(job.id);
+      expect(result?.status).toBe("queued");
+    });
+
+    it("findAnyByIssue should return running job from cache", () => {
+      const job = store.create(22, "test/repo");
+      store.update(job.id, { status: "running", startedAt: new Date().toISOString() });
+
+      const result = store.findAnyByIssue(22, "test/repo");
+      expect(result).toBeDefined();
+      expect(result?.status).toBe("running");
+    });
+
+    it("findAnyByIssue should return failure job from DB (not archived)", () => {
+      const job = store.create(23, "test/repo");
+      store.update(job.id, {
+        status: "failure",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        error: "failed"
+      });
+
+      const result = store.findAnyByIssue(23, "test/repo");
+      expect(result).toBeDefined();
+      expect(result?.status).toBe("failure");
+    });
+
+    it("findAnyByIssue should return undefined when only archived job exists", () => {
+      const job = store.create(24, "test/repo");
+      store.update(job.id, { status: "archived" });
+
+      const result = store.findAnyByIssue(24, "test/repo");
+      expect(result).toBeUndefined();
+    });
+
+    it("findAnyByIssue should prefer non-archived job over archived", () => {
+      const archivedJob = store.create(25, "test/repo");
+      store.update(archivedJob.id, { status: "archived" });
+
+      const failedJob = store.create(25, "test/repo");
+      store.update(failedJob.id, {
+        status: "failure",
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        error: "failed"
+      });
+
+      const result = store.findAnyByIssue(25, "test/repo");
+      expect(result).toBeDefined();
+      expect(result?.id).toBe(failedJob.id);
+      expect(result?.status).toBe("failure");
+    });
+
+    it("findAnyByIssue should respect repo boundary", () => {
+      store.create(26, "other/repo");
+
+      const result = store.findAnyByIssue(26, "test/repo");
+      expect(result).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #513 — refactor: JobStore.list() DB-level pagination 적용

SSE 주기 호출 시 job 수백 건 이상이면 list()가 전체 로드 후 JS 필터링하여 응답 지연 발생. findCompletedByIssue(), findAnyByIssue()도 list() 전체 호출 후 필터링.

## Requirements

- list()에 status filter를 DB 쿼리 레벨로 이동
- list()에 limit/offset pagination 추가
- findCompletedByIssue(), findAnyByIssue()가 직접 DB 쿼리 사용

## Implementation Phases

- Phase 0: database.ts DB 쿼리 확장 — SUCCESS (d28b3a0c)
- Phase 1: JobStore.list() 리팩터링 — SUCCESS (9adfa862)
- Phase 2: findCompletedByIssue/findAnyByIssue 직접 DB 쿼리 — SUCCESS (9adfa862)
- Phase 3: 테스트 추가 및 검증 — SUCCESS (eccf707d)

## Risks

- 캐시 병합 로직과 DB 필터링 간 데이터 불일치 가능성
- 기존 list() 호출부 동작 변경 위험

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/513-refactor-jobstore-list-db-level-pagination` → `develop`
- **Tokens**: 202 input, 30530 output{{#stats.cacheCreationTokens}}, 296431 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3111940 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #513