### PR TITLE
[AQ-#518] fix: instanceOwners 미설정 시 이슈 픽업 차단

### DIFF
--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -32,6 +32,7 @@ export class IssuePoller {
   private lastActivityAt: number = Date.now(); // 마지막 이슈 발견 시각
   private readonly IDLE_THRESHOLD_MS = 5 * 60 * 1000; // 5분 idle 임계값
   private readonly IDLE_INTERVAL_MS = 5 * 60 * 1000; // 5분 idle 폴링 간격
+  private hasWarnedNoOwners = false; // instanceOwners 미설정 경고 중복 방지
 
   constructor(
     config: AQConfig,
@@ -85,6 +86,20 @@ export class IssuePoller {
   }
 
   private async poll(): Promise<void> {
+    const owners = this.config.general.instanceOwners ?? [];
+
+    // instanceOwners 미설정 시 이슈 픽업 전체 차단 (스팸 방지: 최초 1회만 경고)
+    if (owners.length === 0) {
+      if (!this.hasWarnedNoOwners) {
+        logger.warn(
+          "[instanceOwners 미설정] 이슈 픽업이 차단됩니다. config.general.instanceOwners를 설정하세요."
+        );
+        this.hasWarnedNoOwners = true;
+      }
+      return;
+    }
+    this.hasWarnedNoOwners = false;
+
     const projects = this.config.projects ?? [];
     const triggerLabels = getTriggerLabels(this.config.general.instanceLabel, this.config.safety.allowedLabels);
     const ghPath = this.config.commands.ghCli.path;

--- a/src/safety/label-filter.ts
+++ b/src/safety/label-filter.ts
@@ -20,6 +20,14 @@ export function isAllowedLabel(
 }
 
 /**
+ * Checks if instanceOwners is configured (non-empty).
+ * Returns false if instanceOwners is empty or undefined, meaning no owners are set.
+ */
+export function hasInstanceOwnersConfigured(instanceOwners: string[]): boolean {
+  return instanceOwners.length > 0;
+}
+
+/**
  * Checks if the issue author is an allowed owner.
  * Returns true if instanceOwners is empty (all owners allowed).
  */

--- a/src/server/event-dispatcher.ts
+++ b/src/server/event-dispatcher.ts
@@ -3,7 +3,7 @@ import { listConfiguredRepos } from "../config/project-resolver.js";
 import type { AQConfig } from "../types/config.js";
 import { parseDependencies, checkCircularDependency } from "../queue/dependency-resolver.js";
 import type { JobStore } from "../queue/job-store.js";
-import { isAllowedOwner } from "../safety/label-filter.js";
+import { isAllowedOwner, hasInstanceOwnersConfigured } from "../safety/label-filter.js";
 
 const logger = getLogger();
 
@@ -71,6 +71,12 @@ export function dispatchEvent(
   // Check if issue author is an allowed owner (when config is provided)
   if (config) {
     const instanceOwners = config.general.instanceOwners ?? [];
+    if (!hasInstanceOwnersConfigured(instanceOwners)) {
+      return {
+        shouldProcess: false,
+        reason: "instanceOwners is not configured. Set at least one owner in config to enable issue processing.",
+      };
+    }
     const author = payload.issue.user.login;
     if (!isAllowedOwner(author, instanceOwners)) {
       return {

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -281,6 +281,15 @@ if (localStorage.getItem('aqm-theme') === 'light') {
   <button onclick="saveApiKey()" class="px-4 py-1.5 rounded-lg bg-primary/10 text-primary border border-primary/30 text-sm font-bold hover:bg-primary/20 transition-colors" data-i18n="save">저장</button>
 </div>
 
+<!-- Owners Warning Banner -->
+<div id="owners-warning-banner" style="display:none;" class="fixed left-0 right-0 z-[997] bg-gradient-to-r from-error/10 to-error-container/10 border-b border-error/30 px-6 py-3 flex items-center gap-4 flex-wrap">
+  <div class="flex items-center gap-2 text-error">
+    <span class="material-symbols-outlined text-lg" style="font-variation-settings: 'FILL' 1;">warning</span>
+    <span class="text-sm font-bold">instanceOwners 미설정</span>
+  </div>
+  <span class="text-sm text-on-surface flex-1 min-w-[200px]">보안 경고: <code class="font-mono text-xs bg-surface-container-lowest px-2 py-0.5 rounded border border-outline-variant/20">instanceOwners</code>가 설정되지 않아 이슈 처리가 차단됩니다. Settings에서 허용할 사용자를 설정하세요.</span>
+</div>
+
 <!-- Update Banner -->
 <div id="update-banner" style="display:none;" class="fixed left-0 right-0 z-[998] bg-gradient-to-r from-primary/10 to-primary-container/10 border-b border-primary/30 px-6 py-3 flex items-center gap-4 flex-wrap">
   <div class="flex items-center gap-2 text-primary">

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -113,6 +113,7 @@ function loadInstanceLabel() {
         var label = data.config.general.instanceLabel || data.config.general.projectName || '';
         updateInstanceLabel(label);
         updateInstanceOwners(data.config.general.instanceOwners);
+        checkOwnersWarning(data.config.general.instanceOwners);
       }
     })
     .catch(function() {});
@@ -602,6 +603,7 @@ function connectSSE() {
         var label = data.changes.general.instanceLabel || data.changes.general.projectName || '';
         updateInstanceLabel(label);
         updateInstanceOwners(data.changes.general.instanceOwners);
+        checkOwnersWarning(data.changes.general.instanceOwners);
       }
       if (currentView === 'settings') {
         loadSettings();
@@ -678,10 +680,34 @@ function checkForUpdates(data) {
   adjustPagePadding();
 }
 
+function checkOwnersWarning(owners) {
+  var banner = document.getElementById('owners-warning-banner');
+  if (!banner) return;
+
+  var isEmpty = !Array.isArray(owners) || owners.length === 0;
+  if (isEmpty) {
+    var topOffset = getApiBannerHeight() + getUpdateBannerHeight();
+    banner.style.top = topOffset + 'px';
+    banner.style.display = 'flex';
+  } else {
+    banner.style.display = 'none';
+  }
+  adjustPagePadding();
+}
+
+function getUpdateBannerHeight() {
+  var updateBanner = document.getElementById('update-banner');
+  if (updateBanner && updateBanner.style.display !== 'none') {
+    return updateBanner.offsetHeight;
+  }
+  return 0;
+}
+
 function adjustPagePadding() {
   var header = document.querySelector('header');
   var apiBanner = document.getElementById('api-key-banner');
   var updateBanner = document.getElementById('update-banner');
+  var ownersBanner = document.getElementById('owners-warning-banner');
 
   if (!header) return;
 
@@ -691,6 +717,21 @@ function adjustPagePadding() {
   }
   if (updateBanner && updateBanner.style.display !== 'none') {
     totalBannerHeight += updateBanner.offsetHeight;
+  }
+  if (ownersBanner && ownersBanner.style.display !== 'none') {
+    totalBannerHeight += ownersBanner.offsetHeight;
+  }
+
+  // owners-warning-banner top을 api+update 배너 높이만큼 동적으로 조정
+  if (ownersBanner && ownersBanner.style.display !== 'none') {
+    var ownersBannerTop = 0;
+    if (apiBanner && apiBanner.style.display !== 'none') {
+      ownersBannerTop += apiBanner.offsetHeight;
+    }
+    if (updateBanner && updateBanner.style.display !== 'none') {
+      ownersBannerTop += updateBanner.offsetHeight;
+    }
+    ownersBanner.style.top = ownersBannerTop + 'px';
   }
 
   // 헤더 top을 배너 높이만큼 동적으로 조정 (sticky header가 배너 아래로 밀리도록)

--- a/tests/e2e/polling-integration.test.ts
+++ b/tests/e2e/polling-integration.test.ts
@@ -159,6 +159,7 @@ function makeJobQueue(store: ReturnType<typeof makeJobStore>) {
 function makeConfig(overrides: Partial<AQConfig> = {}): AQConfig {
   const config = structuredClone(DEFAULT_CONFIG);
   config.general.pollingIntervalMs = 50; // fast for tests
+  config.general.instanceOwners = ["test-user"]; // poll() 차단 방지용 기본값
   config.safety.allowedLabels = ["aq-task"];
   config.projects = [
     {

--- a/tests/polling/issue-poller.test.ts
+++ b/tests/polling/issue-poller.test.ts
@@ -35,6 +35,7 @@ const mockQueue = {
 function makeConfig(overrides: Partial<AQConfig> = {}): AQConfig {
   const config = structuredClone(DEFAULT_CONFIG);
   config.general.pollingIntervalMs = 50; // fast for tests
+  config.general.instanceOwners = ["test-user"]; // poll() 차단 방지용 기본값
   config.projects = [
     {
       repo: "test/repo",
@@ -42,7 +43,12 @@ function makeConfig(overrides: Partial<AQConfig> = {}): AQConfig {
       baseBranch: "master",
     },
   ];
-  return Object.assign(config, overrides);
+  // general은 shallow merge로 처리 (Object.assign이 general 전체를 덮어쓰는 것을 방지)
+  const { general: generalOverride, ...rest } = overrides;
+  if (generalOverride) {
+    Object.assign(config.general, generalOverride);
+  }
+  return Object.assign(config, rest);
 }
 
 describe("IssuePoller - PR 충돌 체크 통합", () => {
@@ -902,6 +908,67 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       expect(labelArgs).toContain("bug");
       expect(labelArgs).toContain("feature");
       expect(labelArgs).not.toContain("aqm");
+    });
+  });
+
+  describe("instanceOwners 미설정 시 폴링 차단", () => {
+    it("instanceOwners가 빈 배열이면 poll()이 조기 종료되고 이슈 조회를 하지 않는다", async () => {
+      const config = makeConfig();
+      config.general.instanceOwners = [];
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      await (poller as any).poll();
+
+      expect(mockRunCli).not.toHaveBeenCalled();
+      expect(mockListOpenPrs).not.toHaveBeenCalled();
+    });
+
+    it("instanceOwners가 빈 배열이면 경고 로그를 최초 1회만 출력한다", async () => {
+      const config = makeConfig();
+      config.general.instanceOwners = [];
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // poll()을 3번 호출해도 경고는 1번만 발생해야 함
+      await (poller as any).poll();
+      await (poller as any).poll();
+      await (poller as any).poll();
+
+      // hasWarnedNoOwners 플래그가 true로 세팅되어 있어야 함
+      expect((poller as any).hasWarnedNoOwners).toBe(true);
+      // 이슈 조회는 한 번도 호출되지 않아야 함
+      expect(mockRunCli).not.toHaveBeenCalled();
+    });
+
+    it("instanceOwners가 설정되면 정상 폴링이 진행된다", async () => {
+      const config = makeConfig();
+      config.general.instanceOwners = ["user1"];
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockListOpenPrs.mockResolvedValue([]);
+      mockRunCli.mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+
+      await (poller as any).poll();
+
+      expect(mockRunCli).toHaveBeenCalled();
+    });
+
+    it("instanceOwners가 설정되면 hasWarnedNoOwners 플래그가 초기화된다", async () => {
+      const config = makeConfig();
+      config.general.instanceOwners = [];
+      poller = new IssuePoller(config, mockStore as any, mockQueue as any);
+
+      // 먼저 빈 owners로 경고 발생
+      await (poller as any).poll();
+      expect((poller as any).hasWarnedNoOwners).toBe(true);
+
+      // owners를 설정하면 플래그가 리셋되어야 함
+      config.general.instanceOwners = ["user1"];
+      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockListOpenPrs.mockResolvedValue([]);
+      mockRunCli.mockResolvedValue({ stdout: "[]", stderr: "", exitCode: 0 });
+
+      await (poller as any).poll();
+      expect((poller as any).hasWarnedNoOwners).toBe(false);
     });
   });
 });

--- a/tests/safety/label-filter.test.ts
+++ b/tests/safety/label-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isAllowedLabel, isAllowedOwner, getTriggerLabels } from "../../src/safety/label-filter.js";
+import { isAllowedLabel, isAllowedOwner, getTriggerLabels, hasInstanceOwnersConfigured } from "../../src/safety/label-filter.js";
 
 describe("isAllowedLabel", () => {
   it("should return true when allowedLabels is empty", () => {
@@ -45,6 +45,17 @@ describe("isAllowedLabel", () => {
   it("should ignore instanceLabel when it is empty string", () => {
     expect(isAllowedLabel(["bug"], [], "")).toBe(true); // empty allowedLabels → allow all
     expect(isAllowedLabel(["bug"], ["feature"], "")).toBe(false);
+  });
+});
+
+describe("hasInstanceOwnersConfigured", () => {
+  it("should return false when instanceOwners is empty", () => {
+    expect(hasInstanceOwnersConfigured([])).toBe(false);
+  });
+
+  it("should return true when instanceOwners has entries", () => {
+    expect(hasInstanceOwnersConfigured(["alice"])).toBe(true);
+    expect(hasInstanceOwnersConfigured(["alice", "bob"])).toBe(true);
   });
 });
 

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -52,10 +52,11 @@ describe("dispatchEvent", () => {
   });
 
   describe("owner filtering", () => {
-    it("should process when instanceOwners is empty (allow all authors)", () => {
+    it("should block when instanceOwners is empty (not configured)", () => {
       const config = makeConfig([]);
       const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "anyone"), ["ai-quartermaster"], config);
-      expect(result.shouldProcess).toBe(true);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toMatch(/instanceOwners/);
     });
 
     it("should process when author is in instanceOwners", () => {


### PR DESCRIPTION
## Summary

Resolves #518 — fix: instanceOwners 미설정 시 이슈 픽업 차단

**보안 취약점**: `instanceOwners`가 빈 배열(`[]`)일 때 `isAllowedOwner()`가 `true`를 반환하여 누구나 이슈를 생성해 코드를 실행할 수 있음.

**현재 동작**:
- `label-filter.ts:30`: `instanceOwners.length === 0`이면 모든 사용자 허용
- `issue-poller.ts:193-194`: 빈 배열이면 author 필터 없이 전체 이슈 조회
- `event-dispatcher.ts:73-80`: `isAllowedOwner()` 호출 → 빈 배열이면 모두 통과

**목표**: `instanceOwners`가 설정되지 않으면 이슈 처리를 완전 차단하고, 대시보드에 경고 표시

## Requirements

- instanceOwners가 빈 배열이면 폴링에서 모든 이슈 스킵 + 경고 로그
- instanceOwners가 빈 배열이면 웹훅에서 모든 이슈 거부 + 적절한 reason 반환
- 대시보드 상단에 경고 배너 표시: 'instanceOwners가 설정되지 않아 이슈를 처리하지 않습니다'
- 서버 시작은 차단하지 않음 (대시보드 접속 가능)
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: label-filter 가드 함수 추가 — SUCCESS (bd5db0a1)
- Phase 3: 대시보드 경고 배너 — SUCCESS (e23b7026)
- Phase 1: 폴링 차단 로직 — SUCCESS (0f553fd6)
- Phase 2: 웹훅 차단 로직 — SUCCESS (760f3a9a)
- Phase 4: 테스트 추가/업데이트 — SUCCESS (0f553fd6)

## Risks

- 기존 instanceOwners=[] 로 운영 중인 환경에서 이슈 처리 중단 (의도된 동작이지만 breaking change)
- 테스트 파일이 없을 경우 신규 생성 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 5/5 completed
- **Branch**: `aq/518-fix-instanceowners` → `develop`
- **Tokens**: 384 input, 41383 output{{#stats.cacheCreationTokens}}, 357414 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 6467988 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #518