### PR TITLE
[AQ-#554] test: 프로젝트별 오버라이드 검증 테스트 보강

### DIFF
--- a/tests/config/project-override.test.ts
+++ b/tests/config/project-override.test.ts
@@ -282,4 +282,292 @@ describe("Project Override Integration Tests", () => {
       expect(resolved.review).toEqual(DEFAULT_CONFIG.review);
     });
   });
+
+  describe("cross-project isolation", () => {
+    it("should not leak project A overrides into project B", () => {
+      const baseConfig: AQConfig = {
+        ...structuredClone(DEFAULT_CONFIG),
+        general: { ...DEFAULT_CONFIG.general, projectName: "test" },
+        git: { ...DEFAULT_CONFIG.git, allowedRepos: [] },
+        projects: [
+          {
+            repo: "myorg/project-a",
+            path: "/home/user/project-a",
+            commands: {
+              test: "yarn test",
+              claudeCli: { model: "claude-haiku-4-5-20251001" },
+            },
+          },
+          {
+            repo: "myorg/project-b",
+            path: "/home/user/project-b",
+            safety: {
+              maxPhases: 3,
+              allowedLabels: ["b-label"],
+            },
+          },
+        ],
+      };
+
+      const resolvedA = resolveProject("myorg/project-a", baseConfig);
+      const resolvedB = resolveProject("myorg/project-b", baseConfig);
+
+      // A's overrides are applied to A
+      expect(resolvedA.commands.test).toBe("yarn test");
+      expect(resolvedA.commands.claudeCli.model).toBe("claude-haiku-4-5-20251001");
+
+      // A's overrides do NOT appear in B
+      expect(resolvedB.commands.test).toBe(DEFAULT_CONFIG.commands.test);
+      expect(resolvedB.commands.claudeCli.model).toBe(DEFAULT_CONFIG.commands.claudeCli.model);
+
+      // B's overrides are applied to B
+      expect(resolvedB.safety.maxPhases).toBe(3);
+      expect(resolvedB.safety.allowedLabels).toEqual(["b-label"]);
+
+      // B's overrides do NOT appear in A
+      expect(resolvedA.safety.maxPhases).toBe(DEFAULT_CONFIG.safety.maxPhases);
+      expect(resolvedA.safety.allowedLabels).toEqual(DEFAULT_CONFIG.safety.allowedLabels);
+    });
+
+    it("should produce independent result objects for each project", () => {
+      const baseConfig: AQConfig = {
+        ...structuredClone(DEFAULT_CONFIG),
+        general: { ...DEFAULT_CONFIG.general, projectName: "test" },
+        git: { ...DEFAULT_CONFIG.git, allowedRepos: [] },
+        projects: [
+          { repo: "myorg/proj-x", path: "/home/user/proj-x", commands: { test: "jest" } },
+          { repo: "myorg/proj-y", path: "/home/user/proj-y", commands: { test: "mocha" } },
+        ],
+      };
+
+      const resolvedX = resolveProject("myorg/proj-x", baseConfig);
+      const resolvedY = resolveProject("myorg/proj-y", baseConfig);
+
+      expect(resolvedX.commands.test).toBe("jest");
+      expect(resolvedY.commands.test).toBe("mocha");
+
+      // Mutating one result does not affect the other
+      resolvedX.commands.test = "mutated";
+      expect(resolvedY.commands.test).toBe("mocha");
+    });
+  });
+
+  describe("global fallback", () => {
+    const createFallbackConfig = (repo: string): AQConfig => ({
+      ...structuredClone(DEFAULT_CONFIG),
+      general: { ...DEFAULT_CONFIG.general, projectName: "test", targetRoot: "/home/user/fallback" },
+      git: { ...DEFAULT_CONFIG.git, allowedRepos: [repo] },
+      projects: [],
+    });
+
+    it("should return global config for repo in allowedRepos but not in projects", () => {
+      const config = createFallbackConfig("myorg/fallback-repo");
+      const resolved = resolveProject("myorg/fallback-repo", config);
+
+      expect(resolved.commands).toEqual(DEFAULT_CONFIG.commands);
+      expect(resolved.safety).toEqual(DEFAULT_CONFIG.safety);
+      expect(resolved.review).toEqual(DEFAULT_CONFIG.review);
+      expect(resolved.pr).toEqual(DEFAULT_CONFIG.pr);
+    });
+
+    it("should use global git config for baseBranch and branchTemplate on fallback", () => {
+      const config = createFallbackConfig("myorg/fallback-repo");
+      const resolved = resolveProject("myorg/fallback-repo", config);
+
+      expect(resolved.baseBranch).toBe(DEFAULT_CONFIG.git.defaultBaseBranch);
+      expect(resolved.branchTemplate).toBe(DEFAULT_CONFIG.git.branchTemplate);
+    });
+
+    it("should throw when repo is not in projects or allowedRepos", () => {
+      const config: AQConfig = {
+        ...structuredClone(DEFAULT_CONFIG),
+        general: { ...DEFAULT_CONFIG.general, projectName: "test" },
+        git: { ...DEFAULT_CONFIG.git, allowedRepos: [] },
+        projects: [],
+      };
+
+      expect(() => resolveProject("myorg/unknown-repo", config)).toThrow(
+        "myorg/unknown-repo"
+      );
+    });
+
+    it("should throw when fallback path is not configured", () => {
+      const config: AQConfig = {
+        ...structuredClone(DEFAULT_CONFIG),
+        general: { ...DEFAULT_CONFIG.general, projectName: "test", targetRoot: undefined },
+        git: { ...DEFAULT_CONFIG.git, allowedRepos: ["myorg/no-path-repo"] },
+        projects: [],
+      };
+
+      expect(() => resolveProject("myorg/no-path-repo", config)).toThrow(
+        "myorg/no-path-repo"
+      );
+    });
+  });
+
+  describe("PR override", () => {
+    it("should override specific pr settings while preserving others", () => {
+      const config = createTestConfig("myorg/pr-override", "/home/user/pr-override", {
+        pr: {
+          draft: false,
+          labels: ["feature", "auto-pr"],
+          mergeMethod: "merge",
+        },
+      });
+
+      const resolved = resolveProject("myorg/pr-override", config);
+
+      // Overridden fields
+      expect(resolved.pr.draft).toBe(false);
+      expect(resolved.pr.labels).toEqual(["feature", "auto-pr"]);
+      expect(resolved.pr.mergeMethod).toBe("merge");
+
+      // Inherited fields
+      expect(resolved.pr.targetBranch).toBe(DEFAULT_CONFIG.pr.targetBranch);
+      expect(resolved.pr.titleTemplate).toBe(DEFAULT_CONFIG.pr.titleTemplate);
+      expect(resolved.pr.bodyTemplate).toBe(DEFAULT_CONFIG.pr.bodyTemplate);
+      expect(resolved.pr.assignees).toEqual(DEFAULT_CONFIG.pr.assignees);
+      expect(resolved.pr.reviewers).toEqual(DEFAULT_CONFIG.pr.reviewers);
+      expect(resolved.pr.linkIssue).toBe(DEFAULT_CONFIG.pr.linkIssue);
+      expect(resolved.pr.autoMerge).toBe(DEFAULT_CONFIG.pr.autoMerge);
+    });
+
+    it("should merge pr override with all fields specified", () => {
+      const config = createTestConfig("myorg/full-pr-override", "/home/user/full-pr-override", {
+        pr: {
+          targetBranch: "develop",
+          draft: true,
+          titleTemplate: "[CUSTOM] {{title}}",
+          bodyTemplate: "## Custom Body\n\n{summary}",
+          labels: ["custom"],
+          assignees: ["dev1"],
+          reviewers: ["reviewer1"],
+          linkIssue: false,
+          autoMerge: true,
+          mergeMethod: "rebase",
+        },
+      });
+
+      const resolved = resolveProject("myorg/full-pr-override", config);
+
+      expect(resolved.pr.targetBranch).toBe("develop");
+      expect(resolved.pr.draft).toBe(true);
+      expect(resolved.pr.titleTemplate).toBe("[CUSTOM] {{title}}");
+      expect(resolved.pr.bodyTemplate).toBe("## Custom Body\n\n{summary}");
+      expect(resolved.pr.labels).toEqual(["custom"]);
+      expect(resolved.pr.assignees).toEqual(["dev1"]);
+      expect(resolved.pr.reviewers).toEqual(["reviewer1"]);
+      expect(resolved.pr.linkIssue).toBe(false);
+      expect(resolved.pr.autoMerge).toBe(true);
+      expect(resolved.pr.mergeMethod).toBe("rebase");
+    });
+  });
+
+  describe("deepMerge edge cases", () => {
+    it("should replace array fields (not concat) when overridden", () => {
+      const config = createTestConfig("myorg/array-replace", "/home/user/array-replace", {
+        commands: {
+          claudeCli: {
+            additionalArgs: ["--new-flag"],
+          },
+        },
+        safety: {
+          sensitivePaths: [".env.local"],
+        },
+      });
+
+      const resolved = resolveProject("myorg/array-replace", config);
+
+      // Arrays are replaced, not concatenated
+      expect(resolved.commands.claudeCli.additionalArgs).toEqual(["--new-flag"]);
+      expect(resolved.commands.claudeCli.additionalArgs).not.toContain(
+        ...(DEFAULT_CONFIG.commands.claudeCli.additionalArgs.length > 0
+          ? [DEFAULT_CONFIG.commands.claudeCli.additionalArgs[0]]
+          : ["__never__"])
+      );
+
+      expect(resolved.safety.sensitivePaths).toEqual([".env.local"]);
+      expect(resolved.safety.sensitivePaths).not.toEqual(
+        expect.arrayContaining(DEFAULT_CONFIG.safety.sensitivePaths)
+      );
+    });
+
+    it("should replace empty array override (not keep defaults)", () => {
+      const config = createTestConfig("myorg/empty-array", "/home/user/empty-array", {
+        safety: {
+          allowedLabels: [],
+          sensitivePaths: [],
+        },
+      });
+
+      const resolved = resolveProject("myorg/empty-array", config);
+
+      expect(resolved.safety.allowedLabels).toEqual([]);
+      expect(resolved.safety.sensitivePaths).toEqual([]);
+    });
+
+    it("should handle project with undefined optional fields gracefully", () => {
+      const config = createTestConfig("myorg/undefined-fields", "/home/user/undefined-fields", {
+        commands: {
+          claudeCli: {
+            retry: undefined,
+          },
+        },
+      });
+
+      // Should not throw
+      expect(() => resolveProject("myorg/undefined-fields", config)).not.toThrow();
+
+      const resolved = resolveProject("myorg/undefined-fields", config);
+      // Other commands fields are still inherited
+      expect(resolved.commands.claudeCli.path).toBe(DEFAULT_CONFIG.commands.claudeCli.path);
+      expect(resolved.commands.claudeCli.maxTurns).toBe(DEFAULT_CONFIG.commands.claudeCli.maxTurns);
+    });
+  });
+
+  describe("DEFAULT_CONFIG immutability", () => {
+    it("should not mutate DEFAULT_CONFIG after resolveProject with overrides", () => {
+      const snapshot = structuredClone(DEFAULT_CONFIG);
+
+      const config = createTestConfig("myorg/mutation-check", "/home/user/mutation-check", {
+        commands: {
+          test: "yarn test",
+          claudeCli: {
+            model: "claude-haiku-4-5-20251001",
+            additionalArgs: ["--injected"],
+          },
+        },
+        safety: {
+          maxPhases: 99,
+          sensitivePaths: ["injected/**"],
+        },
+        review: {
+          enabled: false,
+          rounds: [],
+        },
+        pr: {
+          draft: false,
+          labels: ["mutated"],
+        },
+      });
+
+      resolveProject("myorg/mutation-check", config);
+
+      expect(DEFAULT_CONFIG).toEqual(snapshot);
+    });
+
+    it("should not mutate DEFAULT_CONFIG after multiple resolveProject calls", () => {
+      const snapshot = structuredClone(DEFAULT_CONFIG);
+
+      for (let i = 0; i < 3; i++) {
+        const config = createTestConfig(`myorg/multi-call-${i}`, `/home/user/multi-call-${i}`, {
+          commands: { test: `run-${i}` },
+          safety: { maxPhases: i + 1 },
+        });
+        resolveProject(`myorg/multi-call-${i}`, config);
+      }
+
+      expect(DEFAULT_CONFIG).toEqual(snapshot);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves #554 — test: 프로젝트별 오버라이드 검증 테스트 보강

현재 `tests/config/project-override.test.ts`에 commands/safety/review 기본 오버라이드 테스트가 있으나, **프로젝트 간 독립성 검증**(A 프로젝트 오버라이드가 B에 누출되지 않는지), **글로벌 fallback 경로**, **deepMerge 엣지케이스**(배열 대체, null/undefined 처리), **PR 오버라이드** 검증이 미비함. `resolveProject()`의 병합 로직 전체 경로를 커버하는 테스트 보강 필요.

## Requirements

- 프로젝트 간 오버라이드 독립성 검증 — A 프로젝트 설정이 B 프로젝트에 영향 없음을 확인
- 글로벌 fallback 경로 검증 — allowedRepos에만 등록된 프로젝트는 글로벌 config 그대로 사용
- PR 오버라이드 검증 — pr 설정도 프로젝트별 독립 적용 확인
- deepMerge 엣지케이스 — 배열은 대체(concat 아님), null/undefined 소스 처리
- 오버라이드 적용 후 원본 DEFAULT_CONFIG 불변성 검증
- npx tsc --noEmit 통과
- npx vitest run 전체 통과

## Implementation Phases

- Phase 0: 프로젝트 간 독립성 + 전체 경로 테스트 추가 — SUCCESS (56b73841)

## Risks

- deepMerge의 배열 대체 동작이 기대와 다를 경우 테스트 실패 가능 — loader.ts의 deepMerge 구현 확인 완료: 배열은 source로 대체됨
- DEFAULT_CONFIG의 structuredClone이 테스트 환경에서 정상 동작하는지 — Node.js 20+ 이므로 문제 없음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 1/1 completed
- **Branch**: `aq/554-test` → `develop`
- **Tokens**: 26 input, 7890 output{{#stats.cacheCreationTokens}}, 89981 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 341411 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #554