### PR TITLE
[AQ-#558] test: 대시보드 UI playwright 구조 검증 테스트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "aqm": "dist/cli.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.11.0",
         "@types/node-cron": "^3.0.11",
@@ -781,6 +782,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3300,6 +3317,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "postbuild": "node scripts/add-shebang.cjs",
     "prepublishOnly": "npm run typecheck && npm run lint && npm run test && npm run build",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "lint": "eslint src/ tests/",
     "typecheck": "tsc --noEmit"
@@ -39,6 +40,7 @@
     "zod": "^3.22.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.11.0",
     "@types/node-cron": "^3.0.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env['CI'],
+  retries: process.env['CI'] ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3100',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'tsx src/cli.ts start --port 3100',
+    url: 'http://localhost:3100/health',
+    reuseExistingServer: !process.env['CI'],
+    timeout: 30000,
+  },
+});

--- a/tests/e2e/ui/dashboard-navigation.test.ts
+++ b/tests/e2e/ui/dashboard-navigation.test.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+
+const VIEWS = ['dashboard', 'logs', 'repositories', 'automations', 'settings'] as const;
+type ViewName = typeof VIEWS[number];
+
+// Header nav only exposes dashboard and logs
+const HEADER_NAV_VIEWS: ViewName[] = ['dashboard', 'logs'];
+
+test.describe('Dashboard Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('초기 상태: dashboard 뷰가 active', async ({ page }) => {
+    await expect(page.locator('#view-dashboard')).toHaveClass(/active/);
+
+    for (const view of VIEWS.filter((v) => v !== 'dashboard')) {
+      await expect(page.locator(`#view-${view}`)).not.toHaveClass(/active/);
+    }
+
+    await expect(page.locator('#sidebar-nav a[data-nav="dashboard"]')).toHaveClass(/nav-item-active/);
+  });
+
+  // ── Sidebar navigation ──────────────────────────────────────────────────────
+
+  for (const view of VIEWS) {
+    test(`사이드바 → ${view}: 해당 뷰 활성화`, async ({ page }) => {
+      await page.locator(`#sidebar-nav a[data-nav="${view}"]`).click();
+
+      // Target view gains active class
+      await expect(page.locator(`#view-${view}`)).toHaveClass(/active/);
+
+      // All other views lose active class
+      for (const other of VIEWS.filter((v) => v !== view)) {
+        await expect(page.locator(`#view-${other}`)).not.toHaveClass(/active/);
+      }
+
+      // Clicked sidebar item gains nav-item-active
+      await expect(page.locator(`#sidebar-nav a[data-nav="${view}"]`)).toHaveClass(/nav-item-active/);
+
+      // All other sidebar items lose nav-item-active
+      for (const other of VIEWS.filter((v) => v !== view)) {
+        await expect(page.locator(`#sidebar-nav a[data-nav="${other}"]`)).not.toHaveClass(/nav-item-active/);
+      }
+    });
+  }
+
+  // ── Header navigation ───────────────────────────────────────────────────────
+
+  for (const view of HEADER_NAV_VIEWS) {
+    test(`헤더 nav → ${view}: 해당 뷰 활성화`, async ({ page }) => {
+      // Navigate away first so we have a meaningful transition to test
+      const startView: ViewName = view === 'dashboard' ? 'logs' : 'dashboard';
+      await page.locator(`#sidebar-nav a[data-nav="${startView}"]`).click();
+      await expect(page.locator(`#view-${startView}`)).toHaveClass(/active/);
+
+      // Click header nav link
+      await page.locator(`header nav a[data-nav="${view}"]`).click();
+
+      // Target view becomes active
+      await expect(page.locator(`#view-${view}`)).toHaveClass(/active/);
+
+      // Previous view becomes inactive
+      await expect(page.locator(`#view-${startView}`)).not.toHaveClass(/active/);
+
+      // Active header link has border-b-2
+      await expect(page.locator(`header nav a[data-nav="${view}"]`)).toHaveClass(/border-b-2/);
+
+      // Inactive header links do not have border-b-2
+      for (const other of HEADER_NAV_VIEWS.filter((v) => v !== view)) {
+        await expect(page.locator(`header nav a[data-nav="${other}"]`)).not.toHaveClass(/border-b-2/);
+      }
+    });
+  }
+
+  // ── Full cycle traversal ─────────────────────────────────────────────────────
+
+  test('5개 뷰 순회: 사이드바로 모든 뷰 전환 검증', async ({ page }) => {
+    for (const view of VIEWS) {
+      await page.locator(`#sidebar-nav a[data-nav="${view}"]`).click();
+
+      await expect(page.locator(`#view-${view}`)).toHaveClass(/active/);
+      await expect(page.locator(`#sidebar-nav a[data-nav="${view}"]`)).toHaveClass(/nav-item-active/);
+
+      // Exactly one view-panel should be active at any time
+      const activePanels = page.locator('.view-panel.active');
+      await expect(activePanels).toHaveCount(1);
+    }
+  });
+});

--- a/tests/e2e/ui/dashboard-structure.test.ts
+++ b/tests/e2e/ui/dashboard-structure.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('대시보드 레이아웃 구조 검증', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('사이드바 존재 및 5개 nav 항목 확인', async ({ page }) => {
+    const sidebarNav = page.locator('#sidebar-nav');
+    await expect(sidebarNav).toBeVisible();
+
+    const navKeys = ['dashboard', 'logs', 'repositories', 'automations', 'settings'];
+    for (const nav of navKeys) {
+      await expect(page.locator(`#sidebar-nav [data-nav="${nav}"]`)).toBeVisible();
+    }
+  });
+
+  test('헤더 바 + 프로젝트 셀렉터 + 테마 토글 + 언어 토글 + 접속 상태 표시 확인', async ({ page }) => {
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('#project-selector')).toBeVisible();
+    await expect(page.locator('#btn-theme')).toBeVisible();
+    await expect(page.locator('#lang-label')).toBeVisible();
+    await expect(page.locator('#conn-dot')).toBeAttached();
+    await expect(page.locator('#conn-label')).toBeAttached();
+  });
+
+  test('기본 뷰(dashboard)가 active 상태', async ({ page }) => {
+    await expect(page.locator('#view-dashboard')).toHaveClass(/active/);
+  });
+
+  test('5개 view-panel 요소가 DOM에 존재', async ({ page }) => {
+    const viewIds = [
+      'view-dashboard',
+      'view-logs',
+      'view-repositories',
+      'view-automations',
+      'view-settings',
+    ];
+    for (const id of viewIds) {
+      await expect(page.locator(`#${id}`)).toBeAttached();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     },
   },
   test: {
+    exclude: ['node_modules', 'dist', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json-summary'],


### PR DESCRIPTION
## Summary

Resolves #558 — test: 대시보드 UI playwright 구조 검증 테스트 추가

프론트엔드 HTML/JS 수정 시 UI 깨짐을 코드 레벨에서 탐지할 수 없음. 현재 vitest 기반 서버 테스트는 백엔드 로직만 검증하며, 브라우저 렌더링·네비게이션·뷰 전환은 테스트하지 않음. Playwright로 실제 서버를 띄우고 주요 UI 요소 존재 여부 + 사이드바/헤더 네비게이션 + 뷰 전환을 검증하는 e2e 테스트를 추가하여, 이후 HTML/JS 분리 리팩터링의 안전망을 확보한다.

## Requirements

- Playwright 설치 및 playwright.config.ts 설정
- 테스트 실행 시 Hono 서버 자동 기동/종료 (webServer 옵션)
- 주요 레이아웃 요소 존재 검증 (사이드바, 헤더, 프로젝트 셀렉터, 테마 토글 등)
- 5개 뷰 패널 존재 검증 (dashboard, logs, repositories, automations, settings)
- 사이드바 [data-nav] 클릭 → 뷰 전환 동작 검증
- 헤더 네비게이션 동작 검증
- package.json에 test:e2e 스크립트 추가
- CI에서 선택적 실행 가능하도록 vitest 기존 테스트와 분리

## Implementation Phases

- Phase 0: Playwright 인프라 설정 — SUCCESS (79563fb0)
- Phase 1: 레이아웃 구조 검증 테스트 — SUCCESS (56c95972)
- Phase 2: 네비게이션 동작 검증 테스트 — SUCCESS (56c95972)
- Phase 3: 전체 검증 및 CI 정리 — SUCCESS (56c95972)

## Risks

- Playwright 브라우저 바이너리 설치가 CI 환경에서 실패할 수 있음 → npx playwright install --with-deps chromium으로 최소 설치
- 테스트 포트 충돌 → 기본 3000 대신 3100 등 별도 포트 사용
- 서버 기동 시간이 길면 테스트 타임아웃 → webServer.timeout 충분히 설정
- HTML assembler가 뷰 파일 경로를 빌드 결과 기준으로 참조 → 테스트 전 빌드 필요 여부 확인

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/558-test-ui-playwright` → `develop`
- **Tokens**: 132 input, 20776 output{{#stats.cacheCreationTokens}}, 174392 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1926643 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #558