### PR TITLE
[AQ-#572] fix: 폴링 디스패치 중복 호출 스팸 — 동일 이슈 초당 수십 번 디스패치 시도

### DIFF
--- a/src/polling/issue-poller.ts
+++ b/src/polling/issue-poller.ts
@@ -252,16 +252,12 @@ export class IssuePoller {
     let newIssuesFound = 0;
 
     for (const issue of issues) {
-      if (this.store.shouldBlockRepickup(issue.number, repo)) {
-        const existingJob = this.store.findAnyByIssue(issue.number, repo);
-        if (existingJob) {
-          if (existingJob.status === "running" || existingJob.status === "queued") {
-            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 처리 중), 건너뜀`);
-          } else {
-            logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 존재), 건너뜀`);
-          }
+      const existingJob = this.store.findAnyByIssue(issue.number, repo);
+      if (existingJob) {
+        if (existingJob.status === "running" || existingJob.status === "queued") {
+          logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 처리 중), 건너뜀`);
         } else {
-          logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단, 건너뜀`);
+          logger.debug(`이슈 #${issue.number} (${repo}) — 재픽업 차단 (${existingJob.status} 상태 잡 존재), 건너뜀`);
         }
         continue;
       }

--- a/src/server/event-dispatcher.ts
+++ b/src/server/event-dispatcher.ts
@@ -116,6 +116,20 @@ export function dispatchEvent(
     }
   }
 
+  // Check for active (queued/running) job to prevent duplicate webhook dispatch
+  if (store) {
+    const activeJob = store.findAnyByIssue(payload.issue.number, repo);
+    if (activeJob && (activeJob.status === "queued" || activeJob.status === "running")) {
+      logger.debug(
+        `Skipping dispatch for issue #${payload.issue.number} in ${repo} — active job ${activeJob.id} (${activeJob.status})`
+      );
+      return {
+        shouldProcess: false,
+        reason: `Active job already exists for issue #${payload.issue.number} (${activeJob.status})`,
+      };
+    }
+  }
+
   logger.info(`Dispatching pipeline for issue #${payload.issue.number} in ${repo}`);
 
   return {

--- a/tests/e2e/polling-integration.test.ts
+++ b/tests/e2e/polling-integration.test.ts
@@ -259,16 +259,16 @@ describe("E2E: polling integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2b. Success jobs do NOT block — re-labeling triggers re-processing
+  // 2b. Success jobs block re-pickup from pollProjectLabel (스팸 방지)
   // -------------------------------------------------------------------------
-  it("allows re-pickup of success jobs (re-label triggers new processing)", async () => {
-    // Issue #10 has a success job — re-labeling should trigger new processing
+  it("skips re-pickup of success jobs in pollProjectLabel (spam prevention)", async () => {
+    // Issue #10 has a success job — pollProjectLabel should skip it to prevent spam
     const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "success" }]);
     const queue = makeJobQueue(store);
 
     mockRunCli.mockResolvedValue({
       stdout: makeGhIssueListResponse([
-        { number: 10, title: "Add feature A" }, // has success job - should be re-enqueued
+        { number: 10, title: "Add feature A" }, // has success job - should be skipped
       ]),
       stderr: "",
       exitCode: 0,
@@ -277,26 +277,26 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // The success issue should be re-enqueued (success does not block re-pickup)
-    expect(queue.enqueue).toHaveBeenCalledTimes(1);
-    expect(queue.enqueue).toHaveBeenCalledWith(10, "test/repo");
+    // pollProjectLabel should NOT re-enqueue - success job blocks re-pickup
+    expect(queue.enqueue).not.toHaveBeenCalledWith(10, "test/repo");
 
-    // Original success job should be archived
+    // Original success job should remain unchanged (not archived by poller)
     const originalJob = store.get("aq-10-0");
-    expect(originalJob?.status).toBe("archived");
+    expect(originalJob?.status).toBe("success");
   });
 
   // -------------------------------------------------------------------------
-  // 3. Failed jobs should allow re-pickup (do not block)
+  // 3. Failed jobs block re-pickup from pollProjectLabel (스팸 방지)
   // -------------------------------------------------------------------------
-  it("allows re-pickup of issues with failed jobs", async () => {
-    // Issue #10 has a failed job - should allow re-pickup
+  it("skips re-pickup of issues with failed jobs in pollProjectLabel (spam prevention)", async () => {
+    // Issue #10 has a failed job — pollProjectLabel should skip it to prevent spam
+    // (retry is handled by pollFailedJobs separately with 10-minute delay)
     const store = makeJobStore([{ issueNumber: 10, repo: "test/repo", status: "failure" }]);
     const queue = makeJobQueue(store);
 
     mockRunCli.mockResolvedValue({
       stdout: makeGhIssueListResponse([
-        { number: 10, title: "Add feature A" }, // has failed job - should be re-enqueued
+        { number: 10, title: "Add feature A" }, // has failed job - should be skipped
       ]),
       stderr: "",
       exitCode: 0,
@@ -305,9 +305,8 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // The failed issue should be re-enqueued
-    expect(queue.enqueue).toHaveBeenCalledTimes(1);
-    expect(queue.enqueue).toHaveBeenCalledWith(10, "test/repo");
+    // pollProjectLabel should NOT re-enqueue - failure job blocks re-pickup
+    expect(queue.enqueue).not.toHaveBeenCalledWith(10, "test/repo");
   });
 
   // -------------------------------------------------------------------------
@@ -384,28 +383,14 @@ describe("E2E: polling integration", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 6. Full integration scenario: failed job → re-polling → auto-archive → new job → cleanup
+  // 6. pollProjectLabel은 failure job 있는 이슈를 스킵한다 (스팸 방지)
   // -------------------------------------------------------------------------
-  it("handles full re-pickup scenario: failed job → polling → auto-archive → new job creation", async () => {
+  it("skips failed job issues in pollProjectLabel (no auto-archive, no new job from poller)", async () => {
     // Start with a failed job for issue #20
     const store = makeJobStore([{ issueNumber: 20, repo: "test/repo", status: "failure" }]);
     const queue = makeJobQueue(store);
 
-    // Mock checkpoint with worktree to simulate cleanup scenario
-    mockLoadCheckpoint.mockReturnValue({
-      jobId: "aq-20-0",
-      issueNumber: 20,
-      repo: "test/repo",
-      state: "failed",
-      worktreePath: "/tmp/test-worktree-20",
-      branchName: "aq/20-fix-critical-bug",
-      projectRoot: "/tmp/project",
-      phaseResults: [],
-      mode: "auto",
-      savedAt: new Date().toISOString(),
-    });
-
-    // Mock GitHub returning the same issue again (simulating re-pickup)
+    // Mock GitHub returning the same issue again
     mockRunCli.mockResolvedValue({
       stdout: makeGhIssueListResponse([
         { number: 20, title: "Fix critical bug", labels: ["aq-task"] },
@@ -415,73 +400,31 @@ describe("E2E: polling integration", () => {
     });
 
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
-
-    // Manually trigger one poll cycle
     await (poller as any).poll();
 
-    // Verify the workflow:
-    // 1. Queue.enqueue should have been called (re-pickup detected)
-    expect(queue.enqueue).toHaveBeenCalledTimes(1);
-    expect(queue.enqueue).toHaveBeenCalledWith(20, "test/repo");
+    // pollProjectLabel should NOT enqueue - failure job blocks re-pickup
+    expect(queue.enqueue).not.toHaveBeenCalledWith(20, "test/repo");
 
-    // 2. Checkpoint should be loaded to check for worktree
-    expect(mockLoadCheckpoint).toHaveBeenCalledWith(expect.any(String), 20);
+    // No cleanup should be triggered from pollProjectLabel
+    expect(mockLoadCheckpoint).not.toHaveBeenCalled();
+    expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(mockRemoveCheckpoint).not.toHaveBeenCalled();
 
-    // 3. Worktree cleanup should have been triggered
-    expect(mockRemoveWorktree).toHaveBeenCalledWith(
-      expect.any(Object), // gitConfig
-      "/tmp/test-worktree-20",
-      expect.objectContaining({ force: true })
-    );
-
-    // 4. Checkpoint removal should have been triggered
-    expect(mockRemoveCheckpoint).toHaveBeenCalledWith(expect.any(String), 20);
-
-    // 5. Original failed job should be archived
-    const originalJob = store.get("aq-20-0"); // First job created in makeJobStore
-    expect(originalJob?.status).toBe("archived");
-
-    // 6. New job should be created
-    expect(store.create).toHaveBeenCalledWith(20, "test/repo");
+    // Original failed job should remain unchanged
+    const originalJob = store.get("aq-20-0");
+    expect(originalJob?.status).toBe("failure");
   });
 
   // -------------------------------------------------------------------------
-  // 7. Cleanup verification: checkpoint removal is called for failed jobs during re-pickup
+  // 7. pollProjectLabel은 failure/cancelled job 있는 이슈를 모두 스킵한다
   // -------------------------------------------------------------------------
-  it("ensures worktree/branch cleanup occurs during failed job re-pickup", async () => {
-    // Start with multiple failed jobs
+  it("skips all issues with failure or cancelled jobs in pollProjectLabel", async () => {
+    // Start with multiple failed/cancelled jobs
     const store = makeJobStore([
       { issueNumber: 30, repo: "test/repo", status: "failure" },
       { issueNumber: 31, repo: "test/repo", status: "cancelled" },
     ]);
     const queue = makeJobQueue(store);
-
-    // Mock checkpoints with worktrees for both issues
-    mockLoadCheckpoint
-      .mockReturnValueOnce({
-        jobId: "aq-30-0",
-        issueNumber: 30,
-        repo: "test/repo",
-        state: "failed",
-        worktreePath: "/tmp/test-worktree-30",
-        branchName: "aq/30-failed-feature-a",
-        projectRoot: "/tmp/project",
-        phaseResults: [],
-        mode: "auto",
-        savedAt: new Date().toISOString(),
-      })
-      .mockReturnValueOnce({
-        jobId: "aq-31-1",
-        issueNumber: 31,
-        repo: "test/repo",
-        state: "cancelled",
-        worktreePath: "/tmp/test-worktree-31",
-        branchName: "aq/31-cancelled-feature-b",
-        projectRoot: "/tmp/project",
-        phaseResults: [],
-        mode: "auto",
-        savedAt: new Date().toISOString(),
-      });
 
     // Mock GitHub returning both issues again
     mockRunCli.mockResolvedValue({
@@ -496,49 +439,30 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // Both issues should trigger re-pickup
-    expect(queue.enqueue).toHaveBeenCalledTimes(2);
-    expect(queue.enqueue).toHaveBeenCalledWith(30, "test/repo");
-    expect(queue.enqueue).toHaveBeenCalledWith(31, "test/repo");
+    // Neither issue should be re-enqueued from pollProjectLabel
+    expect(queue.enqueue).not.toHaveBeenCalledWith(30, "test/repo");
+    expect(queue.enqueue).not.toHaveBeenCalledWith(31, "test/repo");
 
-    // Checkpoint should be loaded for both issues
-    expect(mockLoadCheckpoint).toHaveBeenCalledWith(expect.any(String), 30);
-    expect(mockLoadCheckpoint).toHaveBeenCalledWith(expect.any(String), 31);
+    // No cleanup triggered from pollProjectLabel
+    expect(mockLoadCheckpoint).not.toHaveBeenCalled();
+    expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(mockRemoveCheckpoint).not.toHaveBeenCalled();
 
-    // Worktree cleanup should be called for both failed jobs
-    expect(mockRemoveWorktree).toHaveBeenCalledTimes(2);
-    expect(mockRemoveWorktree).toHaveBeenCalledWith(
-      expect.any(Object),
-      "/tmp/test-worktree-30",
-      expect.objectContaining({ force: true })
-    );
-    expect(mockRemoveWorktree).toHaveBeenCalledWith(
-      expect.any(Object),
-      "/tmp/test-worktree-31",
-      expect.objectContaining({ force: true })
-    );
-
-    // Checkpoint removal should be called twice (once per failed job)
-    expect(mockRemoveCheckpoint).toHaveBeenCalledTimes(2);
-    expect(mockRemoveCheckpoint).toHaveBeenCalledWith(expect.any(String), 30);
-    expect(mockRemoveCheckpoint).toHaveBeenCalledWith(expect.any(String), 31);
-
-    // Both original jobs should be archived
+    // Original jobs should remain unchanged
     const failedJob = store.get("aq-30-0");
     const cancelledJob = store.get("aq-31-1");
-    expect(failedJob?.status).toBe("archived");
-    expect(cancelledJob?.status).toBe("archived");
+    expect(failedJob?.status).toBe("failure");
+    expect(cancelledJob?.status).toBe("cancelled");
   });
 
   // -------------------------------------------------------------------------
-  // 8. Verifies that worktree cleanup is not called when no checkpoint or worktree exists
+  // 8. failure job 있는 이슈는 pollProjectLabel에서 스킵됨 (cleanup 없음)
   // -------------------------------------------------------------------------
-  it("skips worktree cleanup when no checkpoint or worktree path exists", async () => {
-    // Start with a failed job but no checkpoint/worktree
+  it("does not trigger checkpoint or worktree cleanup from pollProjectLabel for failed jobs", async () => {
+    // Start with a failed job
     const store = makeJobStore([{ issueNumber: 40, repo: "test/repo", status: "failure" }]);
     const queue = makeJobQueue(store);
 
-    // Mock loadCheckpoint to return null (no checkpoint found)
     mockLoadCheckpoint.mockReturnValue(null);
 
     // Mock GitHub returning the issue again
@@ -553,39 +477,33 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // Issue should trigger re-pickup
-    expect(queue.enqueue).toHaveBeenCalledTimes(1);
-    expect(queue.enqueue).toHaveBeenCalledWith(40, "test/repo");
+    // Issue should be SKIPPED - no re-pickup from pollProjectLabel
+    expect(queue.enqueue).not.toHaveBeenCalledWith(40, "test/repo");
 
-    // Checkpoint should be loaded
-    expect(mockLoadCheckpoint).toHaveBeenCalledWith(expect.any(String), 40);
-
-    // Worktree cleanup should NOT be called since no checkpoint was found
+    // No cleanup triggered
+    expect(mockLoadCheckpoint).not.toHaveBeenCalled();
     expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(mockRemoveCheckpoint).not.toHaveBeenCalled();
 
-    // Checkpoint removal should still be called (even if no checkpoint exists)
-    expect(mockRemoveCheckpoint).toHaveBeenCalledWith(expect.any(String), 40);
-
-    // Original job should be archived
+    // Original job should remain as failure
     const failedJob = store.get("aq-40-0");
-    expect(failedJob?.status).toBe("archived");
+    expect(failedJob?.status).toBe("failure");
   });
 
   // -------------------------------------------------------------------------
-  // 9. Verifies that worktree cleanup is not called when checkpoint exists but has no worktree path
+  // 9. failure job 있는 이슈는 worktree 유무와 관계없이 스킵됨
   // -------------------------------------------------------------------------
-  it("skips worktree cleanup when checkpoint exists but has no worktree path", async () => {
+  it("skips failed job issue regardless of checkpoint state", async () => {
     // Start with a failed job
     const store = makeJobStore([{ issueNumber: 50, repo: "test/repo", status: "failure" }]);
     const queue = makeJobQueue(store);
 
-    // Mock checkpoint without worktree path
+    // Even if checkpoint exists, pollProjectLabel should not trigger cleanup
     mockLoadCheckpoint.mockReturnValue({
       jobId: "aq-50-0",
       issueNumber: 50,
       repo: "test/repo",
       state: "failed",
-      // No worktreePath field
       branchName: "aq/50-no-worktree",
       projectRoot: "/tmp/project",
       phaseResults: [],
@@ -605,22 +523,17 @@ describe("E2E: polling integration", () => {
     poller = new IssuePoller(makeConfig(), store as any, queue as any);
     await (poller as any).poll();
 
-    // Issue should trigger re-pickup
-    expect(queue.enqueue).toHaveBeenCalledTimes(1);
-    expect(queue.enqueue).toHaveBeenCalledWith(50, "test/repo");
+    // Issue should be SKIPPED - no re-pickup from pollProjectLabel
+    expect(queue.enqueue).not.toHaveBeenCalledWith(50, "test/repo");
 
-    // Checkpoint should be loaded
-    expect(mockLoadCheckpoint).toHaveBeenCalledWith(expect.any(String), 50);
-
-    // Worktree cleanup should NOT be called since checkpoint has no worktree path
+    // pollProjectLabel does not touch checkpoint/worktree
+    expect(mockLoadCheckpoint).not.toHaveBeenCalled();
     expect(mockRemoveWorktree).not.toHaveBeenCalled();
+    expect(mockRemoveCheckpoint).not.toHaveBeenCalled();
 
-    // Checkpoint removal should still be called
-    expect(mockRemoveCheckpoint).toHaveBeenCalledWith(expect.any(String), 50);
-
-    // Original job should be archived
+    // Original job should remain as failure
     const failedJob = store.get("aq-50-0");
-    expect(failedJob?.status).toBe("archived");
+    expect(failedJob?.status).toBe("failure");
   });
 
   // -------------------------------------------------------------------------

--- a/tests/polling/issue-poller.test.ts
+++ b/tests/polling/issue-poller.test.ts
@@ -559,7 +559,7 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       );
 
       poller = new IssuePoller(config, mockStore as any, mockQueue);
-      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockStore.findAnyByIssue.mockReturnValue(null);
 
       await (poller as any).poll();
 
@@ -600,7 +600,7 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       );
 
       poller = new IssuePoller(config, mockStore as any, mockQueue);
-      mockStore.shouldBlockRepickup.mockReturnValue(false);
+      mockStore.findAnyByIssue.mockReturnValue(null);
 
       await (poller as any).poll();
 
@@ -669,22 +669,16 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
     });
   });
 
-  describe("shouldBlockRepickup integration", () => {
-    it("should skip issues blocked by shouldBlockRepickup", async () => {
+  describe("findAnyByIssue 기반 중복 디스패치 방지", () => {
+    it("findAnyByIssue가 job을 반환하면 이슈를 스킵해야 한다", async () => {
       const config = makeConfig();
       poller = new IssuePoller(config, mockStore as any, mockQueue as any);
 
-      // Mock shouldBlockRepickup to return true for specific issue
-      mockStore.shouldBlockRepickup.mockImplementation((issueNumber: number) =>
-        issueNumber === 123
-      );
-
-      // Mock findAnyByIssue to return a running job for blocked issue
+      // findAnyByIssue: 123은 running job 존재, 124는 없음
       mockStore.findAnyByIssue.mockImplementation((issueNumber: number) =>
         issueNumber === 123 ? { id: "job-123", status: "running", issueNumber: 123, repo: "test/repo" } : null
       );
 
-      // Mock issues response
       mockRunCli.mockResolvedValue({
         stdout: JSON.stringify([
           { number: 123, title: "Blocked issue", state: "open" },
@@ -696,21 +690,20 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
 
-      // Verify shouldBlockRepickup was called for both issues
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(123, "test/repo");
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(124, "test/repo");
+      // findAnyByIssue는 모든 이슈에 대해 호출되어야 함
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(123, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(124, "test/repo");
 
-      // Verify only non-blocked issue was enqueued
+      // job이 없는 이슈만 enqueue
       expect(mockQueue.enqueue).toHaveBeenCalledWith(124, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(123, "test/repo");
     });
 
-    it("should handle different blocking job statuses", async () => {
+    it("queued/running/success 등 모든 비-archived 상태 job이 있으면 스킵해야 한다", async () => {
       const config = makeConfig();
 
-      // Test queued status blocking
+      // queued 상태 차단
       poller = new IssuePoller(config, mockStore as any, mockQueue as any);
-      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
       mockStore.findAnyByIssue.mockReturnValueOnce({
         id: "job-100", status: "queued", issueNumber: 100, repo: "test/repo"
       });
@@ -722,12 +715,11 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       });
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(100, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(100, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(100, "test/repo");
 
-      // Reset and test running status blocking
+      // running 상태 차단
       vi.clearAllMocks();
-      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
       mockStore.findAnyByIssue.mockReturnValueOnce({
         id: "job-101", status: "running", issueNumber: 101, repo: "test/repo"
       });
@@ -739,12 +731,11 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       });
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(101, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(101, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(101, "test/repo");
 
-      // Reset and test success status blocking
+      // success 상태도 차단 (핵심 변경: 이전에는 shouldBlockRepickup이 success를 허용했음)
       vi.clearAllMocks();
-      mockStore.shouldBlockRepickup.mockReturnValueOnce(true);
       mockStore.findAnyByIssue.mockReturnValueOnce({
         id: "job-102", status: "success", issueNumber: 102, repo: "test/repo"
       });
@@ -756,16 +747,14 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
       });
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(102, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(102, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(102, "test/repo");
     });
 
-    it("should enqueue available issues when shouldBlockRepickup returns false", async () => {
+    it("findAnyByIssue가 null을 반환하면 이슈를 enqueue해야 한다", async () => {
       const config = makeConfig();
       poller = new IssuePoller(config, mockStore as any, mockQueue as any);
 
-      // Mock shouldBlockRepickup to allow all issues
-      mockStore.shouldBlockRepickup.mockReturnValue(false);
       mockStore.findAnyByIssue.mockReturnValue(null);
 
       mockRunCli.mockResolvedValue({
@@ -779,25 +768,20 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
 
-      // Verify shouldBlockRepickup was called for all issues
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(200, "test/repo");
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(201, "test/repo");
+      // findAnyByIssue는 모든 이슈에 대해 호출되어야 함
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(200, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(201, "test/repo");
 
-      // Verify all issues were enqueued
+      // 모든 이슈가 enqueue되어야 함
       expect(mockQueue.enqueue).toHaveBeenCalledWith(200, "test/repo");
       expect(mockQueue.enqueue).toHaveBeenCalledWith(201, "test/repo");
     });
 
-    it("should handle mixed blocked and available issues correctly", async () => {
+    it("혼합 시나리오: job 있는 이슈는 스킵, 없는 이슈는 enqueue", async () => {
       const config = makeConfig();
       poller = new IssuePoller(config, mockStore as any, mockQueue as any);
 
-      // Mock mixed scenarios: block 300 and 302, allow 301
-      mockStore.shouldBlockRepickup
-        .mockReturnValueOnce(true)  // issue 300 blocked
-        .mockReturnValueOnce(false) // issue 301 available
-        .mockReturnValueOnce(true); // issue 302 blocked
-
+      // 300: running job 존재(차단), 301: 없음(허용), 302: queued job 존재(차단)
       mockStore.findAnyByIssue
         .mockReturnValueOnce({ id: "job-300", status: "running", issueNumber: 300, repo: "test/repo" })
         .mockReturnValueOnce(null)
@@ -815,27 +799,21 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
 
-      // Verify shouldBlockRepickup was called for all issues
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(300, "test/repo");
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(301, "test/repo");
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(302, "test/repo");
+      // findAnyByIssue는 모든 이슈에 대해 호출되어야 함
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(300, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(301, "test/repo");
+      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(302, "test/repo");
 
-      // Verify only available issue was enqueued
+      // 301만 enqueue
       expect(mockQueue.enqueue).toHaveBeenCalledWith(301, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(300, "test/repo");
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(302, "test/repo");
-
-      // Verify findAnyByIssue was called for blocked issues to get job details
-      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(300, "test/repo");
-      expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(302, "test/repo");
     });
 
-    it("should correctly integrate shouldBlockRepickup with existing job lookup", async () => {
+    it("success 상태 job이 있는 이슈도 재enqueue하지 않아야 한다 (스팸 방지)", async () => {
       const config = makeConfig();
       poller = new IssuePoller(config, mockStore as any, mockQueue as any);
 
-      // Mock shouldBlockRepickup to return true and verify findAnyByIssue integration
-      mockStore.shouldBlockRepickup.mockReturnValue(true);
       mockStore.findAnyByIssue.mockReturnValue({
         id: "job-400",
         status: "success",
@@ -852,11 +830,7 @@ describe("IssuePoller - PR 충돌 체크 통합", () => {
 
       await (poller as any).pollProjectLabel("test/repo", "aqm:ready", "gh", 30000);
 
-      // Verify the integration flow: shouldBlockRepickup -> findAnyByIssue for job details
-      expect(mockStore.shouldBlockRepickup).toHaveBeenCalledWith(400, "test/repo");
       expect(mockStore.findAnyByIssue).toHaveBeenCalledWith(400, "test/repo");
-
-      // Verify issue was not enqueued due to blocking
       expect(mockQueue.enqueue).not.toHaveBeenCalledWith(400, "test/repo");
     });
   });

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { dispatchEvent } from "../../src/server/event-dispatcher.js";
 import type { AQConfig } from "../../src/types/config.js";
+import type { JobStore } from "../../src/queue/job-store.js";
+import type { Job } from "../../src/types/pipeline.js";
 
 const makePayload = (action: string, labels: string[], author = "user") => ({
   action,
@@ -79,6 +81,38 @@ describe("dispatchEvent", () => {
       const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toMatch(/instanceOwners/);
+    });
+  });
+
+  describe("active job deduplication", () => {
+    const makeStore = (job: Partial<Job> | undefined): Pick<JobStore, "findAnyByIssue"> => ({
+      findAnyByIssue: () => job as Job | undefined,
+    });
+
+    it("should block dispatch when queued job already exists", () => {
+      const store = makeStore({ id: "aq-42-1", status: "queued", issueNumber: 42, repo: "test/repo" });
+      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toMatch(/queued/);
+    });
+
+    it("should block dispatch when running job already exists", () => {
+      const store = makeStore({ id: "aq-42-2", status: "running", issueNumber: 42, repo: "test/repo" });
+      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toMatch(/running/);
+    });
+
+    it("should allow dispatch when only a success job exists", () => {
+      const store = makeStore({ id: "aq-42-3", status: "success", issueNumber: 42, repo: "test/repo" });
+      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it("should allow dispatch when no existing job", () => {
+      const store = makeStore(undefined);
+      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      expect(result.shouldProcess).toBe(true);
     });
   });
 });

--- a/tests/store/queries.test.ts
+++ b/tests/store/queries.test.ts
@@ -27,7 +27,7 @@ describe("queries", () => {
   let db: AQDatabase;
 
   beforeEach(() => {
-    dataDir = join(tmpdir(), `aq-queries-test-${Date.now()}`);
+    dataDir = join(tmpdir(), `aq-queries-test-${Date.now()}-${process.pid}`);
     dbPath = join(dataDir, "test.db");
     db = new AQDatabase(dbPath);
   });


### PR DESCRIPTION
## Summary

Resolves #572 — fix: 폴링 디스패치 중복 호출 스팸 — 동일 이슈 초당 수십 번 디스패치 시도

폴링 시 동일 이슈에 대해 이미 job이 존재하는데도 반복 디스패치가 발생. (1) issue-poller.ts의 shouldBlockRepickup()이 queued/running만 차단하여 success/failure/cancelled 상태 job이 매 폴링 사이클마다 archive→재생성 반복. (2) event-dispatcher.ts의 dispatchEvent()가 기존 job 존재 여부를 전혀 체크하지 않아 중복 webhook 이벤트마다 Dispatching pipeline 로그 스팸 + 불필요한 enqueue 호출. 실제 중복 실행은 enqueue 내부 가드로 차단되지만 로그 오염과 CPU 낭비 발생.

## Requirements

- 디스패치 전 job 존재 여부를 먼저 체크해서 중복 호출 스킵
- 이미 처리된(success) 이슈는 폴링에서 재디스패치하지 않음
- failure 재시도는 기존 pollFailedJobs() 메커니즘에 위임 (폴러에서 중복 재큐잉 금지)
- webhook 경로에서도 active job 존재 시 shouldProcess: false 반환
- 기존 테스트 통과 유지

## Implementation Phases

- Phase 0: issue-poller 중복 디스패치 방지 — SUCCESS (1c81820c)
- Phase 1: event-dispatcher active job 체크 추가 — SUCCESS (b5ce5452)
- Phase 2: 테스트 추가 및 검증 — SUCCESS (b5ce5452)

## Risks

- shouldBlockRepickup 변경이 다른 호출처(pollFailedJobs 등)에 영향 → findAnyByIssue 직접 사용으로 우회
- success job 스킵으로 인해 라벨 재부착으로 재처리가 불가능해질 수 있음 → success job은 webhook 경로에서는 enqueue 내부에서 archive+재생성으로 처리 가능

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 3/3 completed
- **Branch**: `aq/572-fix` → `develop`
- **Tokens**: 85 input, 17144 output{{#stats.cacheCreationTokens}}, 153467 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1268408 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #572