### PR TITLE
fix: readOnlyGuard 제거 + YAML repo 매칭 + baseBranch 필드 항상 표시

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -438,28 +438,10 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     api.use("/api/events", sseTokenAuth);
     api.use("/api/jobs/:id/logs/stream", sseTokenAuth);
   } else {
-    // apiKey 미설정 경고: 쓰기 API 비활성화
-    getLogger().warn(
-      "Dashboard API key is not configured. Write endpoints (cancel/retry/delete) are disabled. " +
-        "Set dashboard.apiKey in config.yml to enable full access."
+    // apiKey 미설정: 로컬 환경에서는 모든 API 허용
+    getLogger().info(
+      "Dashboard API key is not configured. All endpoints are accessible without authentication."
     );
-
-    // 파괴적 쓰기 요청 차단 미들웨어 (cancel/retry/delete)
-    const readOnlyGuard = async (c: Context, next: Next) => {
-      const method = c.req.method;
-      if (method !== "GET" && method !== "HEAD") {
-        return c.json(
-          { error: "API key required for write operations. Set dashboard.apiKey in config." },
-          403
-        );
-      }
-      await next();
-    };
-
-    // cancel/retry/delete만 차단 (config, projects 관리는 허용)
-    api.use("/api/jobs/:id/cancel", readOnlyGuard);
-    api.use("/api/jobs/:id/retry", readOnlyGuard);
-    api.use("/api/jobs/:id", readOnlyGuard);
   }
 
   // Get configuration (masked for security)

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -557,9 +557,7 @@ function editProject(repo) {
 
   var fieldsHtml = createModalField('저장소 (owner/repo)', 'repo', project.repo, true);
   fieldsHtml += createModalField('로컬 경로', 'path', project.path, false);
-  if (project.baseBranch !== undefined) {
-    fieldsHtml += createModalField('기본 브랜치', 'baseBranch', project.baseBranch || '', false);
-  }
+  fieldsHtml += createModalField('기본 브랜치', 'baseBranch', project.baseBranch || '', false);
   if (project.mode !== undefined) {
     fieldsHtml += createModalField('모드', 'mode', project.mode || '', false);
   }

--- a/tests/security/dashboard-auth.test.ts
+++ b/tests/security/dashboard-auth.test.ts
@@ -106,24 +106,23 @@ describe("Dashboard Auth — apiKey 미설정 시 쓰기 API 차단", () => {
     stopPeriodicCleanup();
   });
 
-  it("apiKey 미설정 시 job cancel(POST)은 403을 반환한다", async () => {
+  it("apiKey 미설정 시 job cancel(POST)은 허용된다", async () => {
     const app = createDashboardRoutes(store, queue);
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
-    expect(res.status).toBe(403);
-    const body = await res.json() as { error: string };
-    expect(body.error).toContain("API key required");
+    // readOnlyGuard 제거 — apiKey 없이도 모든 API 허용
+    expect(res.status).not.toBe(403);
   });
 
-  it("apiKey 미설정 시 job retry(POST)은 403을 반환한다", async () => {
+  it("apiKey 미설정 시 job retry(POST)은 허용된다", async () => {
     const app = createDashboardRoutes(store, queue);
     const res = await request(app, "POST", "/api/jobs/job-123/retry");
-    expect(res.status).toBe(403);
+    expect(res.status).not.toBe(403);
   });
 
-  it("apiKey 미설정 시 job delete(DELETE)은 403을 반환한다", async () => {
+  it("apiKey 미설정 시 job delete(DELETE)은 허용된다", async () => {
     const app = createDashboardRoutes(store, queue);
     const res = await request(app, "DELETE", "/api/jobs/job-123");
-    expect(res.status).toBe(403);
+    expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 project 관리(DELETE)는 허용된다", async () => {


### PR DESCRIPTION
## Summary
- readOnlyGuard 완전 제거 — apiKey 없이 모든 API 허용 (로컬 환경)
- YAML 따옴표 없는 repo명 매칭 버그 수정
- 프로젝트 편집 모달에서 baseBranch 필드 항상 표시
- 절대경로 프로젝트 추가 허용
- 로그 페이지 작업 선택 드롭다운 추가
- 사이드바 인스턴스 정보 구조 개선