### PR TITLE
[AQ-#519] fix: typescript를 dependencies로 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "minimatch": "^9.0.9",
     "node-cron": "^3.0.3",
     "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
     "yaml": "^2.3.0",
     "zod": "^3.22.0"
   },
@@ -45,7 +46,6 @@
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/coverage-v8": "^1.3.0",
     "eslint": "^8.57.0",
-    "typescript": "^5.4.0",
     "vitest": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Summary

Resolves #519 — fix: typescript를 dependencies로 이동

plan-generator.ts가 런타임에 typescript 모듈을 import하지만, typescript가 devDependencies에 있어 npm ci --production 시 설치되지 않아 모듈 없음 에러 발생

## Requirements

- package.json에서 typescript를 devDependencies → dependencies로 이동
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: typescript 의존성 위치 변경 — SUCCESS (d94a49b9)

## Risks

- 없음 - 단순 위치 변경으로 기존 기능에 영향 없음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/519-fix-typescript-dependencies` → `develop`
- **Tokens**: 42 input, 3130 output{{#stats.cacheCreationTokens}}, 82061 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 273473 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #519