### PR TITLE
[AQ-#520] fix: Claude CLI env 화이트리스트 + retry USER_INPUT 태그 유지

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -46,6 +46,36 @@ export interface ClaudeRunOptions {
   disallowedTools?: string[];  // Tools to block (e.g. ["Read", "Glob", "Grep", "Bash"])
 }
 
+/** Claude CLI spawn에 전달할 환경변수 화이트리스트. 민감 정보(GITHUB_TOKEN 등) 노출 방지. */
+function buildClaudeEnv(): NodeJS.ProcessEnv {
+  const ALLOWED_KEYS = [
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "NODE_ENV",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY",
+  ];
+
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_KEYS) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
 async function _runClaudeInternal(options: ClaudeRunOptions): Promise<ClaudeRunResult> {
   const { prompt, cwd, config, systemPrompt, maxTurns, enableAgents } = options;
 
@@ -86,7 +116,7 @@ async function _runClaudeInternal(options: ClaudeRunOptions): Promise<ClaudeRunR
   const result = await new Promise<{ stdout: string; stderr: string; exitCode: number; costUsd?: number; usage?: UsageInfo }>((resolve, reject) => {
     const child = spawn(config.path, args, {
       cwd,
-      env: process.env,
+      env: buildClaudeEnv(),
       stdio: [useStdin ? "pipe" : "ignore", "pipe", "pipe"],
     });
 

--- a/src/pipeline/plan-generator.ts
+++ b/src/pipeline/plan-generator.ts
@@ -123,7 +123,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       issue: {
         number: ctx.issue.number,
         title: ctx.issue.title,
-        body: attempt === 1 ? `<USER_INPUT>\n${ctx.issue.body}\n</USER_INPUT>` : ctx.issue.body,
+        body: `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi, "&lt;/USER_INPUT&gt;")}\n</USER_INPUT>`,
         labels: ctx.issue.labels,
       },
       repo: {
@@ -220,7 +220,7 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
           ...data,
           issue: {
             ...data.issue,
-            body: attempt === 1 ? `<USER_INPUT>\n${truncatedIssueBody}\n</USER_INPUT>` : truncatedIssueBody,
+            body: `<USER_INPUT>\n${truncatedIssueBody.replace(/<\/USER_INPUT>/gi, "&lt;/USER_INPUT&gt;")}\n</USER_INPUT>`,
           },
         }),
         "issue body truncation"


### PR DESCRIPTION
## Summary

Resolves #520 — fix: Claude CLI env 화이트리스트 + retry USER_INPUT 태그 유지

보안 취약점 2건 수정: (1) Claude CLI spawn 시 process.env 전체 전달로 GITHUB_TOKEN, API 키 등 민감 정보가 자식 프로세스에 노출됨 (2) Plan 생성 retry 시 USER_INPUT 태그가 누락되어 prompt injection 가능성 존재

## Requirements

- claude-runner.ts spawn에서 env를 화이트리스트 방식으로 변경 (PATH, HOME, LANG, NODE_ENV, CLAUDE_CONFIG_DIR 등 필수 변수만)
- plan-generator.ts에서 attempt > 1인 경우에도 USER_INPUT 태그 적용
- plan-generator.ts에서 </USER_INPUT> 태그를 &lt;/USER_INPUT&gt;로 이스케이프 (phase-executor.ts:64 방식)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: env 화이트리스트 적용 — SUCCESS (f334da8e)
- Phase 1: USER_INPUT 태그 sanitize 수정 — SUCCESS (f334da8e)

## Risks

- 화이트리스트 누락 시 Claude CLI가 필수 환경변수 없이 실행되어 오류 발생 가능
- 플랫폼별로 필요한 환경변수가 다를 수 있음 (Windows vs Linux/macOS)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 2/2 completed
- **Branch**: `aq/520-fix-claude-cli-env-retry-user-input` → `develop`
- **Tokens**: 92 input, 8753 output{{#stats.cacheCreationTokens}}, 160031 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1104738 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #520