### PR TITLE
fix: 대시보드 instanceOwners 저장 실패 — Zod 스키마 필드 누락

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,6 +20,7 @@ const mergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
 const generalConfigUpdateSchema = z.object({
   projectName: z.string().min(1),
   instanceLabel: z.string(),
+  instanceOwners: z.array(z.string()),
   logLevel: logLevelSchema,
   logDir: z.string(),
   dryRun: z.boolean(),


### PR DESCRIPTION
## Summary
- `generalConfigUpdateSchema`에 `instanceOwners` 필드 누락으로 대시보드 Settings 저장 시 instanceOwners가 drop되던 버그 수정

## Test plan
- [ ] 대시보드 Settings에서 instanceOwners 입력 후 저장 → config.yml에 반영 확인