### PR TITLE
[AQ-#524] fix: SSE 초기 데이터에서 running 잡 누락 — slice(0,20) 버그

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -345,6 +345,22 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
   }
 }
 
+const SSE_INITIAL_JOB_LIMIT = 20;
+
+/**
+ * Returns jobs for SSE initial state:
+ * - Excludes archived jobs
+ * - Always includes running/queued jobs (regardless of position)
+ * - Fills remaining slots with recent non-active jobs (up to SSE_INITIAL_JOB_LIMIT total)
+ */
+function getInitialJobs(store: JobStore): Job[] {
+  const all = store.list().filter(j => j.status !== "archived");
+  const active = all.filter(j => j.status === "running" || j.status === "queued");
+  const rest = all.filter(j => j.status !== "running" && j.status !== "queued");
+  const remaining = Math.max(0, SSE_INITIAL_JOB_LIMIT - active.length);
+  return [...active, ...rest.slice(0, remaining)];
+}
+
 /**
  * Creates dashboard API routes.
  * If apiKey is provided, all /api/* routes require `Authorization: Bearer <key>`.
@@ -957,9 +973,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
         // Send initial state
         const sendInitialState = () => {
           try {
-            const jobs = store.list();
             const status = queue.getStatus();
-            const data = JSON.stringify({ jobs: jobs.slice(0, 20), queue: status });
+            const data = JSON.stringify({ jobs: getInitialJobs(store), queue: status });
             controller.enqueue(encoder.encode(`data: ${data}\n\n`));
           } catch {
             // stream closed


### PR DESCRIPTION
## Summary

Resolves #524 — fix: SSE 초기 데이터에서 running 잡 누락 — slice(0,20) 버그

SSE sendInitialState에서 store.list().slice(0, 20)으로 최근 생성 20개만 반환하여, 오래 전 시작된 running 잡이 누락됨. 대시보드에서 실행 중 잡이 실제보다 적게 표시되는 버그.

## Requirements

- archived 상태 잡 제외
- running/queued 상태 잡 우선 포함
- 나머지는 createdAt 내림차순으로 채워 최대 20개
- sendInitialState와 10초 interval 업데이트 모두 동일 로직 적용
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase 0: SSE 잡 필터링 로직 수정 — SUCCESS (7b923888)

## Risks

- 정렬 로직 변경으로 UI 표시 순서가 달라질 수 있음 (의도된 동작)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/524-fix-sse-running-slice-0-20` → `develop`
- **Tokens**: 112 input, 8286 output{{#stats.cacheCreationTokens}}, 95197 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1075942 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #524