### PR TITLE
fix: 프로젝트 편집 모달 baseBranch 필드 항상 표시

### DIFF
--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -557,9 +557,7 @@ function editProject(repo) {
 
   var fieldsHtml = createModalField('저장소 (owner/repo)', 'repo', project.repo, true);
   fieldsHtml += createModalField('로컬 경로', 'path', project.path, false);
-  if (project.baseBranch !== undefined) {
-    fieldsHtml += createModalField('기본 브랜치', 'baseBranch', project.baseBranch || '', false);
-  }
+  fieldsHtml += createModalField('기본 브랜치', 'baseBranch', project.baseBranch || '', false);
   if (project.mode !== undefined) {
     fieldsHtml += createModalField('모드', 'mode', project.mode || '', false);
   }


### PR DESCRIPTION
## Summary
- baseBranch가 undefined인 프로젝트에서도 브랜치 입력란 표시
- 기존에는 baseBranch !== undefined 조건으로 숨겨짐