### PR TITLE
fix: WSL 환경 대시보드 접근 불가 — hostname 바인딩 제거

### DIFF
--- a/src/server/webhook-server.ts
+++ b/src/server/webhook-server.ts
@@ -75,7 +75,7 @@ export function startServer(
 ): { close: () => void } {
   let server: ReturnType<typeof serve>;
   try {
-    server = serve({ fetch: app.fetch, port, hostname: '127.0.0.1' });
+    server = serve({ fetch: app.fetch, port });
   } catch (err: unknown) {
     if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EADDRINUSE") {
       logger.warn(`포트 ${port}가 이미 사용 중입니다 (EADDRINUSE)`);
@@ -83,7 +83,7 @@ export function startServer(
     }
     throw err;
   }
-  logger.info(`AI Quartermaster server listening on 127.0.0.1:${port}`);
+  logger.info(`AI Quartermaster server listening on port ${port}`);
   return {
     close: () => {
       // @hono/node-server returns a Node http.Server

--- a/tests/server/webhook-server.test.ts
+++ b/tests/server/webhook-server.test.ts
@@ -221,7 +221,7 @@ describe("startServer", () => {
     const app = new Hono();
     const result = startServer(app, 3000);
 
-    expect(mockServe).toHaveBeenCalledWith({ fetch: app.fetch, port: 3000, hostname: '127.0.0.1' });
+    expect(mockServe).toHaveBeenCalledWith({ fetch: app.fetch, port: 3000 });
     expect(typeof result.close).toBe("function");
   });
 
@@ -231,7 +231,7 @@ describe("startServer", () => {
     const app = new Hono();
     startServer(app);
 
-    expect(mockServe).toHaveBeenCalledWith({ fetch: app.fetch, port: 3000, hostname: '127.0.0.1' });
+    expect(mockServe).toHaveBeenCalledWith({ fetch: app.fetch, port: 3000 });
   });
 
   it("calls server close when close is invoked", () => {


### PR DESCRIPTION
## Summary
- WSL2 환경에서 `hostname: '127.0.0.1'` 바인딩으로 윈도우 호스트 브라우저 접근 불가 수정
- hostname 제한 제거하여 0.0.0.0 바인딩으로 복원

## Test plan
- [ ] WSL 환경에서 대시보드 접근 확인
- [ ] `npx vitest run` 전체 통과