### PR TITLE
fix: PR 생성 시 라벨 자동 생성 + 에러 로그 개선

### DIFF
--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -120,13 +120,30 @@ export async function createDraftPR(
     args.push("--reviewer", reviewer);
   }
 
-  const result = await runCli(ghConfig.path, args, {
+  let result = await runCli(ghConfig.path, args, {
     cwd: options.cwd,
     timeout: ghConfig.timeout,
   });
 
+  // Label not found → auto-create and retry
+  if (result.exitCode !== 0 && result.stderr.includes("label") && result.stderr.includes("not found")) {
+    logger.warn(`PR label not found, auto-creating labels and retrying...`);
+    const allLabels = [...prConfig.labels];
+    if (ctx.instanceLabel) allLabels.push(ctx.instanceLabel);
+    for (const label of allLabels) {
+      await runCli(ghConfig.path, ["label", "create", label, "--repo", ctx.repo, "--force"], {
+        cwd: options.cwd,
+        timeout: 10000,
+      });
+    }
+    result = await runCli(ghConfig.path, args, {
+      cwd: options.cwd,
+      timeout: ghConfig.timeout,
+    });
+  }
+
   if (result.exitCode !== 0) {
-    logger.error(`Failed to create PR: ${result.stderr}`);
+    logger.error(`Failed to create PR: ${result.stderr} | stdout: ${result.stdout}`);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- PR 생성 시 레포에 라벨이 없으면 자동 생성 후 재시도
- 실패 시 stderr + stdout 모두 로그에 출력
- 새 프로젝트에서 PR 생성 실패하던 근본 원인 해결