### PR TITLE
[AQ-#647] feat: job 집계 API — 주간 처리량/성공률 엔드포인트

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1063,7 +1063,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     try {
       const queryParams = {
         project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "7d",
+        window: c.req.query("window") || "7d",
       };
 
       const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
@@ -1086,7 +1086,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     try {
       const queryParams = {
         project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "7d",
+        window: c.req.query("window") || "7d",
       };
 
       const parseResult = GetMetricsQuerySchema.safeParse(queryParams);

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -11,8 +11,8 @@ import type { ProjectConfig, AQConfig } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, UpdateJobPriorityRequestSchema, UpdateProjectRequestSchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
-import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange } from "../store/queries.js";
+import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, UpdateJobPriorityRequestSchema, UpdateProjectRequestSchema, GetMetricsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
 import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
 import { runCli } from "../utils/cli-runner.js";
@@ -1055,6 +1055,52 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
       return c.json(stats);
     } catch (error: unknown) {
       return c.json({ error: `Failed to fetch project stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
+    }
+  });
+
+  // Throughput time series
+  api.get("/api/metrics/throughput", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error)
+        }, 400);
+      }
+
+      const data = getThroughputTimeSeries(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return c.json({ error: `Failed to fetch throughput metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
+    }
+  });
+
+  // Success rate metrics
+  api.get("/api/metrics/success-rate", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error)
+        }, 400);
+      }
+
+      const data = getSuccessRate(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return c.json({ error: `Failed to fetch success rate metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
     }
   });
 

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -1,5 +1,5 @@
 import type { AQDatabase } from "./database.js";
-import type { StatsResponse, GetStatsQuery, CostsResponse, GetCostsQuery, CostEntry, GetProjectStatsQuery, ProjectStatsResponse } from "../types/api.js";
+import type { StatsResponse, GetStatsQuery, CostsResponse, GetCostsQuery, CostEntry, GetProjectStatsQuery, ProjectStatsResponse, GetMetricsQuery, ThroughputResponse, SuccessRateResponse } from "../types/api.js";
 
 // SQLite row types for query results
 interface StatsRow {
@@ -60,6 +60,7 @@ function getTimeRangeCutoff(timeRange: string): string | null {
     case "24h": return new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
     case "7d": return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
     case "30d": return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    case "90d": return new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
     default: return null;
   }
 }
@@ -252,6 +253,99 @@ export function getProjectStatsWithTimeRange(aqDb: AQDatabase, query: GetProject
       totalCostUsd: row.total_cost_usd,
       avgCostUsd: row.total > 0 ? row.total_cost_usd / row.total : 0,
     })),
+  };
+}
+
+interface ThroughputRow {
+  date: string;
+  count: number;
+}
+
+interface SuccessRateRow {
+  total: number;
+  success_count: number;
+  failure_count: number;
+  retry_success_count: number;
+}
+
+export function getThroughputTimeSeries(aqDb: AQDatabase, query: GetMetricsQuery): ThroughputResponse {
+  const { window, project } = query;
+  const cutoff = getTimeRangeCutoff(window);
+  const { sql: whereClause, params } = buildWhereClause(project, cutoff);
+
+  const db = aqDb.getDb();
+
+  const rows = db.prepare(`
+    SELECT
+      date(created_at) AS date,
+      COUNT(*) AS count
+    FROM jobs
+    ${whereClause}
+    GROUP BY date(created_at)
+    ORDER BY date(created_at)
+  `).all(...params) as ThroughputRow[];
+
+  return {
+    window,
+    project: project ?? null,
+    series: rows.map(row => ({ date: row.date, count: row.count })),
+  };
+}
+
+export function getSuccessRate(aqDb: AQDatabase, query: GetMetricsQuery): SuccessRateResponse {
+  const { window, project } = query;
+  const cutoff = getTimeRangeCutoff(window);
+  const { sql: whereClause, params } = buildWhereClause(project, cutoff);
+
+  const db = aqDb.getDb();
+
+  const row = db.prepare(`
+    WITH latest_jobs AS (
+      SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY issue_number, repo ORDER BY created_at DESC) AS rn
+      FROM jobs
+      ${whereClause}
+    )
+    SELECT
+      COUNT(*) AS total,
+      SUM(CASE
+        WHEN status = 'success' AND NOT EXISTS (
+          SELECT 1 FROM jobs j2
+          WHERE j2.issue_number = latest_jobs.issue_number
+            AND j2.repo = latest_jobs.repo
+            AND j2.status = 'failure'
+            AND j2.id != latest_jobs.id
+        ) THEN 1 ELSE 0
+      END) AS success_count,
+      SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) AS failure_count,
+      SUM(CASE
+        WHEN status = 'success' AND EXISTS (
+          SELECT 1 FROM jobs j2
+          WHERE j2.issue_number = latest_jobs.issue_number
+            AND j2.repo = latest_jobs.repo
+            AND j2.status = 'failure'
+            AND j2.id != latest_jobs.id
+        ) THEN 1 ELSE 0
+      END) AS retry_success_count
+    FROM latest_jobs
+    WHERE rn = 1
+  `).get(...params) as SuccessRateRow;
+
+  const total = row.total ?? 0;
+  const successCount = row.success_count ?? 0;
+  const failureCount = row.failure_count ?? 0;
+  const retrySuccessCount = row.retry_success_count ?? 0;
+
+  return {
+    window,
+    project: project ?? null,
+    total,
+    successCount,
+    failureCount,
+    retrySuccessCount,
+    successRate: total > 0 ? Math.round((successCount / total) * 100) : 0,
+    failureRate: total > 0 ? Math.round((failureCount / total) * 100) : 0,
+    retrySuccessRate: total > 0 ? Math.round((retrySuccessCount / total) * 100) : 0,
   };
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -373,6 +373,45 @@ export const CostBreakdownResponseSchema = z.object({
 
 export type CostBreakdownResponse = z.infer<typeof CostBreakdownResponseSchema>;
 
+// GetMetrics 쿼리 스키마 (GET /api/metrics/throughput, GET /api/metrics/success-rate)
+export const GetMetricsQuerySchema = z.object({
+  window: z.enum(["7d", "30d", "90d"]).default("7d"),
+  project: z.string().optional(),
+}).strict();
+
+export type GetMetricsQuery = z.infer<typeof GetMetricsQuerySchema>;
+
+// ThroughputResponse 응답 타입 (GET /api/metrics/throughput)
+export const ThroughputSeriesEntrySchema = z.object({
+  date: z.string(), // YYYY-MM-DD
+  count: z.number().int().nonnegative(),
+});
+
+export type ThroughputSeriesEntry = z.infer<typeof ThroughputSeriesEntrySchema>;
+
+export const ThroughputResponseSchema = z.object({
+  window: z.enum(["7d", "30d", "90d"]),
+  project: z.string().nullable(),
+  series: z.array(ThroughputSeriesEntrySchema),
+});
+
+export type ThroughputResponse = z.infer<typeof ThroughputResponseSchema>;
+
+// SuccessRateResponse 응답 타입 (GET /api/metrics/success-rate)
+export const SuccessRateResponseSchema = z.object({
+  window: z.enum(["7d", "30d", "90d"]),
+  project: z.string().nullable(),
+  total: z.number().int().nonnegative(),
+  successCount: z.number().int().nonnegative(),
+  failureCount: z.number().int().nonnegative(),
+  retrySuccessCount: z.number().int().nonnegative(),
+  successRate: z.number().min(0).max(100),
+  failureRate: z.number().min(0).max(100),
+  retrySuccessRate: z.number().min(0).max(100),
+});
+
+export type SuccessRateResponse = z.infer<typeof SuccessRateResponseSchema>;
+
 // Zod 에러를 클라이언트 친화적 형태로 변환
 export function formatZodError(error: z.ZodError): { field: string; message: string }[] {
   return error.issues.map((issue) => ({

--- a/tests/server/metrics-api.test.ts
+++ b/tests/server/metrics-api.test.ts
@@ -1,0 +1,208 @@
+/**
+ * metrics API 테스트
+ * GET /api/metrics/throughput, GET /api/metrics/success-rate
+ *
+ * 테스트 전략:
+ *  - 쿼리 함수 직접 호출 (in-memory SQLite AQDatabase)
+ *  - HTTP 400 검증은 inline Hono app 사용
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { AQDatabase } from "../../src/store/database.js";
+import type { DatabaseJob } from "../../src/store/database.js";
+import { getThroughputTimeSeries, getSuccessRate } from "../../src/store/queries.js";
+import { GetMetricsQuerySchema, formatZodError } from "../../src/types/api.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  setGlobalLogLevel: vi.fn(),
+}));
+
+vi.mock("../../src/config/project-resolver.js", () => ({
+  AQM_HOME: "/tmp",
+}));
+
+// ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+function makeJob(id: string, overrides: Partial<DatabaseJob> = {}): DatabaseJob {
+  return {
+    id,
+    issueNumber: 1,
+    repo: "test/repo",
+    status: "success",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** N일 전 자정(UTC) ISO 문자열 */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString();
+}
+
+/** ISO 문자열에서 YYYY-MM-DD 추출 */
+function toDate(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+// ── 테스트 ───────────────────────────────────────────────────────────────────
+
+describe("metrics API", () => {
+  let db: AQDatabase;
+
+  beforeEach(() => {
+    db = new AQDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── throughput ────────────────────────────────────────────────────────────
+
+  describe("throughput", () => {
+    it("빈 DB 시 빈 series 반환", () => {
+      const result = getThroughputTimeSeries(db, { window: "7d" });
+
+      expect(result.window).toBe("7d");
+      expect(result.project).toBeNull();
+      expect(result.series).toEqual([]);
+    });
+
+    it("여러 날짜의 잡 삽입 후 일별 카운트 검증", () => {
+      const day2 = daysAgo(2);
+      const day1 = daysAgo(1);
+
+      // day2에 잡 2개, day1에 잡 1개
+      db.createJob(makeJob("j1", { issueNumber: 1, createdAt: day2 }));
+      db.createJob(makeJob("j2", { issueNumber: 2, createdAt: day2 }));
+      db.createJob(makeJob("j3", { issueNumber: 3, createdAt: day1 }));
+
+      const result = getThroughputTimeSeries(db, { window: "7d" });
+
+      expect(result.series).toHaveLength(2);
+
+      const entryDay2 = result.series.find(s => s.date === toDate(day2));
+      const entryDay1 = result.series.find(s => s.date === toDate(day1));
+      expect(entryDay2?.count).toBe(2);
+      expect(entryDay1?.count).toBe(1);
+    });
+
+    it("window=7d 범위 밖 잡은 제외", () => {
+      const inside = daysAgo(3);  // 7d 이내
+      const outside = daysAgo(10); // 7d 초과
+
+      db.createJob(makeJob("j-in", { issueNumber: 1, createdAt: inside }));
+      db.createJob(makeJob("j-out", { issueNumber: 2, createdAt: outside }));
+
+      const result = getThroughputTimeSeries(db, { window: "7d" });
+
+      expect(result.series).toHaveLength(1);
+      expect(result.series[0].date).toBe(toDate(inside));
+      expect(result.series[0].count).toBe(1);
+    });
+
+    it("project 필터 동작", () => {
+      const today = daysAgo(1);
+      db.createJob(makeJob("j-a", { repo: "org/project-a", issueNumber: 1, createdAt: today }));
+      db.createJob(makeJob("j-b", { repo: "org/project-b", issueNumber: 1, createdAt: today }));
+
+      const result = getThroughputTimeSeries(db, { window: "7d", project: "org/project-a" });
+
+      const totalCount = result.series.reduce((sum, s) => sum + s.count, 0);
+      expect(totalCount).toBe(1);
+      expect(result.project).toBe("org/project-a");
+    });
+  });
+
+  // ── success-rate ──────────────────────────────────────────────────────────
+
+  describe("success-rate", () => {
+    it("단순 성공/실패 비율", () => {
+      const t = daysAgo(1);
+      db.createJob(makeJob("j-s", { issueNumber: 1, status: "success", createdAt: t }));
+      db.createJob(makeJob("j-f", { issueNumber: 2, status: "failure", createdAt: t }));
+
+      const result = getSuccessRate(db, { window: "7d" });
+
+      expect(result.total).toBe(2);
+      expect(result.successCount).toBe(1);
+      expect(result.failureCount).toBe(1);
+      expect(result.retrySuccessCount).toBe(0);
+      expect(result.successRate).toBe(50);
+      expect(result.failureRate).toBe(50);
+      expect(result.retrySuccessRate).toBe(0);
+    });
+
+    it("동일 이슈 재시도 후 성공 → retrySuccessCount=1, failureCount=0", () => {
+      // 같은 issue_number, 같은 repo
+      // 먼저 실패 잡, 이후 성공 잡
+      const t1 = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2시간 전
+      const t2 = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(); // 1시간 전
+
+      db.createJob(makeJob("j-fail", { issueNumber: 1, status: "failure", createdAt: t1 }));
+      db.createJob(makeJob("j-success", { issueNumber: 1, status: "success", createdAt: t2 }));
+
+      const result = getSuccessRate(db, { window: "7d" });
+
+      // 최신 잡(j-success)만 집계 대상. 이전 failure가 존재하므로 retrySuccess
+      expect(result.total).toBe(1);
+      expect(result.retrySuccessCount).toBe(1);
+      expect(result.successCount).toBe(0);
+      expect(result.failureCount).toBe(0);
+    });
+
+    it("동일 이슈 최신 잡이 failure면 failure로 카운트", () => {
+      const t1 = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2시간 전
+      const t2 = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(); // 1시간 전
+
+      db.createJob(makeJob("j-success", { issueNumber: 1, status: "success", createdAt: t1 }));
+      db.createJob(makeJob("j-fail", { issueNumber: 1, status: "failure", createdAt: t2 }));
+
+      const result = getSuccessRate(db, { window: "7d" });
+
+      // 최신 잡(j-fail)이 failure → failure로 카운트
+      expect(result.total).toBe(1);
+      expect(result.failureCount).toBe(1);
+      expect(result.successCount).toBe(0);
+      expect(result.retrySuccessCount).toBe(0);
+    });
+  });
+
+  // ── 파라미터 검증 ─────────────────────────────────────────────────────────
+
+  describe("window 파라미터 검증", () => {
+    it("잘못된 window 파라미터 시 400 반환", async () => {
+      // GetMetricsQuerySchema 검증 로직을 inline Hono app으로 테스트
+      const app = new Hono();
+      app.get("/api/metrics/throughput", (c) => {
+        const queryParams = {
+          window: c.req.query("window"),
+          project: c.req.query("project"),
+        };
+        const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+        if (!parseResult.success) {
+          return c.json(
+            { error: "Invalid query parameters", details: formatZodError(parseResult.error) },
+            400,
+          );
+        }
+        return c.json({ ok: true });
+      });
+
+      const res = await app.request("/api/metrics/throughput?window=invalid");
+
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe("Invalid query parameters");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #647 — feat: job 집계 API — 주간 처리량/성공률 엔드포인트

대시보드에서 일별 처리 건수 시계열과 성공/실패/재시도후성공 비율을 표시하기 위한 두 개의 메트릭 API 엔드포인트가 필요하다. 현재 `/api/stats`는 집계 카운트만 제공하며 시계열이나 재시도 후 성공 분류가 없다. "재시도 후 성공" 분모 정의: 동일 issue_number의 최신 잡을 기준으로 이전 실패는 제외한다.

## Requirements

- GET /api/metrics/throughput?window=7d — 일별 처리 건수 시계열 배열 반환
- GET /api/metrics/success-rate?window=7d — 성공/실패/재시도후성공 비율(분모 포함) 반환
- window 파라미터: 7d, 30d, 90d 지원 (기본값 7d)
- project 파라미터로 프로젝트별 필터링 옵션
- SQLite 집계 쿼리를 src/store/queries.ts에 추가
- 재시도 후 성공 판정: 동일 issue_number+repo의 최신 잡이 success이고 이전 잡 중 failure가 있으면 retrySuccess로 분류
- Zod 스키마로 요청/응답 타입 정의
- 엔드포인트를 dashboard-api.ts에 등록
- Vitest 테스트 작성 (tests/server/metrics-api.test.ts)

## Implementation Phases

- Phase 0: API 타입 정의 — SUCCESS (ca910ce9)
- Phase 1: SQLite 집계 쿼리 구현 — SUCCESS (c159fe95)
- Phase 2: 엔드포인트 등록 — SUCCESS (4bc0313d)
- Phase 3: 테스트 작성 — SUCCESS (993ebe2e)

## Risks

- SQLite의 ROW_NUMBER() 윈도우 함수는 SQLite 3.25+(2018-09) 필요 — better-sqlite3가 번들하는 버전은 충족
- 동일 이슈의 잡이 대량일 경우 서브쿼리 성능 — idx_jobs_issue_repo 인덱스가 이미 존재하므로 문제없음
- window=90d는 기존 getTimeRangeCutoff에 없는 값 — 새 case 추가 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.7616 (review: $0.2152)
- **Phases**: 4/4 completed
- **Branch**: `aq/647-feat-job-api` → `develop`
- **Tokens**: 118 input, 34615 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| API 타입 정의 | $0.3805 | 0 | $0.0000 |
| SQLite 집계 쿼리 구현 | $0.4420 | 0 | $0.0000 |
| 엔드포인트 등록 | $0.3549 | 0 | $0.0000 |
| 테스트 작성 | $0.8425 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $2.0198 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #647