### PR TITLE
[AQ-#571] fix: 저장소 뷰 목업 데이터 제거 — 실제 API 연결

### DIFF
--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -43,9 +43,9 @@ function navigateTo(view) {
     loadSettings();
   }
 
-  // If navigating to repositories view, render it
+  // If navigating to repositories view, load from API
   if (view === 'repositories') {
-    renderRepositoriesView(MOCK_REPOS, MOCK_STORAGE);
+    loadRepositories();
   }
 
   // If navigating to automations view, render it

--- a/src/server/public/js/render.js
+++ b/src/server/public/js/render.js
@@ -803,38 +803,34 @@ function renderObjectInput(fieldId, value, configPath, isReadonly) {
    Repositories View
    ══════════════════════════════════════════════════════════════ */
 
-var MOCK_REPOS = [
-  {
-    repo: 'myorg/api-service',
-    path: '/home/user/workspace/api-service',
-    baseBranch: 'main',
-    totalJobs: 23,
-    successRate: 87,
-    totalCostUsd: 4.32,
-    worktreeCount: 2,
-    lastActiveAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    isActive: true,
-    health: 'stable'
-  },
-  {
-    repo: 'myorg/frontend',
-    path: '/home/user/workspace/frontend',
-    baseBranch: 'develop',
-    totalJobs: 8,
-    successRate: 100,
-    totalCostUsd: 1.20,
-    worktreeCount: 1,
-    lastActiveAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
-    isActive: false,
-    health: 'local-missing'
-  }
-];
-
-var MOCK_STORAGE = {
-  dbSizeBytes: 1288490188,
-  logSizeBytes: 471859200,
-  retentionPct: 65
-};
+function loadRepositories() {
+  apiFetch('/api/repositories')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var repos = (data.repositories || []).map(function(item) {
+        var localPathStatus = item.health && item.health.localPath ? item.health.localPath.status : 'ok';
+        var health = localPathStatus === 'error' ? 'local-missing' : (item.status === 'healthy' ? 'stable' : item.status);
+        var stats = item.stats || {};
+        var lastActivity = stats.lastActivity || null;
+        var isActive = lastActivity !== null && (Date.now() - new Date(lastActivity).getTime()) < 7 * 24 * 60 * 60 * 1000;
+        return {
+          repo: item.repository || item.name,
+          path: item.path,
+          totalJobs: stats.totalJobs || 0,
+          successRate: stats.successRate,
+          totalCostUsd: stats.totalCostUsd || 0,
+          worktreeCount: item.worktreeCount || 0,
+          lastActiveAt: lastActivity,
+          isActive: isActive,
+          health: health
+        };
+      });
+      renderRepositoriesView(repos, {});
+    })
+    .catch(function() {
+      renderRepositoriesView([], {});
+    });
+}
 
 function fmtBytes(bytes) {
   if (bytes === null || bytes === undefined) return '—';
@@ -995,14 +991,14 @@ function renderRepositoriesView(repos, storageData) {
   renderStorageSection(storageData);
 }
 
-// Hook into navigateTo for repositories view (mock data until API is connected)
+// Hook into navigateTo for repositories view
 document.addEventListener('DOMContentLoaded', function() {
   var orig = window.navigateTo;
   if (typeof orig === 'function') {
     window.navigateTo = function(view) {
       orig(view);
       if (view === 'repositories') {
-        renderRepositoriesView(MOCK_REPOS, MOCK_STORAGE);
+        loadRepositories();
       }
     };
   }


### PR DESCRIPTION
## Summary

Resolves #571 — fix: 저장소 뷰 목업 데이터 제거 — 실제 API 연결

저장소(Repositories) 뷰가 MOCK_REPOS, MOCK_STORAGE 하드코딩 데이터로 렌더링 중. 실제 API는 이미 구현되어 있음 (GET /api/repositories — health + stats 포함). 목업 데이터를 제거하고 실제 API를 호출하여 렌더링하도록 변경 필요.

## Requirements

- MOCK_REPOS, MOCK_STORAGE 하드코딩 데이터 완전 제거
- GET /api/repositories 호출로 실제 데이터 fetch
- API 응답 형식(repository, path, status, worktreeCount, stats.*)을 renderRepoCard가 기대하는 형식으로 매핑
- 로딩/에러 상태 처리 (빈 프로젝트 포함)
- storage 섹션은 API 미제공이므로 숨기거나 별도 처리

## Implementation Phases

- Phase 0: API 연결 함수 추가 및 목업 제거 — SUCCESS (78b0d18a)
- Phase 1: app.js 네비게이션 훅 연결 — SUCCESS (8328f720)
- Phase 2: 타입체크 및 동작 검증 — SUCCESS (8328f720)

## Risks

- storage 섹션(dbSizeBytes, logSizeBytes, retentionPct)은 현재 API에 해당 엔드포인트가 없음 — 빈 데이터로 렌더링하거나 섹션 숨김 처리 필요
- API 호출 실패 시 빈 화면 방지를 위한 에러 핸들링 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/571-fix-api` → `develop`
- **Tokens**: 87 input, 11495 output{{#stats.cacheCreationTokens}}, 152577 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1031616 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #571