### PR TITLE
[AQ-#516] feat: cache hit ratio 메트릭 추가 + 대시보드 표시

### DIFF
--- a/src/claude/token-pricing.ts
+++ b/src/claude/token-pricing.ts
@@ -91,6 +91,20 @@ export function calculateCostFromUsage(usage: UsageInfo, model: string): number 
 }
 
 /**
+ * cache hit ratio를 계산합니다.
+ * 공식: cache_read / (input + cache_read)
+ *
+ * @param usage - Claude CLI가 반환한 토큰 사용량 정보
+ * @returns 0~1 범위의 cache hit ratio (토큰 없으면 0)
+ */
+export function calculateCacheHitRatio(usage: UsageInfo): number {
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const denominator = usage.input_tokens + cacheRead;
+  if (denominator === 0) return 0;
+  return cacheRead / denominator;
+}
+
+/**
  * 모델별 단가 정보를 반환합니다.
  *
  * @param model - Claude 모델명

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -121,6 +121,7 @@ function renderJobDetail(job) {
   if (dur) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">schedule</span> <span data-dur="' + esc(job.id) + '">' + dur + '</span></span>';
   var costHtml = fmtCost(job.totalCostUsd);
   if (costHtml) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">payments</span> ' + costHtml + '</span>';
+  if (job.cacheHitRatio != null && job.cacheHitRatio > 0) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">cached</span> Cache: ' + Math.round(job.cacheHitRatio * 100) + '%</span>';
   html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">calendar_today</span> ' + relativeTime(job.createdAt) + '</span>';
   html += '<span class="flex items-center gap-1.5 font-mono text-xs opacity-80">' + esc(job.id) + '</span>';
   html += '</div></div>';
@@ -317,6 +318,10 @@ function renderAccordionDetail(job) {
   html += '</div>';
   html += '<div><span class="text-[10px] uppercase tracking-widest font-bold text-outline">Cost</span>';
   html += '<p class="font-mono text-sm text-tertiary mt-1">$' + (job.totalCostUsd || job.costUsd || 0).toFixed(4) + '</p></div>';
+  if (job.cacheHitRatio != null && job.cacheHitRatio > 0) {
+    html += '<div><span class="text-[10px] uppercase tracking-widest font-bold text-outline">Cache</span>';
+    html += '<p class="font-mono text-sm text-tertiary mt-1">Cache: ' + Math.round(job.cacheHitRatio * 100) + '%</p></div>';
+  }
   html += '<div><span class="text-[10px] uppercase tracking-widest font-bold text-outline">Status</span>';
   html += '<p class="mt-1">' + statusLabel(job.status, job) + '</p></div>';
   html += '</div>';

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -166,16 +166,20 @@ export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsRespo
     ${whereClause}
   `).get(...params) as CostSummaryRow;
 
-  const breakdown: CostEntry[] = breakdownRows.map(row => ({
-    label: row.label,
-    totalCostUsd: row.total_cost_usd,
-    jobCount: row.job_count,
-    avgCostUsd: row.job_count > 0 ? row.total_cost_usd / row.job_count : 0,
-    totalInputTokens: row.total_input_tokens,
-    totalOutputTokens: row.total_output_tokens,
-    totalCacheCreationTokens: row.total_cache_creation_tokens,
-    totalCacheReadTokens: row.total_cache_read_tokens,
-  }));
+  const breakdown: CostEntry[] = breakdownRows.map(row => {
+    const cacheTotal = row.total_cache_creation_tokens + row.total_cache_read_tokens;
+    return {
+      label: row.label,
+      totalCostUsd: row.total_cost_usd,
+      jobCount: row.job_count,
+      avgCostUsd: row.job_count > 0 ? row.total_cost_usd / row.job_count : 0,
+      totalInputTokens: row.total_input_tokens,
+      totalOutputTokens: row.total_output_tokens,
+      totalCacheCreationTokens: row.total_cache_creation_tokens,
+      totalCacheReadTokens: row.total_cache_read_tokens,
+      cacheHitRatio: cacheTotal > 0 ? row.total_cache_read_tokens / cacheTotal : 0,
+    };
+  });
 
   const totalJobCount = summaryRow.job_count;
 
@@ -191,6 +195,9 @@ export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsRespo
       totalOutputTokens: summaryRow.total_output_tokens,
       totalCacheCreationTokens: summaryRow.total_cache_creation_tokens,
       totalCacheReadTokens: summaryRow.total_cache_read_tokens,
+      cacheHitRatio: (summaryRow.total_cache_creation_tokens + summaryRow.total_cache_read_tokens) > 0
+        ? summaryRow.total_cache_read_tokens / (summaryRow.total_cache_creation_tokens + summaryRow.total_cache_read_tokens)
+        : 0,
     },
     breakdown,
   };

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -167,7 +167,7 @@ export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsRespo
   `).get(...params) as CostSummaryRow;
 
   const breakdown: CostEntry[] = breakdownRows.map(row => {
-    const cacheTotal = row.total_cache_creation_tokens + row.total_cache_read_tokens;
+    const cacheHitDenominator = row.total_input_tokens + row.total_cache_read_tokens;
     return {
       label: row.label,
       totalCostUsd: row.total_cost_usd,
@@ -177,7 +177,7 @@ export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsRespo
       totalOutputTokens: row.total_output_tokens,
       totalCacheCreationTokens: row.total_cache_creation_tokens,
       totalCacheReadTokens: row.total_cache_read_tokens,
-      cacheHitRatio: cacheTotal > 0 ? row.total_cache_read_tokens / cacheTotal : 0,
+      cacheHitRatio: cacheHitDenominator > 0 ? row.total_cache_read_tokens / cacheHitDenominator : 0,
     };
   });
 
@@ -195,8 +195,8 @@ export function getCostStats(aqDb: AQDatabase, query: GetCostsQuery): CostsRespo
       totalOutputTokens: summaryRow.total_output_tokens,
       totalCacheCreationTokens: summaryRow.total_cache_creation_tokens,
       totalCacheReadTokens: summaryRow.total_cache_read_tokens,
-      cacheHitRatio: (summaryRow.total_cache_creation_tokens + summaryRow.total_cache_read_tokens) > 0
-        ? summaryRow.total_cache_read_tokens / (summaryRow.total_cache_creation_tokens + summaryRow.total_cache_read_tokens)
+      cacheHitRatio: (summaryRow.total_input_tokens + summaryRow.total_cache_read_tokens) > 0
+        ? summaryRow.total_cache_read_tokens / (summaryRow.total_input_tokens + summaryRow.total_cache_read_tokens)
         : 0,
     },
     breakdown,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -222,6 +222,7 @@ export const CostEntrySchema = z.object({
   totalOutputTokens: z.number().int().nonnegative(),
   totalCacheCreationTokens: z.number().int().nonnegative(),
   totalCacheReadTokens: z.number().int().nonnegative(),
+  cacheHitRatio: z.number().min(0).max(1),
 });
 
 export type CostEntry = z.infer<typeof CostEntrySchema>;
@@ -238,6 +239,7 @@ export const CostsResponseSchema = z.object({
     totalOutputTokens: z.number().int().nonnegative(),
     totalCacheCreationTokens: z.number().int().nonnegative(),
     totalCacheReadTokens: z.number().int().nonnegative(),
+    cacheHitRatio: z.number().min(0).max(1),
   }),
   breakdown: z.array(CostEntrySchema),
 });


### PR DESCRIPTION
## Summary

Resolves #516 — feat: cache hit ratio 메트릭 추가 + 대시보드 표시

프롬프트 구조 변경이 비용에 미치는 영향을 측정하기 위해 cache hit ratio 메트릭이 필요합니다. calculateCostFromUsage() 반환값에 cache hit ratio를 포함하고, 대시보드 Costs 뷰에 cache 효율 퍼센트를 표시해야 합니다.

## Requirements

- calculateCostFromUsage() 반환값에 cache hit ratio (cache_read / (input + cache_read)) 포함
- 대시보드 Costs 뷰에 cache 효율 퍼센트 표시
- 기존 API 호환성 유지 (breaking change 최소화)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: cache hit ratio 계산 함수 추가 — SUCCESS (037ab499)
- Phase 1: API 타입에 cacheHitRatio 필드 추가 — SUCCESS (037ab499)
- Phase 2: getCostStats에서 cache hit ratio 계산 — SUCCESS (3c27e903)
- Phase 3: 대시보드 UI에 cache hit ratio 표시 — SUCCESS (53846c11)

## Risks

- calculateCostFromUsage 반환 타입 변경 시 기존 호출부 수정 필요
- cache_read_input_tokens가 0인 경우 division by zero 처리 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/516-feat-cache-hit-ratio` → `develop`
- **Tokens**: 274 input, 41463 output{{#stats.cacheCreationTokens}}, 289569 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 3864296 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #516