### PR TITLE
[AQ-#642] fix: phaseResults에 startedAt/completedAt 기록 + 타임라인 Gantt 절대 시간 배치

### DIFF
--- a/src/server/public/js/timeline.js
+++ b/src/server/public/js/timeline.js
@@ -80,16 +80,19 @@ function renderGanttChart(phases, totalDurationMs, epochStart) {
       '<span class="material-symbols-outlined text-lg mr-2">hourglass_empty</span>No phase data available</div>';
   }
 
+  var hasTimestamps = epochStart && phases.some(function(p) { return p.startedAt; });
+
   // Legend
-  var html = '<div class="flex gap-4 text-[10px] font-mono text-outline mb-6">' +
+  var html = '<div class="flex flex-wrap gap-4 text-[10px] font-mono text-outline mb-6">' +
     '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#3fb950]"></span> SUCCESS</span>' +
     '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#f85149]"></span> FAILED</span>' +
     '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-[#58a6ff]"></span> RUNNING</span>' +
     '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full" style="background:#31353c"></span> PENDING</span>' +
+    (hasTimestamps ? '<span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded" style="background:rgba(65,71,82,0.5)"></span> GAP/IDLE</span>' : '') +
     '</div>';
 
   // X-axis labels
-  html += buildXAxis(totalDurationMs);
+  html += buildXAxis(totalDurationMs, hasTimestamps ? epochStart : null);
 
   // Phase rows with grid overlay
   html += '<div class="relative">';
@@ -99,9 +102,22 @@ function renderGanttChart(phases, totalDurationMs, epochStart) {
 
   html += '<div class="space-y-4">';
   var cumulativeMs = 0;
-  phases.forEach(function(phase) {
+  phases.forEach(function(phase, i) {
     html += renderGanttPhaseRow(phase, epochStart, cumulativeMs, totalDurationMs);
     cumulativeMs += (phase.durationMs || 0);
+
+    // Gap rendering: only when timestamp data is available
+    if (hasTimestamps && phase.completedAt && i + 1 < phases.length) {
+      var nextPhase = phases[i + 1];
+      if (nextPhase.startedAt) {
+        var gapStartMs = new Date(phase.completedAt) - epochStart;
+        var gapEndMs = new Date(nextPhase.startedAt) - epochStart;
+        var gapDurationMs = gapEndMs - gapStartMs;
+        if (gapDurationMs > 1000) {
+          html += renderGanttGapRow(gapStartMs, gapDurationMs, totalDurationMs);
+        }
+      }
+    }
   });
   html += '</div>';
   html += '</div>';
@@ -113,19 +129,72 @@ function renderGanttChart(phases, totalDurationMs, epochStart) {
    X-Axis
    ══════════════════════════════════════════════════════════════ */
 
-function buildXAxis(totalDurationMs) {
+function buildXAxis(totalDurationMs, epochStart) {
   var TICKS = 6;
   var labels = [];
   for (var i = 0; i < TICKS; i++) {
     var ms = totalDurationMs > 0 ? Math.round((totalDurationMs * i) / (TICKS - 1)) : 0;
-    labels.push(fmtDurationMs(ms));
+    if (epochStart) {
+      // Relative time labels: +0m, +5m, ... (wall-clock based)
+      var mins = Math.round(ms / 60000);
+      labels.push('+' + mins + 'm');
+    } else {
+      labels.push(fmtDurationMs(ms));
+    }
   }
 
-  var html = '<div class="flex justify-between text-[10px] font-mono text-outline-variant pb-2 border-b border-outline-variant/10 mb-4" style="margin-left:12rem">';
+  var axisLabel = epochStart ? '<span class="text-[9px] text-outline-variant/50 mr-2">wall-clock</span>' : '';
+
+  var html = '<div class="flex items-center pb-2 border-b border-outline-variant/10 mb-4" style="margin-left:12rem">' +
+    axisLabel +
+    '<div class="flex justify-between flex-1 text-[10px] font-mono text-outline-variant">';
   labels.forEach(function(label, i) {
     var cls = i === labels.length - 1 ? ' class="text-primary"' : '';
     html += '<span' + cls + '>' + esc(label) + '</span>';
   });
+  html += '</div></div>';
+  return html;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   Gap Row
+   ══════════════════════════════════════════════════════════════ */
+
+function renderGanttGapRow(gapStartMs, gapDurationMs, totalDurationMs) {
+  var leftPct = totalDurationMs > 0 ? (gapStartMs / totalDurationMs * 100) : 0;
+  var widthPct = totalDurationMs > 0 ? (gapDurationMs / totalDurationMs * 100) : 0;
+
+  leftPct = Math.min(Math.max(leftPct, 0), 100);
+  widthPct = Math.max(widthPct, 0.5);
+  widthPct = Math.min(widthPct, 100 - leftPct);
+
+  var idleLabel = fmtDurationMs(gapDurationMs);
+
+  var barStyle = [
+    'position:absolute',
+    'left:' + leftPct.toFixed(2) + '%',
+    'top:0',
+    'height:100%',
+    'width:' + widthPct.toFixed(2) + '%',
+    'background:rgba(65,71,82,0.45)',
+    'border:1px dashed rgba(100,110,125,0.35)',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'border-radius:3px',
+    'overflow:hidden',
+    'min-width:4px'
+  ].join(';');
+
+  var html = '<div class="flex items-center">';
+  // Label column (same 12rem width as phase rows)
+  html += '<div class="pr-4 text-[10px] font-mono truncate" style="width:12rem;flex-shrink:0;color:rgba(100,110,125,0.6)">idle</div>';
+  // Bar track
+  html += '<div class="flex-1 relative" style="height:1.25rem">';
+  html += '<div style="' + barStyle + '">';
+  html += '<span class="text-[9px] font-mono" style="color:rgba(139,145,157,0.7)">' + esc(idleLabel) + '</span>';
+  html += '</div>';
+  html += '</div>';
   html += '</div>';
   return html;
 }


### PR DESCRIPTION
## Summary

Resolves #642 — fix: phaseResults에 startedAt/completedAt 기록 + 타임라인 Gantt 절대 시간 배치

Job의 총 wall-clock 시간(47분) 중 phaseResults 합산(22분, 46%)만 기록되는데, Gantt 차트가 bars를 순차로 붙여 그려서 phase 사이의 gap(유휴 시간)이 시각적으로 소거됨. 분석 결과 startedAt/completedAt 타입과 executor 기록은 이미 구현되어 있으나, timeline.js에서 phase 간 gap을 별도 회색 영역으로 시각화하는 부분이 누락됨.

## Requirements

- PhaseResult 타입에 startedAt/completedAt 필드 존재 확인 (이미 구현됨 — pipeline.ts:144-145)
- phase-executor/phase-retry 모든 return 경로에서 타임스탬프 기록 확인 (이미 구현됨)
- timeline.js renderGanttChart가 startedAt 기준 절대 시간 좌표로 bar 배치 (이미 구현됨 — lines 148-160)
- timeline.js에서 phase 사이 gap을 별도 회색 영역으로 렌더 (미구현 — 핵심 작업)
- X축 라벨을 절대 시간(wall-clock) 기준으로 표시 옵션 추가

## Implementation Phases

- Phase 0: Gap 렌더링 + X축 개선 (timeline.js) — SUCCESS (3998de2a)
- Phase 1: 빌드 검증 + 타입 체크 — SUCCESS (3998de2a)

## Risks

- timeline.js가 vanilla JS라 타입 안전성 없음 — Date 파싱 실패 시 NaN 전파 가능, 방어 코드 필요
- epochStart(job.startedAt)가 null이면 gap 계산 불가 — fallback 모드에서는 gap 렌더링 스킵 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.3039 (review: $0.1301)
- **Phases**: 2/2 completed
- **Branch**: `aq/642-fix-phaseresults-startedat-completedat-gantt` → `develop`
- **Tokens**: 56 input, 12705 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| Gap 렌더링 + X축 개선 (timeline.js) | $0.3454 | 0 | $0.0000 |
| 빌드 검증 + 타입 체크 | $0.1787 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.5241 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #642