### PR TITLE
[AQ-#517] fix: 서버 기본 바인딩 localhost + Bearer timingSafeEqual 적용

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context, type Next } from "hono";
-import { randomUUID } from "crypto";
+import { randomUUID, timingSafeEqual } from "crypto";
 import { readFileSync } from "fs";
 import { resolve, normalize, basename } from "path";
 import type { JobStore, Job } from "../queue/job-store.js";
@@ -372,7 +372,9 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     // POST /api/auth — exchange Bearer key for a short-lived session token
     api.post("/api/auth", (c) => {
       const auth = c.req.header("Authorization");
-      if (!auth || auth !== `Bearer ${apiKey}`) {
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
         return c.json({ error: "Unauthorized" }, 401);
       }
       pruneExpiredTokens();
@@ -384,7 +386,9 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     // Auth middleware for regular (non-SSE) API endpoints — Bearer header only
     const bearerAuth = async (c: Context, next: Next) => {
       const auth = c.req.header("Authorization");
-      if (!auth || auth !== `Bearer ${apiKey}`) {
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
         return c.json({ error: "Unauthorized" }, 401);
       }
       await next();

--- a/src/server/webhook-server.ts
+++ b/src/server/webhook-server.ts
@@ -75,7 +75,7 @@ export function startServer(
 ): { close: () => void } {
   let server: ReturnType<typeof serve>;
   try {
-    server = serve({ fetch: app.fetch, port });
+    server = serve({ fetch: app.fetch, port, hostname: '127.0.0.1' });
   } catch (err: unknown) {
     if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EADDRINUSE") {
       logger.warn(`포트 ${port}가 이미 사용 중입니다 (EADDRINUSE)`);
@@ -83,7 +83,7 @@ export function startServer(
     }
     throw err;
   }
-  logger.info(`AI Quartermaster server listening on port ${port}`);
+  logger.info(`AI Quartermaster server listening on 127.0.0.1:${port}`);
   return {
     close: () => {
       // @hono/node-server returns a Node http.Server


### PR DESCRIPTION
## Summary

Resolves #517 — fix: 서버 기본 바인딩 localhost + Bearer timingSafeEqual 적용

현재 serve()가 hostname 미지정으로 0.0.0.0에 바인딩되어 외부에서 대시보드 접근 가능. Bearer 토큰 비교가 === 연산자를 사용하여 timing attack에 취약함.

## Requirements

- serve()에 hostname '127.0.0.1' 기본값 적용
- dashboard-api.ts Bearer 토큰 비교를 timingSafeEqual로 교체
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: localhost 기본 바인딩 — SUCCESS (4a32735f)
- Phase 1: Bearer timingSafeEqual 적용 — SUCCESS (4a32735f)

## Risks

- timingSafeEqual은 동일 길이 버퍼 필요 — 길이 불일치 예외 처리 필수
- 기존 --host 옵션이 있다면 우선순위 확인 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/517-fix-localhost-bearer-timingsafeequal` → `develop`
- **Tokens**: 128 input, 9002 output{{#stats.cacheCreationTokens}}, 133551 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1362322 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #517