### PR TITLE
[AQ-#637] feat: project detector v2 — lockfile/wrapper 기반 정밀 감지

### DIFF
--- a/src/config/project-detector.ts
+++ b/src/config/project-detector.ts
@@ -39,29 +39,76 @@ function parsePackageJson(projectPath: string): Record<string, string> {
   }
 }
 
-function detectNodeCommands(projectPath: string): Partial<CommandsConfig> {
-  const scripts = parsePackageJson(projectPath);
+interface PackageManagerDetection {
+  packageManager: DetectedPackageManager;
+  confidence: "high" | "medium";
+  fallbackReason?: string;
+}
+
+function detectPackageManager(projectPath: string): PackageManagerDetection {
+  if (existsSync(join(projectPath, "pnpm-lock.yaml"))) {
+    return { packageManager: "pnpm", confidence: "high" };
+  }
+  if (existsSync(join(projectPath, "yarn.lock"))) {
+    return { packageManager: "yarn", confidence: "high" };
+  }
+  if (existsSync(join(projectPath, "bun.lockb"))) {
+    return { packageManager: "bun", confidence: "high" };
+  }
+  return {
+    packageManager: "npm",
+    confidence: "medium",
+    fallbackReason: "lockfile 없음 — npm fallback",
+  };
+}
+
+function buildNodeCommands(
+  scripts: Record<string, string>,
+  projectPath: string,
+  pm: DetectedPackageManager,
+): Partial<CommandsConfig> {
+  const run = (script: string): string => {
+    if (pm === "yarn") return `yarn ${script}`;
+    return `${pm} run ${script}`;
+  };
+
   const commands: Partial<CommandsConfig> = {};
 
-  commands.test = scripts["test"] ? "npm test" : "echo skip";
+  if (pm === "bun") {
+    commands.test = scripts["test"] ? "bun test" : "echo skip";
+  } else if (pm === "yarn") {
+    commands.test = scripts["test"] ? "yarn test" : "echo skip";
+  } else {
+    commands.test = scripts["test"] ? `${pm} test` : "echo skip";
+  }
 
   if (scripts["lint"]) {
-    commands.lint = "npm run lint";
+    commands.lint = run("lint");
   }
 
   if (scripts["build"]) {
-    commands.build = "npm run build";
+    commands.build = run("build");
   }
 
   if (scripts["typecheck"]) {
-    commands.typecheck = "npm run typecheck";
+    commands.typecheck = run("typecheck");
   } else if (scripts["type-check"]) {
-    commands.typecheck = "npm run type-check";
+    commands.typecheck = run("type-check");
   } else if (existsSync(join(projectPath, "tsconfig.json"))) {
     commands.typecheck = "npx tsc --noEmit";
   }
 
   return commands;
+}
+
+function detectNodeCommands(projectPath: string): {
+  commands: Partial<CommandsConfig>;
+  pmDetection: PackageManagerDetection;
+} {
+  const scripts = parsePackageJson(projectPath);
+  const pmDetection = detectPackageManager(projectPath);
+  const commands = buildNodeCommands(scripts, projectPath, pmDetection.packageManager);
+  return { commands, pmDetection };
 }
 
 export function detectProjectCommands(projectPath: string): DetectionResult {
@@ -70,24 +117,39 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
   try {
     if (existsSync(join(projectPath, "package.json"))) {
       logger.debug(`[project-detector] Node.js 프로젝트 감지: ${projectPath}`);
-      return { language: "nodejs", commands: detectNodeCommands(projectPath), confidence: "high" };
+      const { commands, pmDetection } = detectNodeCommands(projectPath);
+      return {
+        language: "nodejs",
+        commands,
+        confidence: pmDetection.confidence,
+        packageManager: pmDetection.packageManager,
+        ...(pmDetection.fallbackReason ? { fallbackReason: pmDetection.fallbackReason } : {}),
+      };
     }
 
     if (existsSync(join(projectPath, "build.gradle.kts"))) {
       logger.debug(`[project-detector] Kotlin-Gradle 프로젝트 감지: ${projectPath}`);
+      const hasWrapper = existsSync(join(projectPath, "gradlew"));
       return {
         language: "kotlin-gradle",
-        commands: { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" },
-        confidence: "high",
+        commands: hasWrapper
+          ? { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" }
+          : { test: "gradle test", build: "gradle build", typecheck: "echo skip" },
+        confidence: hasWrapper ? "high" : "medium",
+        ...(hasWrapper ? {} : { fallbackReason: "gradlew not found" }),
       };
     }
 
     if (existsSync(join(projectPath, "build.gradle"))) {
       logger.debug(`[project-detector] Java-Gradle 프로젝트 감지: ${projectPath}`);
+      const hasWrapper = existsSync(join(projectPath, "gradlew"));
       return {
         language: "java-gradle",
-        commands: { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" },
-        confidence: "high",
+        commands: hasWrapper
+          ? { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" }
+          : { test: "gradle test", build: "gradle build", typecheck: "echo skip" },
+        confidence: hasWrapper ? "high" : "medium",
+        ...(hasWrapper ? {} : { fallbackReason: "gradlew not found" }),
       };
     }
 
@@ -132,10 +194,10 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
     }
 
     logger.debug(`[project-detector] 언어 감지 불가: ${projectPath}`);
-    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low" };
+    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low", fallbackReason: "no project marker found" };
   } catch (err: unknown) {
     logger.warn(`[project-detector] 감지 중 오류: ${getErrorMessage(err)}`);
-    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low" };
+    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low", fallbackReason: "no project marker found" };
   }
 }
 

--- a/src/config/project-detector.ts
+++ b/src/config/project-detector.ts
@@ -14,9 +14,14 @@ export type DetectedLanguage =
   | "rust"
   | "unknown";
 
+export type DetectedPackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
 export interface DetectionResult {
   language: DetectedLanguage;
   commands: Partial<CommandsConfig>;
+  confidence: "high" | "medium" | "low";
+  fallbackReason?: string;
+  packageManager?: DetectedPackageManager;
 }
 
 const SAFE_DEFAULT_COMMANDS: Partial<CommandsConfig> = {
@@ -65,7 +70,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
   try {
     if (existsSync(join(projectPath, "package.json"))) {
       logger.debug(`[project-detector] Node.js 프로젝트 감지: ${projectPath}`);
-      return { language: "nodejs", commands: detectNodeCommands(projectPath) };
+      return { language: "nodejs", commands: detectNodeCommands(projectPath), confidence: "high" };
     }
 
     if (existsSync(join(projectPath, "build.gradle.kts"))) {
@@ -73,6 +78,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "kotlin-gradle",
         commands: { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" },
+        confidence: "high",
       };
     }
 
@@ -81,6 +87,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "java-gradle",
         commands: { test: "./gradlew test", build: "./gradlew build", typecheck: "echo skip" },
+        confidence: "high",
       };
     }
 
@@ -89,6 +96,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "java-maven",
         commands: { test: "mvn test", build: "mvn package -DskipTests", typecheck: "echo skip" },
+        confidence: "high",
       };
     }
 
@@ -101,6 +109,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "python",
         commands: { test: "python -m pytest", lint: "ruff check .", typecheck: "echo skip" },
+        confidence: "high",
       };
     }
 
@@ -109,6 +118,7 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "go",
         commands: { test: "go test ./...", build: "go build ./...", typecheck: "go vet ./..." },
+        confidence: "high",
       };
     }
 
@@ -117,14 +127,15 @@ export function detectProjectCommands(projectPath: string): DetectionResult {
       return {
         language: "rust",
         commands: { test: "cargo test", build: "cargo build", lint: "cargo clippy", typecheck: "echo skip" },
+        confidence: "high",
       };
     }
 
     logger.debug(`[project-detector] 언어 감지 불가: ${projectPath}`);
-    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS };
+    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low" };
   } catch (err: unknown) {
     logger.warn(`[project-detector] 감지 중 오류: ${getErrorMessage(err)}`);
-    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS };
+    return { language: "unknown", commands: SAFE_DEFAULT_COMMANDS, confidence: "low" };
   }
 }
 

--- a/tests/config/project-detector.test.ts
+++ b/tests/config/project-detector.test.ts
@@ -114,22 +114,46 @@ describe("detectProjectCommands", () => {
   describe("Kotlin-Gradle 감지", () => {
     it("build.gradle.kts가 있으면 kotlin-gradle로 감지한다", () => {
       writeFileSync(join(testDir, "build.gradle.kts"), "");
+      writeFileSync(join(testDir, "gradlew"), "");
       const result = detectProjectCommands(testDir);
       expect(result.language).toBe("kotlin-gradle");
       expect(result.commands.test).toBe("./gradlew test");
       expect(result.commands.build).toBe("./gradlew build");
       expect(result.commands.typecheck).toBe("echo skip");
+      expect(result.confidence).toBe("high");
+    });
+
+    it("gradlew가 없으면 gradle fallback (medium confidence)", () => {
+      writeFileSync(join(testDir, "build.gradle.kts"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.language).toBe("kotlin-gradle");
+      expect(result.commands.test).toBe("gradle test");
+      expect(result.commands.build).toBe("gradle build");
+      expect(result.confidence).toBe("medium");
+      expect(result.fallbackReason).toBe("gradlew not found");
     });
   });
 
   describe("Java-Gradle 감지", () => {
     it("build.gradle가 있으면 java-gradle로 감지한다", () => {
       writeFileSync(join(testDir, "build.gradle"), "");
+      writeFileSync(join(testDir, "gradlew"), "");
       const result = detectProjectCommands(testDir);
       expect(result.language).toBe("java-gradle");
       expect(result.commands.test).toBe("./gradlew test");
       expect(result.commands.build).toBe("./gradlew build");
       expect(result.commands.typecheck).toBe("echo skip");
+      expect(result.confidence).toBe("high");
+    });
+
+    it("gradlew가 없으면 gradle fallback (medium confidence)", () => {
+      writeFileSync(join(testDir, "build.gradle"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.language).toBe("java-gradle");
+      expect(result.commands.test).toBe("gradle test");
+      expect(result.commands.build).toBe("gradle build");
+      expect(result.confidence).toBe("medium");
+      expect(result.fallbackReason).toBe("gradlew not found");
     });
   });
 

--- a/tests/config/project-detector.test.ts
+++ b/tests/config/project-detector.test.ts
@@ -221,6 +221,119 @@ describe("detectProjectCommands", () => {
     });
   });
 
+  describe("lockfile 기반 패키지 매니저 감지", () => {
+    it("pnpm-lock.yaml이 있으면 pnpm으로 감지한다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "pnpm-lock.yaml"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("pnpm");
+      expect(result.confidence).toBe("high");
+      expect(result.fallbackReason).toBeUndefined();
+    });
+
+    it("pnpm-lock.yaml이 있으면 test 커맨드가 pnpm test이다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "pnpm-lock.yaml"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.test).toBe("pnpm test");
+    });
+
+    it("pnpm-lock.yaml이 있으면 lint/build 커맨드에 pnpm run을 사용한다", () => {
+      writeFileSync(
+        join(testDir, "package.json"),
+        JSON.stringify({ scripts: { test: "vitest run", lint: "eslint .", build: "tsc" } }),
+      );
+      writeFileSync(join(testDir, "pnpm-lock.yaml"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.lint).toBe("pnpm run lint");
+      expect(result.commands.build).toBe("pnpm run build");
+    });
+
+    it("yarn.lock이 있으면 yarn으로 감지한다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "yarn.lock"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("yarn");
+      expect(result.confidence).toBe("high");
+      expect(result.fallbackReason).toBeUndefined();
+    });
+
+    it("yarn.lock이 있으면 test 커맨드가 yarn test이다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "yarn.lock"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.test).toBe("yarn test");
+    });
+
+    it("yarn.lock이 있으면 lint/build 커맨드에 yarn을 사용한다", () => {
+      writeFileSync(
+        join(testDir, "package.json"),
+        JSON.stringify({ scripts: { test: "vitest run", lint: "eslint .", build: "tsc" } }),
+      );
+      writeFileSync(join(testDir, "yarn.lock"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.lint).toBe("yarn lint");
+      expect(result.commands.build).toBe("yarn build");
+    });
+
+    it("bun.lockb가 있으면 bun으로 감지한다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "bun.lockb"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("bun");
+      expect(result.confidence).toBe("high");
+      expect(result.fallbackReason).toBeUndefined();
+    });
+
+    it("bun.lockb가 있으면 test 커맨드가 bun test이다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "bun.lockb"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.test).toBe("bun test");
+    });
+
+    it("bun.lockb가 있으면 lint/build 커맨드에 bun run을 사용한다", () => {
+      writeFileSync(
+        join(testDir, "package.json"),
+        JSON.stringify({ scripts: { test: "vitest run", lint: "eslint .", build: "tsc" } }),
+      );
+      writeFileSync(join(testDir, "bun.lockb"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.lint).toBe("bun run lint");
+      expect(result.commands.build).toBe("bun run build");
+    });
+
+    it("lockfile이 없으면 npm fallback이고 confidence가 medium이다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("npm");
+      expect(result.confidence).toBe("medium");
+      expect(result.fallbackReason).toBe("lockfile 없음 — npm fallback");
+    });
+
+    it("lockfile이 없으면 test 커맨드가 npm test이다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      const result = detectProjectCommands(testDir);
+      expect(result.commands.test).toBe("npm test");
+    });
+
+    it("scripts.test가 없고 lockfile도 없으면 test는 echo skip이고 npm fallback", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: {} }));
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("npm");
+      expect(result.commands.test).toBe("echo skip");
+      expect(result.confidence).toBe("medium");
+    });
+
+    it("pnpm-lock.yaml과 yarn.lock이 함께 있으면 pnpm이 우선한다", () => {
+      writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: { test: "vitest run" } }));
+      writeFileSync(join(testDir, "pnpm-lock.yaml"), "");
+      writeFileSync(join(testDir, "yarn.lock"), "");
+      const result = detectProjectCommands(testDir);
+      expect(result.packageManager).toBe("pnpm");
+    });
+  });
+
   describe("감지 우선순위", () => {
     it("package.json이 있으면 build.gradle.kts보다 nodejs가 우선", () => {
       writeFileSync(join(testDir, "package.json"), JSON.stringify({ scripts: {} }));


### PR DESCRIPTION
## Summary

Resolves #637 — feat: project detector v2 — lockfile/wrapper 기반 정밀 감지

현재 project-detector는 Node.js 프로젝트에서 항상 `npm`을 사용하고, Gradle 프로젝트에서 wrapper 존재 여부를 확인하지 않는다. 감지 결과에 신뢰도 정보도 없어 downstream에서 판단 근거를 알 수 없다. lockfile 기반 패키지 매니저 선택, Gradle wrapper 분기, confidence/fallbackReason 필드 추가가 필요하다.

## Requirements

- pnpm-lock.yaml / yarn.lock / bun.lockb 감지 후 패키지 매니저 명령 선택 (npm fallback)
- Gradle wrapper(./gradlew) 존재 여부에 따라 ./gradlew vs gradle 분기
- DetectionResult에 confidence('high'|'medium'|'low') + fallbackReason(string|undefined) 필드 추가
- detector fixture 기반 단위 테스트 추가

## Implementation Phases

- Phase 0: 타입 확장 — SUCCESS (0a6dd5f8)
- Phase 1: lockfile 기반 패키지 매니저 감지 — SUCCESS (bc7ba383)
- Phase 2: Gradle wrapper 분기 — SUCCESS (bc7ba383)
- Phase 3: 나머지 언어 confidence 할당 + unknown fallback 보강 — SUCCESS (bc7ba383)
- Phase 4: fixture 기반 단위 테스트 — SUCCESS (21d26407)

## Risks

- DetectionResult 인터페이스 변경 시 dashboard-api.ts 등 소비자 코드가 영향받을 수 있음 → 새 필드는 추가만이므로 하위 호환성 유지됨
- bun.lockb는 바이너리 파일이라 existsSync로만 감지 (내용 파싱 불필요)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.4037 (review: $0.1112)
- **Phases**: 5/5 completed
- **Branch**: `aq/637-feat-project-detector-v2-lockfile-wrapper` → `develop`
- **Tokens**: 165 input, 28701 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 타입 확장 | $0.4483 | 0 | $0.0000 |
| lockfile 기반 패키지 매니저 감지 | $0.4679 | 0 | $0.0000 |
| Gradle wrapper 분기 | $0.1857 | 1 | $0.1857 |
| 나머지 언어 confidence 할당 + unknown fallback 보강 | $0.4504 | 0 | $0.0000 |
| fixture 기반 단위 테스트 | $0.2577 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.8100 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #637