### PR TITLE
[AQ-#608] test: GitHub/gh CLI 실패 경계조건 강화 — 외부 의존 에러 핸들링

### DIFF
--- a/tests/github/issue-fetcher.test.ts
+++ b/tests/github/issue-fetcher.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../src/github/github-cache.js", () => ({
   clearCache: vi.fn(),
 }));
 
-import { fetchIssue } from "../../src/github/issue-fetcher.js";
+import { fetchIssue, fetchPR } from "../../src/github/issue-fetcher.js";
 import { runCli } from "../../src/utils/cli-runner.js";
 import { getCached, setCached } from "../../src/github/github-cache.js";
 
@@ -330,6 +330,338 @@ describe("fetchIssue", () => {
       ["issue", "view", "999999", "--repo", "test/repo", "--json", "number,title,body,labels"],
       { timeout: undefined }
     );
+  });
+
+  it("should throw auth error when 401 authentication required", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "HTTP 401: authentication required",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("test/repo", 1)).rejects.toThrow(
+      "Failed to fetch issue #1 from test/repo: GitHub issue view failed: Authentication required"
+    );
+  });
+
+  it("should throw auth error when stderr contains authentication required text", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "authentication required - please run gh auth login",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("test/repo", 1)).rejects.toThrow(
+      "Failed to fetch issue #1 from test/repo: GitHub issue view failed: Authentication required"
+    );
+  });
+
+  it("should throw permission error when 403 forbidden", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "HTTP 403: Forbidden",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("private/repo", 42)).rejects.toThrow(
+      "Failed to fetch issue #42 from private/repo: GitHub issue view failed: Permission denied"
+    );
+  });
+
+  it("should throw rate limit error when rate limit exceeded", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "rate limit exceeded, try again later",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("test/repo", 10)).rejects.toThrow(
+      "Failed to fetch issue #10 from test/repo: GitHub issue view failed: Rate limit exceeded"
+    );
+  });
+
+  it("should throw rate limit error when HTTP 429 response", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "HTTP 429: too many requests",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("test/repo", 10)).rejects.toThrow(
+      "Failed to fetch issue #10 from test/repo: GitHub issue view failed: Rate limit exceeded"
+    );
+  });
+
+  it("should throw error when network timeout occurs", async () => {
+    mockRunCli.mockRejectedValue(new Error("ETIMEDOUT: connection timed out"));
+
+    await expect(fetchIssue("test/repo", 5, { timeout: 1000 })).rejects.toThrow(
+      "ETIMEDOUT: connection timed out"
+    );
+  });
+
+  it("should throw not found error when accessing deleted repository", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "Could not resolve to a Repository with the name 'deleted/repo'. HTTP 404: not found",
+      exitCode: 1
+    });
+
+    await expect(fetchIssue("deleted/repo", 1)).rejects.toThrow(
+      "Failed to fetch issue #1 from deleted/repo: GitHub issue view failed: Resource not found"
+    );
+  });
+
+});
+
+describe("fetchPR", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCached.mockReturnValue(undefined);
+  });
+
+  it("should fetch PR successfully with all fields", async () => {
+    const mockResponse = {
+      number: 42,
+      title: "Add new feature",
+      body: "This PR adds a new feature",
+      state: "OPEN",
+      headRefName: "feature/new-feature",
+      headRefOid: "abc123def456",
+      baseRefName: "main"
+    };
+
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify(mockResponse),
+      stderr: "",
+      exitCode: 0
+    });
+
+    const result = await fetchPR("test/repo", 42);
+
+    expect(result).toEqual({
+      number: 42,
+      title: "Add new feature",
+      body: "This PR adds a new feature",
+      state: "OPEN",
+      head: {
+        ref: "feature/new-feature",
+        sha: "abc123def456"
+      },
+      base: {
+        ref: "main"
+      }
+    });
+
+    expect(mockRunCli).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "view", "42", "--repo", "test/repo", "--json", "number,title,body,state,headRefName,headRefOid,baseRefName"],
+      { timeout: undefined }
+    );
+  });
+
+  it("should fetch closed PR", async () => {
+    const mockResponse = {
+      number: 10,
+      title: "Old PR",
+      body: "Already merged",
+      state: "CLOSED",
+      headRefName: "old-branch",
+      headRefOid: "deadbeef1234",
+      baseRefName: "main"
+    };
+
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify(mockResponse),
+      stderr: "",
+      exitCode: 0
+    });
+
+    const result = await fetchPR("test/repo", 10);
+
+    expect(result.state).toBe("CLOSED");
+    expect(result.head.ref).toBe("old-branch");
+    expect(result.base.ref).toBe("main");
+  });
+
+  it("should use custom gh path", async () => {
+    const mockResponse = {
+      number: 1,
+      title: "Test PR",
+      body: "",
+      state: "OPEN",
+      headRefName: "feat/test",
+      headRefOid: "abcdef01",
+      baseRefName: "main"
+    };
+
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify(mockResponse),
+      stderr: "",
+      exitCode: 0
+    });
+
+    await fetchPR("test/repo", 1, { ghPath: "/custom/gh" });
+
+    expect(mockRunCli).toHaveBeenCalledWith(
+      "/custom/gh",
+      ["pr", "view", "1", "--repo", "test/repo", "--json", "number,title,body,state,headRefName,headRefOid,baseRefName"],
+      { timeout: undefined }
+    );
+  });
+
+  it("should pass timeout option to runCli", async () => {
+    const mockResponse = {
+      number: 5,
+      title: "Timeout test PR",
+      body: "",
+      state: "OPEN",
+      headRefName: "branch",
+      headRefOid: "sha1sha2sha3",
+      baseRefName: "main"
+    };
+
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify(mockResponse),
+      stderr: "",
+      exitCode: 0
+    });
+
+    await fetchPR("test/repo", 5, { timeout: 8000 });
+
+    expect(mockRunCli).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "view", "5", "--repo", "test/repo", "--json", "number,title,body,state,headRefName,headRefOid,baseRefName"],
+      { timeout: 8000 }
+    );
+  });
+
+  it("should throw error when PR not found (404)", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "no pull requests found for branch 'nonexistent'. HTTP 404: not found",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("test/repo", 9999)).rejects.toThrow(
+      "Failed to fetch PR #9999 from test/repo: GitHub pr view failed: Resource not found"
+    );
+  });
+
+  it("should throw error when stdout contains not found", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "GraphQL: Could not resolve to a PullRequest. not found",
+      stderr: "",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("test/repo", 99)).rejects.toThrow(
+      "Failed to fetch PR #99 from test/repo: GitHub pr view failed: Resource not found"
+    );
+  });
+
+  it("should throw auth error when 401 authentication required", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "HTTP 401: authentication required",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("test/repo", 1)).rejects.toThrow(
+      "Failed to fetch PR #1 from test/repo: GitHub pr view failed: Authentication required"
+    );
+  });
+
+  it("should throw permission error when 403 forbidden", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "HTTP 403: Forbidden - insufficient permissions to access private repo",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("private/repo", 7)).rejects.toThrow(
+      "Failed to fetch PR #7 from private/repo: GitHub pr view failed: Permission denied"
+    );
+  });
+
+  it("should throw rate limit error when rate limit exceeded", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "API rate limit exceeded for user",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("test/repo", 3)).rejects.toThrow(
+      "Failed to fetch PR #3 from test/repo: GitHub pr view failed: Rate limit exceeded"
+    );
+  });
+
+  it("should throw error when JSON is malformed", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "not valid json at all",
+      stderr: "",
+      exitCode: 0
+    });
+
+    await expect(fetchPR("test/repo", 1)).rejects.toThrow(
+      "Failed to parse gh output for PR #1: not valid json at all"
+    );
+  });
+
+  it("should throw error when JSON is partially malformed", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: '{"number": 1, "title": "Test", "broken":',
+      stderr: "",
+      exitCode: 0
+    });
+
+    await expect(fetchPR("test/repo", 1)).rejects.toThrow(
+      'Failed to parse gh output for PR #1: {"number": 1, "title": "Test", "broken":'
+    );
+  });
+
+  it("should throw error on network timeout", async () => {
+    mockRunCli.mockRejectedValue(new Error("ETIMEDOUT: operation timed out"));
+
+    await expect(fetchPR("test/repo", 2, { timeout: 500 })).rejects.toThrow(
+      "ETIMEDOUT: operation timed out"
+    );
+  });
+
+  it("should throw not found error when accessing PR on deleted repository", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: "",
+      stderr: "Could not resolve to a Repository with the name 'deleted/repo'. HTTP 404: not found",
+      exitCode: 1
+    });
+
+    await expect(fetchPR("deleted/repo", 1)).rejects.toThrow(
+      "Failed to fetch PR #1 from deleted/repo: GitHub pr view failed: Resource not found"
+    );
+  });
+
+  it("should map headRefName and headRefOid to head.ref and head.sha", async () => {
+    const mockResponse = {
+      number: 77,
+      title: "Field mapping test",
+      body: "Verify field mapping",
+      state: "MERGED",
+      headRefName: "feature/branch-name",
+      headRefOid: "commitsha123456",
+      baseRefName: "develop"
+    };
+
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify(mockResponse),
+      stderr: "",
+      exitCode: 0
+    });
+
+    const result = await fetchPR("test/repo", 77);
+
+    expect(result.head.ref).toBe("feature/branch-name");
+    expect(result.head.sha).toBe("commitsha123456");
+    expect(result.base.ref).toBe("develop");
   });
 
 });

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -10,6 +10,9 @@ vi.mock("../../src/prompt/template-renderer.js", () => ({
 
 import { createDraftPR, closeIssue, checkPrConflict, commentOnIssue, listOpenPrs, enableAutoMerge, addIssueComment } from "../../src/github/pr-creator.js";
 import { runCli } from "../../src/utils/cli-runner.js";
+import { loadTemplate } from "../../src/prompt/template-renderer.js";
+
+const mockLoadTemplate = vi.mocked(loadTemplate);
 
 const mockRunCli = vi.mocked(runCli);
 
@@ -96,6 +99,61 @@ describe("createDraftPR", () => {
     const labelArgs = args.filter((_, i) => args[i - 1] === "--label");
     // Only prConfig.labels entries should appear (no extra instanceLabel entry)
     expect(labelArgs).toEqual(prConfig.labels);
+  });
+
+  it("should use fallback body when template loading fails", async () => {
+    mockLoadTemplate.mockImplementationOnce(() => { throw new Error("Template file not found"); });
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/99", stderr: "", exitCode: 0 });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toEqual({ url: "https://github.com/test/repo/pull/99", number: 99 });
+    const args = mockRunCli.mock.calls[0][1] as string[];
+    const bodyIdx = args.indexOf("--body");
+    const body = args[bodyIdx + 1];
+    expect(body).toContain("Resolves #42");
+    expect(body).toContain("## Summary");
+    expect(body).toContain("Login is broken");
+  });
+
+  it("should return number 0 for malformed PR URL without /pull/ segment", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "not-a-valid-url", stderr: "", exitCode: 0 });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toEqual({ url: "not-a-valid-url", number: 0 });
+  });
+
+  it("should return null on auth failure", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "", stderr: "authentication required: not logged in", exitCode: 1 });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toBe(null);
+  });
+
+  it("should return null on rate-limit error", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "", stderr: "rate limit exceeded for API", exitCode: 1 });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toBe(null);
+  });
+
+  it("should auto-create labels and retry when label not found", async () => {
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "label 'aqm' not found", exitCode: 1 })
+      .mockResolvedValue({ stdout: "https://github.com/test/repo/pull/7", stderr: "", exitCode: 0 });
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toEqual({ url: "https://github.com/test/repo/pull/7", number: 7 });
+    // Initial attempt + label create for "aqm" + retry
+    expect(mockRunCli).toHaveBeenCalledTimes(3);
+    expect(mockRunCli).toHaveBeenNthCalledWith(
+      2, "gh",
+      ["label", "create", "aqm", "--repo", "test/repo", "--force"],
+      expect.anything()
+    );
+  });
+
+  it("should return null when retry also fails after auto-creating labels", async () => {
+    mockRunCli
+      .mockResolvedValueOnce({ stdout: "", stderr: "label 'aqm' not found", exitCode: 1 })
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // label create
+      .mockResolvedValueOnce({ stdout: "", stderr: "API error", exitCode: 1 }); // retry fails
+    const result = await createDraftPR(prConfig, ghConfig, ctx, options);
+    expect(result).toBe(null);
   });
 });
 
@@ -203,6 +261,39 @@ describe("checkPrConflict", () => {
     expect(result).toBe(null);
     expect(mockRunCli).not.toHaveBeenCalled();
   });
+
+  it("should return conflict info without files when diff command throws", async () => {
+    mockRunCli
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ mergeStateStatus: "DIRTY", mergeable: false }),
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockRejectedValueOnce(new Error("spawn ENOENT"));
+    const result = await checkPrConflict(123, "test/repo", {});
+    expect(result).toMatchObject({
+      prNumber: 123,
+      repo: "test/repo",
+      conflictFiles: [],
+      mergeStatus: "DIRTY",
+    });
+  });
+
+  it("should return null when gh pr view returns invalid JSON", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "not valid json {{", stderr: "", exitCode: 0 });
+    const result = await checkPrConflict(123, "test/repo", {});
+    expect(result).toBe(null);
+  });
+
+  it("should pass timeout to runCli when provided", async () => {
+    mockRunCli.mockResolvedValue({
+      stdout: JSON.stringify({ mergeStateStatus: "CLEAN", mergeable: true }),
+      stderr: "",
+      exitCode: 0,
+    });
+    await checkPrConflict(123, "test/repo", { timeout: 5000 });
+    expect(mockRunCli).toHaveBeenCalledWith("gh", expect.any(Array), { timeout: 5000 });
+  });
 });
 
 describe("commentOnIssue", () => {
@@ -293,6 +384,18 @@ describe("listOpenPrs", () => {
     expect(mockRunCli).toHaveBeenCalledWith("/custom/gh", [
       "pr", "list", "--repo", "test/repo", "--state", "open", "--json", "number,title", "--limit", "100"
     ], {});
+  });
+
+  it("should return null when gh returns invalid JSON", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "not json content {{", stderr: "", exitCode: 0 });
+    const result = await listOpenPrs("test/repo", {});
+    expect(result).toBe(null);
+  });
+
+  it("should pass timeout to runCli when provided", async () => {
+    mockRunCli.mockResolvedValue({ stdout: JSON.stringify([]), stderr: "", exitCode: 0 });
+    await listOpenPrs("test/repo", { timeout: 8000 });
+    expect(mockRunCli).toHaveBeenCalledWith("gh", expect.any(Array), { timeout: 8000 });
   });
 });
 

--- a/tests/utils/cli-runner.test.ts
+++ b/tests/utils/cli-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { runCli, runGhCommand } from "../../src/utils/cli-runner.js";
 import * as rateLimiter from "../../src/utils/rate-limiter.js";
+import type { ChildProcess } from "child_process";
 
 // Mock rate-limiter module
 vi.mock("../../src/utils/rate-limiter.js");
@@ -323,6 +324,254 @@ x-ratelimit-reset: 1234567890
         customRetry,
         "gh pr"
       );
+    });
+
+    it("should throw retryable error (status 429) when exit code is 429", async () => {
+      const { execFile } = await import("child_process");
+      const mockExecFile = vi.mocked(execFile);
+
+      mockExecFile.mockImplementation((command, args, options, callback) => {
+        if (callback) {
+          const error = new Error("HTTP 429") as NodeJS.ErrnoException & { stdout: string; stderr: string };
+          error.code = 429 as unknown as string;
+          error.stdout = "";
+          error.stderr = "";
+          callback(error, "", "");
+        }
+        return {} as any;
+      });
+
+      vi.mocked(rateLimiter.withRateLimit).mockImplementation(async (operation) => {
+        return operation();
+      });
+
+      await expect(runGhCommand("gh", ["api", "/rate_limit"])).rejects.toMatchObject({
+        message: "GitHub API rate limit exceeded",
+        status: 429,
+      });
+    });
+
+    it("should throw retryable error with status 429 on rate limit text in stderr", async () => {
+      const { execFile } = await import("child_process");
+      const mockExecFile = vi.mocked(execFile);
+
+      mockExecFile.mockImplementation((command, args, options, callback) => {
+        if (callback) {
+          callback(null, "", "rate limit exceeded for your account");
+        }
+        return {} as any;
+      });
+
+      vi.mocked(rateLimiter.withRateLimit).mockImplementation(async (operation) => {
+        return operation();
+      });
+
+      const thrownError = await runGhCommand("gh", ["api", "/repos"]).catch((e: unknown) => e);
+      expect(thrownError).toMatchObject({ message: "GitHub API rate limit exceeded", status: 429 });
+    });
+  });
+
+  describe("runCli - error boundary conditions", () => {
+    it("should return exitCode 1 when command is not found (ENOENT)", async () => {
+      const { execFile } = await import("child_process");
+      const mockExecFile = vi.mocked(execFile);
+
+      mockExecFile.mockImplementation((command, args, options, callback) => {
+        if (callback) {
+          const error = Object.assign(new Error("spawn gh ENOENT"), {
+            code: "ENOENT",
+            stdout: "",
+            stderr: "",
+          });
+          callback(error, "", "");
+        }
+        return {} as ReturnType<typeof execFile>;
+      });
+
+      const result = await runCli("gh", ["--version"]);
+
+      // string code "ENOENT" → not a number → exitCode falls back to 1
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+    });
+
+    it("should return exitCode 1 when command times out (ETIMEDOUT)", async () => {
+      const { execFile } = await import("child_process");
+      const mockExecFile = vi.mocked(execFile);
+
+      mockExecFile.mockImplementation((command, args, options, callback) => {
+        if (callback) {
+          const error = Object.assign(new Error("Command timed out"), {
+            code: "ETIMEDOUT",
+            killed: true,
+            stdout: "partial",
+            stderr: "timeout",
+          });
+          callback(error, "partial", "timeout");
+        }
+        return {} as ReturnType<typeof execFile>;
+      });
+
+      const result = await runCli("gh", ["api", "/repos"], { timeout: 100 });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe("partial");
+      expect(result.stderr).toBe("timeout");
+    });
+
+    it("should use numeric exit code from error when available", async () => {
+      const { execFile } = await import("child_process");
+      const mockExecFile = vi.mocked(execFile);
+
+      mockExecFile.mockImplementation((command, args, options, callback) => {
+        if (callback) {
+          const error = Object.assign(new Error("Exited with code 2"), {
+            code: 2,
+            stdout: "",
+            stderr: "usage error",
+          });
+          callback(error, "", "usage error");
+        }
+        return {} as ReturnType<typeof execFile>;
+      });
+
+      const result = await runCli("gh", ["unknown-command"]);
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toBe("usage error");
+    });
+  });
+
+  describe("runCli - stdin/spawn path", () => {
+    function createMockChildProcess() {
+      const closeListeners: Array<(code: number | null) => void> = [];
+      const errorListeners: Array<(err: Error) => void> = [];
+      const stdoutListeners: Array<(d: Buffer) => void> = [];
+      const stderrListeners: Array<(d: Buffer) => void> = [];
+
+      const mockChild = {
+        stdout: {
+          on: vi.fn((event: string, handler: (d: Buffer) => void) => {
+            if (event === "data") stdoutListeners.push(handler);
+          }),
+        },
+        stderr: {
+          on: vi.fn((event: string, handler: (d: Buffer) => void) => {
+            if (event === "data") stderrListeners.push(handler);
+          }),
+        },
+        stdin: { write: vi.fn(), end: vi.fn() },
+        on: vi.fn((event: string, handler: (arg: unknown) => void) => {
+          if (event === "close") closeListeners.push(handler as (code: number | null) => void);
+          if (event === "error") errorListeners.push(handler as (err: Error) => void);
+        }),
+        kill: vi.fn(),
+      };
+
+      const trigger = {
+        close: (code: number | null) => closeListeners.forEach(h => h(code)),
+        error: (err: Error) => errorListeners.forEach(h => h(err)),
+        stdoutData: (data: string) => stdoutListeners.forEach(h => h(Buffer.from(data))),
+        stderrData: (data: string) => stderrListeners.forEach(h => h(Buffer.from(data))),
+      };
+
+      return { mockChild, trigger };
+    }
+
+    it("should write stdin and collect stdout via spawn", async () => {
+      const { spawn } = await import("child_process");
+      const mockSpawn = vi.mocked(spawn);
+
+      const { mockChild, trigger } = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setImmediate(() => {
+          trigger.stdoutData("hello from spawn");
+          trigger.close(0);
+        });
+        return mockChild as unknown as ChildProcess;
+      });
+
+      const result = await runCli("cat", [], { stdin: "hello" });
+
+      expect(mockSpawn).toHaveBeenCalledWith("cat", [], expect.objectContaining({ stdio: ["pipe", "pipe", "pipe"] }));
+      expect(mockChild.stdin.write).toHaveBeenCalledWith("hello");
+      expect(mockChild.stdin.end).toHaveBeenCalled();
+      expect(result.stdout).toBe("hello from spawn");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should handle spawn error event and return exitCode 1", async () => {
+      const { spawn } = await import("child_process");
+      const mockSpawn = vi.mocked(spawn);
+
+      const { mockChild, trigger } = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setImmediate(() => {
+          trigger.error(Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+        });
+        return mockChild as unknown as ChildProcess;
+      });
+
+      const result = await runCli("nonexistent-cmd", [], { stdin: "data" });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toBe("spawn ENOENT");
+    });
+
+    it("should return non-zero exitCode from spawn close event", async () => {
+      const { spawn } = await import("child_process");
+      const mockSpawn = vi.mocked(spawn);
+
+      const { mockChild, trigger } = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setImmediate(() => {
+          trigger.stderrData("command not found");
+          trigger.close(127);
+        });
+        return mockChild as unknown as ChildProcess;
+      });
+
+      const result = await runCli("missing", ["arg"], { stdin: "input" });
+
+      expect(result.exitCode).toBe(127);
+      expect(result.stderr).toBe("command not found");
+    });
+
+    it("should use exitCode 1 when spawn close code is null", async () => {
+      const { spawn } = await import("child_process");
+      const mockSpawn = vi.mocked(spawn);
+
+      const { mockChild, trigger } = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        setImmediate(() => {
+          trigger.close(null);
+        });
+        return mockChild as unknown as ChildProcess;
+      });
+
+      const result = await runCli("cmd", [], { stdin: "" });
+
+      // null code → code ?? 1 → 1
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should kill child process when spawn timeout fires", async () => {
+      const { spawn } = await import("child_process");
+      const mockSpawn = vi.mocked(spawn);
+
+      const { mockChild, trigger } = createMockChildProcess();
+      mockSpawn.mockImplementation(() => {
+        // Close AFTER the timeout would have fired
+        setTimeout(() => trigger.close(0), 200);
+        return mockChild as unknown as ChildProcess;
+      });
+
+      await runCli("slow-cmd", [], { stdin: "x", timeout: 50 });
+
+      // kill() must have been called by the timeout handler
+      expect(mockChild.kill).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #608 — test: GitHub/gh CLI 실패 경계조건 강화 — 외부 의존 에러 핸들링

issue-fetcher.ts 등 외부 의존 경로의 커버리지가 59%로 약함. 실제 운영 실패의 상당수가 외부 CLI/네트워크/권한 경계에서 발생하나, 해당 경로의 테스트가 부족. 특히 fetchPR()은 테스트가 전무하고, cli-runner.ts의 ENOENT/타임아웃/stdin 경로, rate-limit 재시도 전체 사이클 등이 미검증 상태.

## Requirements

- malformed JSON 응답 (gh CLI 출력이 깨진 경우) 테스트
- auth 실패 (token 만료, 권한 부족) 테스트
- repo 접근 불가 (private repo, 삭제된 repo) 테스트
- rate-limit 응답 (403 + retry-after) 테스트
- issue not found (404) 테스트
- PR not found (404) 테스트
- gh CLI 미설치 / 오작동 (ENOENT, 비정상 exit code) 테스트
- 네트워크 타임아웃 테스트
- 기존 테스트 깨뜨리지 않음 (npx vitest run 전체 통과)
- npx tsc --noEmit 통과

## Implementation Phases

- Phase 0: cli-runner 경계조건 테스트 — SUCCESS (a5d54504)
- Phase 1: issue-fetcher 실패 경계조건 테스트 — SUCCESS (a5d54504)
- Phase 2: pr-creator 실패 경계조건 테스트 — SUCCESS (a5d54504)
- Phase 3: 전체 검증 — SUCCESS (a5d54504)

## Risks

- cli-runner.ts의 execFile mock이 복잡해 ENOENT/타임아웃 시뮬레이션이 까다로울 수 있음 — 기존 mock 패턴(vi.mock) 활용
- rate-limit 재시도 로직이 withRateLimit 내부에 있어 단위 테스트로 분리 검증이 필요할 수 있음
- fetchPR은 fetchIssue와 구조가 유사하나 반환 타입이 다르므로 별도 검증 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.0000
- **Phases**: 4/4 completed
- **Branch**: `aq/608-test-github-gh-cli` → `develop`
- **Tokens**: 106 input, 33162 output{{#stats.cacheCreationTokens}}, 185156 cache creation{{/stats.cacheCreationTokens}}{{#stats.cacheReadTokens}}, 1618080 cache read{{/stats.cacheReadTokens}}

---

> Generated by AI 병참부 (AI Quartermaster)


Closes #608