### PR TITLE
[AQ-#509] refactor: 프롬프트 레이어 구조 정의 + template-renderer 조립 함수

### DIFF
--- a/src/prompt/layer-types.ts
+++ b/src/prompt/layer-types.ts
@@ -47,6 +47,8 @@ export interface ProjectLayer {
   structure: string;
   /** 스킬 컨텍스트 (선택) */
   skillsContext?: string;
+  /** 과거 실패 사례 요약 (선택) */
+  pastFailures?: string;
   /** 테스트 실행 명령어 */
   testCommand: string;
   /** 린트 실행 명령어 */
@@ -95,6 +97,19 @@ export interface IssueLayer {
  * Phase 레이어 — 현재 실행 중인 Phase의 컨텍스트. 매 Phase마다 동적으로 생성된다.
  */
 export interface PhaseLayer {
+  /** 이슈 정보 */
+  issue: {
+    /** 이슈 번호 */
+    number: number;
+    /** 이슈 제목 */
+    title: string;
+    /** 이슈 본문 */
+    body: string;
+    /** 이슈 라벨 목록 */
+    labels: string[];
+  };
+  /** 전체 계획 요약 */
+  planSummary: string;
   /** 현재 Phase 정보 */
   currentPhase: {
     /** 1-based Phase 인덱스 */
@@ -110,6 +125,17 @@ export interface PhaseLayer {
   };
   /** 이전 Phase 결과 요약 (없으면 빈 문자열) */
   previousResults: string;
+  /** 저장소 정보 */
+  repository: {
+    /** 저장소 소유자 */
+    owner: string;
+    /** 저장소 이름 */
+    name: string;
+    /** 베이스 브랜치 */
+    baseBranch: string;
+    /** 작업 브랜치 */
+    workBranch: string;
+  };
   /** 로케일 (선택, 기본값 ko) */
   locale?: string;
 }

--- a/src/prompt/template-renderer.ts
+++ b/src/prompt/template-renderer.ts
@@ -352,6 +352,117 @@ ${projectLayer.skillsContext ? `## 스킬 컨텍스트\n\n${projectLayer.skillsC
 ${projectLayer.pastFailures ? `## 과거 실패 사례\n\n${projectLayer.pastFailures}` : ''}`;
 }
 
+// ---------------------------------------------------------------------------
+// 캐시 친화적 조립 타입 및 함수
+// ---------------------------------------------------------------------------
+
+/**
+ * buildStaticLayers 반환값 — Base+Project 조립 결과
+ */
+export interface StaticLayersResult {
+  /** 정적 레이어(Base+Project) 조립 결과 문자열 */
+  content: string;
+  /** 정적 레이어 캐시 키 (16자리 hex) */
+  cacheKey: string;
+  /** 생성 시각 (ISO 8601) */
+  createdAt: string;
+}
+
+/**
+ * buildDynamicLayers 반환값 — Issue+Phase+Learning 변수 맵
+ */
+export interface DynamicLayersResult {
+  /** 템플릿 렌더링에 사용할 변수 맵 */
+  variables: TemplateVariables;
+}
+
+/**
+ * 정적 레이어(Base+Project)를 1회 조립합니다.
+ * 반환된 content는 Anthropic 프롬프트 캐싱에서 정적 블록으로 활용할 수 있습니다.
+ */
+export function buildStaticLayers(
+  base: BaseLayer,
+  project: ProjectLayer
+): StaticLayersResult {
+  const content = buildStaticContent(base, project);
+  const cacheKey = computeLayerCacheKey({
+    role: base.role,
+    conventions: project.conventions,
+    testCommand: project.testCommand,
+    lintCommand: project.lintCommand,
+  });
+  return {
+    content,
+    cacheKey,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * 동적 레이어(Issue+Phase+Learning)를 변수 맵으로 조립합니다.
+ * Phase마다 새로 생성하며, assembleFromCached에 전달합니다.
+ * phase 파라미터는 currentPhase와 previousResults만 사용합니다.
+ */
+export function buildDynamicLayers(
+  issue: IssueLayer,
+  phase: Pick<PhaseLayer, "currentPhase" | "previousResults">,
+  learning: LearningLayer
+): DynamicLayersResult {
+  const pastFailuresText = learning.pastFailures
+    .map(f => `- ${f.context}: ${f.message}${f.resolution ? ` (해결: ${f.resolution})` : ""}`)
+    .join("\n");
+
+  return {
+    variables: {
+      issue: {
+        number: String(issue.number),
+        title: issue.title,
+        body: issue.body,
+        labels: issue.labels,
+      },
+      plan: {
+        summary: issue.planSummary,
+      },
+      repository: issue.repository as unknown as TemplateVariables,
+      phase: {
+        index: String(phase.currentPhase.index),
+        totalCount: String(phase.currentPhase.totalCount),
+        name: phase.currentPhase.name,
+        description: phase.currentPhase.description,
+        files: phase.currentPhase.targetFiles,
+      },
+      previousPhases: {
+        summary: phase.previousResults,
+      },
+      pastFailures: pastFailuresText,
+      errorPatterns: learning.errorPatterns,
+      learnedPatterns: learning.learnedPatterns,
+    },
+  };
+}
+
+/**
+ * 캐시된 정적 레이어와 동적 레이어를 조합하여 최종 프롬프트를 생성합니다.
+ * templateContent는 동적 변수(issue, phase, learning 관련)를 참조하는 템플릿입니다.
+ * 정적 content(Base+Project)는 그대로 prepend되므로 Anthropic API에서 cache_control로 캐시 가능합니다.
+ */
+export function assembleFromCached(
+  staticResult: StaticLayersResult,
+  dynamicResult: DynamicLayersResult,
+  templateContent: string
+): AssembledPrompt {
+  const startTime = Date.now();
+  const renderedDynamic = renderTemplate(templateContent, dynamicResult.variables);
+  const content = `${staticResult.content}\n\n${renderedDynamic}`;
+
+  return {
+    content,
+    cacheKey: staticResult.cacheKey,
+    cacheHit: true,
+    assemblyTimeMs: Date.now() - startTime,
+  };
+}
+
 /**
  * PromptLayers(5계층) 여부를 판별하는 타입 가드
  */

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -266,73 +266,26 @@ export interface PlanRetryContext {
 
 // 프롬프트 레이어 분리를 위한 타입 정의
 
-// BaseLayer는 layer-types.ts와 동일 — import 후 re-export로 중복 제거
-import type { BaseLayer } from "../prompt/layer-types.js";
-export type { BaseLayer };
-
-// IssueLayer, LearningLayer, CacheKeyConfig, PromptLayers는 새 5계층 타입 — 호환성을 위해 re-export
-export type {
+// BaseLayer, ProjectLayer, PhaseLayer, IssueLayer, LearningLayer, CacheKeyConfig, PromptLayers는
+// layer-types.ts에서 단일 관리 — 호환성을 위해 re-export
+import type {
+  BaseLayer,
+  ProjectLayer,
+  PhaseLayer,
   IssueLayer,
   LearningLayer,
   CacheKeyConfig,
   PromptLayers,
 } from "../prompt/layer-types.js";
-
-/**
- * 프로젝트 레이어 - 프로젝트 수준 설정 (정적)
- * @note layer-types.ts의 ProjectLayer보다 pastFailures? 필드가 추가됨.
- *       template-renderer.ts에서 사용 중이므로 별도 유지.
- */
-export interface ProjectLayer {
-  /** 프로젝트 컨벤션 (CLAUDE.md 내용) */
-  conventions: string;
-  /** 프로젝트 구조 정보 */
-  structure: string;
-  /** 스킬 컨텍스트 */
-  skillsContext?: string;
-  /** 과거 실패 사례 */
-  pastFailures?: string;
-  /** 테스트 명령어 */
-  testCommand: string;
-  /** 린트 명령어 */
-  lintCommand: string;
-  /** 프로젝트 특정 안전 규칙 */
-  safetyRules: string[];
-}
-
-/**
- * Phase 레이어 - 현재 실행 컨텍스트 (동적)
- */
-export interface PhaseLayer {
-  /** 이슈 정보 */
-  issue: {
-    number: number;
-    title: string;
-    body: string;
-    labels: string[];
-  };
-  /** 전체 계획 요약 */
-  planSummary: string;
-  /** 현재 Phase 정보 */
-  currentPhase: {
-    index: number;
-    totalCount: number;
-    name: string;
-    description: string;
-    targetFiles: string[];
-  };
-  /** 이전 Phase 결과 요약 */
-  previousResults: string;
-  /** 저장소 정보 */
-  repository: {
-    owner: string;
-    name: string;
-    baseBranch: string;
-    workBranch: string;
-  };
-  /** 로케일 설정 */
-  locale?: string;
-}
+export type {
+  BaseLayer,
+  ProjectLayer,
+  PhaseLayer,
+  IssueLayer,
+  LearningLayer,
+  CacheKeyConfig,
+  PromptLayers,
+};
 
 /**
  * 조합된 프롬프트 레이어

--- a/tests/prompt/template-renderer.test.ts
+++ b/tests/prompt/template-renderer.test.ts
@@ -7,7 +7,10 @@ import {
   buildIssueLayer,
   buildLearningLayer,
   computeLayerCacheKey,
-  assemblePrompt
+  assemblePrompt,
+  buildStaticLayers,
+  buildDynamicLayers,
+  assembleFromCached,
 } from "../../src/prompt/template-renderer.js";
 import type { PromptLayer } from "../../src/types/pipeline.js";
 import type { PromptLayers } from "../../src/prompt/layer-types.js";
@@ -538,5 +541,244 @@ describe("assemblePrompt (5계층 PromptLayers)", () => {
     // Both produce valid 16-char hex keys
     expect(r3.cacheKey).toMatch(/^[a-f0-9]{16}$/);
     expect(r5.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+  });
+});
+
+describe("buildStaticLayers", () => {
+  it("should return content string from base and project layers", () => {
+    const base = buildBaseLayer({ role: "시니어 개발자" });
+    const project = buildProjectLayer({
+      conventions: "TypeScript + ESM",
+      testCommand: "npx vitest run",
+      lintCommand: "npx eslint src/",
+    });
+
+    const result = buildStaticLayers(base, project);
+
+    expect(result.content).toContain("시니어 개발자");
+    expect(result.content).toContain("TypeScript + ESM");
+    expect(result.content).toContain("npx vitest run");
+  });
+
+  it("should return a 16-char hex cache key", () => {
+    const base = buildBaseLayer({ role: "Developer" });
+    const project = buildProjectLayer({
+      conventions: "Conventions",
+      testCommand: "test",
+      lintCommand: "lint",
+    });
+
+    const result = buildStaticLayers(base, project);
+
+    expect(result.cacheKey).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("should produce consistent cache keys for identical inputs", () => {
+    const base = buildBaseLayer({ role: "Developer" });
+    const project = buildProjectLayer({
+      conventions: "Conventions",
+      testCommand: "test",
+      lintCommand: "lint",
+    });
+
+    const r1 = buildStaticLayers(base, project);
+    const r2 = buildStaticLayers(base, project);
+
+    expect(r1.cacheKey).toBe(r2.cacheKey);
+  });
+
+  it("should produce different cache keys for different conventions", () => {
+    const base = buildBaseLayer({ role: "Developer" });
+    const p1 = buildProjectLayer({ conventions: "TypeScript", testCommand: "test", lintCommand: "lint" });
+    const p2 = buildProjectLayer({ conventions: "JavaScript", testCommand: "test", lintCommand: "lint" });
+
+    const r1 = buildStaticLayers(base, p1);
+    const r2 = buildStaticLayers(base, p2);
+
+    expect(r1.cacheKey).not.toBe(r2.cacheKey);
+  });
+
+  it("should return an ISO 8601 createdAt timestamp", () => {
+    const base = buildBaseLayer({ role: "Developer" });
+    const project = buildProjectLayer({ conventions: "C", testCommand: "t", lintCommand: "l" });
+
+    const result = buildStaticLayers(base, project);
+
+    expect(result.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("buildDynamicLayers", () => {
+  function createTestInputs() {
+    const issue = buildIssueLayer({
+      number: 42,
+      title: "Dynamic Test Issue",
+      body: "Issue body",
+      labels: ["bug"],
+      repository: { owner: "org", name: "repo", baseBranch: "main", workBranch: "fix/42" },
+      planSummary: "Fix the bug in 2 phases",
+    });
+    const phase = {
+      currentPhase: {
+        index: 2,
+        totalCount: 3,
+        name: "Implementation",
+        description: "Implement the fix",
+        targetFiles: ["src/fix.ts"],
+      },
+      previousResults: "Phase 1: SUCCESS",
+    };
+    const learning = buildLearningLayer({
+      pastFailures: [{ context: "Phase 1", message: "Login error", resolution: "Run /login" }],
+      errorPatterns: ["Not logged in"],
+      learnedPatterns: ["Check auth first"],
+      updatedAt: "2026-04-12T00:00:00.000Z",
+    });
+    return { issue, phase, learning };
+  }
+
+  it("should include issue variables in the result", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    expect(result.variables.issue).toBeDefined();
+    const issueVars = result.variables.issue as Record<string, unknown>;
+    expect(issueVars["number"]).toBe("42");
+    expect(issueVars["title"]).toBe("Dynamic Test Issue");
+    expect(issueVars["labels"]).toEqual(["bug"]);
+  });
+
+  it("should include phase variables in the result", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    const phaseVars = result.variables.phase as Record<string, unknown>;
+    expect(phaseVars["index"]).toBe("2");
+    expect(phaseVars["totalCount"]).toBe("3");
+    expect(phaseVars["name"]).toBe("Implementation");
+    expect(phaseVars["files"]).toEqual(["src/fix.ts"]);
+  });
+
+  it("should include previous phase results", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    const prev = result.variables.previousPhases as Record<string, unknown>;
+    expect(prev["summary"]).toBe("Phase 1: SUCCESS");
+  });
+
+  it("should include learning layer data", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    expect(result.variables.errorPatterns).toEqual(["Not logged in"]);
+    expect(result.variables.learnedPatterns).toEqual(["Check auth first"]);
+    expect(result.variables.pastFailures).toContain("Phase 1");
+    expect(result.variables.pastFailures).toContain("Login error");
+    expect(result.variables.pastFailures).toContain("Run /login");
+  });
+
+  it("should include plan summary from issue layer", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    const plan = result.variables.plan as Record<string, unknown>;
+    expect(plan["summary"]).toBe("Fix the bug in 2 phases");
+  });
+
+  it("should include repository info from issue layer", () => {
+    const { issue, phase, learning } = createTestInputs();
+    const result = buildDynamicLayers(issue, phase, learning);
+
+    const repo = result.variables.repository as Record<string, unknown>;
+    expect(repo["owner"]).toBe("org");
+    expect(repo["name"]).toBe("repo");
+  });
+});
+
+describe("assembleFromCached", () => {
+  function createStaticAndDynamic() {
+    const base = buildBaseLayer({ role: "시니어 개발자" });
+    const project = buildProjectLayer({
+      conventions: "TypeScript + ESM",
+      testCommand: "npx vitest run",
+      lintCommand: "npx eslint src/",
+    });
+    const staticResult = buildStaticLayers(base, project);
+
+    const issue = buildIssueLayer({
+      number: 99,
+      title: "Cache Test Issue",
+      body: "Body",
+      labels: ["feature"],
+      repository: { owner: "org", name: "repo", baseBranch: "main", workBranch: "feat/99" },
+      planSummary: "Cached plan",
+    });
+    const phase = {
+      currentPhase: {
+        index: 1,
+        totalCount: 2,
+        name: "Phase One",
+        description: "First phase",
+        targetFiles: ["src/feature.ts"],
+      },
+      previousResults: "",
+    };
+    const learning = buildLearningLayer();
+    const dynamicResult = buildDynamicLayers(issue, phase, learning);
+
+    return { staticResult, dynamicResult };
+  }
+
+  it("should prepend static content before rendered template", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const template = "Issue #{{issue.number}}: {{issue.title}}";
+
+    const result = assembleFromCached(staticResult, dynamicResult, template);
+
+    expect(result.content).toContain("시니어 개발자");
+    expect(result.content).toContain("TypeScript + ESM");
+    expect(result.content).toContain("Issue #99: Cache Test Issue");
+    // static comes before dynamic
+    expect(result.content.indexOf("시니어 개발자")).toBeLessThan(result.content.indexOf("Issue #99"));
+  });
+
+  it("should use static cache key in result", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const result = assembleFromCached(staticResult, dynamicResult, "{{issue.title}}");
+
+    expect(result.cacheKey).toBe(staticResult.cacheKey);
+  });
+
+  it("should set cacheHit to true", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const result = assembleFromCached(staticResult, dynamicResult, "{{issue.title}}");
+
+    expect(result.cacheHit).toBe(true);
+  });
+
+  it("should render dynamic template variables", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const template = "Phase {{phase.index}}/{{phase.totalCount}}: {{phase.name}}\nRepo: {{repository.owner}}/{{repository.name}}";
+
+    const result = assembleFromCached(staticResult, dynamicResult, template);
+
+    expect(result.content).toContain("Phase 1/2: Phase One");
+    expect(result.content).toContain("Repo: org/repo");
+  });
+
+  it("should record assembly time", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const result = assembleFromCached(staticResult, dynamicResult, "{{issue.title}}");
+
+    expect(typeof result.assemblyTimeMs).toBe("number");
+    expect(result.assemblyTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should leave unresolved variables unchanged", () => {
+    const { staticResult, dynamicResult } = createStaticAndDynamic();
+    const result = assembleFromCached(staticResult, dynamicResult, "{{unknown.var}}");
+
+    expect(result.content).toContain("{{unknown.var}}");
   });
 });


### PR DESCRIPTION
## Summary

Resolves #509 — refactor: 프롬프트 레이어 구조 정의 + template-renderer 조립 함수

현재 5계층 레이어 타입과 빌더 함수는 구현되어 있으나, (1) types/pipeline.ts와 prompt/layer-types.ts 간 타입 중복/불일치가 있고, (2) "레이어 1-2는 1회 조립, 3-5만 Phase마다 갱신"하는 캐시 친화적 인터페이스가 명확하지 않음. Anthropic 프롬프트 캐싱 효과를 최대화하려면 정적 부분(Base+Project)을 별도로 캐시할 수 있는 API가 필요함.

## Requirements

- layer-types.ts를 single source of truth로 정리하고, pipeline.ts는 re-export로 변경
- 캐시 친화적 조립 인터페이스 추가: buildStaticLayers(), buildDynamicLayers(), assembleFromCached()
- 기존 assemblePrompt() 하위 호환성 유지
- 테스트 추가로 레이어 조립 로직 검증
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase 0: 타입 통합 및 정리 — SUCCESS (b8872ebf)
- Phase 1: 캐시 친화적 조립 함수 추가 — SUCCESS (ac71c94b)
- Phase 2: 테스트 추가 — SUCCESS (ac71c94b)

## Risks

- 기존 assemblePrompt() 호출 코드에 영향 가능 - 하위 호환성 유지 필수
- 타입 변경 시 pipeline 관련 코드에서 타입 에러 발생 가능

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/509-refactor-template-renderer` → `develop`
- **Tokens**: 167 input, 32678 output{{#stats.cacheCreationTokens}}, 266844 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 2743560 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #509