### PR TITLE
[AQ-#638] feat: baseline 확장 + 캡처 실패 침묵 제거

### DIFF
--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -197,8 +197,9 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     ctx.baseline = await captureErrorBaseline(ctx.cwd, {
       typecheck: ctx.config.commands.typecheck,
       lint: ctx.config.commands.lint,
+      test: ctx.config.commands.test,
     });
-    logger.info(`Baseline captured: tsc=${ctx.baseline.tsc.totalErrors} errors, eslint=${ctx.baseline.eslint.totalErrors} errors`);
+    logger.info(`Baseline captured: tsc=${ctx.baseline.tsc.totalErrors} errors, eslint=${ctx.baseline.eslint.totalErrors} errors, test failures=${ctx.baseline.test?.failedFiles.length ?? "not captured"}, capture warnings=${ctx.baseline.captureWarnings?.length ?? 0}`);
   }
 
   // Step 1: Generate plan

--- a/src/pipeline/reporting/error-baseline.ts
+++ b/src/pipeline/reporting/error-baseline.ts
@@ -4,6 +4,7 @@ import { getErrorMessage } from "../../utils/error-utils.js";
 import {
   parseTscOutput,
   parseEslintOutput,
+  parseVitestOutput,
   type BaselineErrors,
 } from "./verification-parser.js";
 
@@ -19,22 +20,44 @@ function emptyBaseline(): BaselineErrors {
 }
 
 /**
- * tsc와 eslint를 실행하여 현재 에러 상태를 BaselineErrors로 반환.
- * 캡처 실패 시 빈 baseline을 반환하여 파이프라인을 중단시키지 않는다.
+ * tsc, eslint, build, test를 실행하여 현재 에러 상태를 BaselineErrors로 반환.
+ * 캡처 실패 시 빈 baseline을 반환하지 않고, captureWarnings에 실패 정보를 기록한다.
  */
 export async function captureErrorBaseline(
   cwd: string,
-  commands: { typecheck: string; lint: string }
+  commands: { typecheck: string; lint: string; build?: string; test?: string }
 ): Promise<BaselineErrors> {
-  const [tscResult, eslintResult] = await Promise.all([
+  const captureWarnings: string[] = [];
+
+  const [tscResult, eslintResult, buildResult, testResult] = await Promise.all([
     runShell(commands.typecheck, { cwd, timeout: BASELINE_TIMEOUT_MS }).catch((err: unknown) => {
-      logger.warn(`baseline: tsc 실행 실패 — ${getErrorMessage(err)}`);
+      const msg = `baseline: tsc 실행 실패 — ${getErrorMessage(err)}`;
+      logger.warn(msg);
+      captureWarnings.push(msg);
       return null;
     }),
     runShell(commands.lint, { cwd, timeout: BASELINE_TIMEOUT_MS }).catch((err: unknown) => {
-      logger.warn(`baseline: eslint 실행 실패 — ${getErrorMessage(err)}`);
+      const msg = `baseline: eslint 실행 실패 — ${getErrorMessage(err)}`;
+      logger.warn(msg);
+      captureWarnings.push(msg);
       return null;
     }),
+    commands.build
+      ? runShell(commands.build, { cwd, timeout: BASELINE_TIMEOUT_MS }).catch((err: unknown) => {
+          const msg = `baseline: build 실행 실패 — ${getErrorMessage(err)}`;
+          logger.warn(msg);
+          captureWarnings.push(msg);
+          return null;
+        })
+      : Promise.resolve(null),
+    commands.test
+      ? runShell(commands.test, { cwd, timeout: BASELINE_TIMEOUT_MS }).catch((err: unknown) => {
+          const msg = `baseline: test 실행 실패 — ${getErrorMessage(err)}`;
+          logger.warn(msg);
+          captureWarnings.push(msg);
+          return null;
+        })
+      : Promise.resolve(null),
   ]);
 
   const baseline = emptyBaseline();
@@ -43,7 +66,9 @@ export async function captureErrorBaseline(
     try {
       baseline.tsc = parseTscOutput(tscResult.stdout + tscResult.stderr);
     } catch (err: unknown) {
-      logger.warn(`baseline: tsc 출력 파싱 실패 — ${getErrorMessage(err)}`);
+      const msg = `baseline: tsc 출력 파싱 실패 — ${getErrorMessage(err)}`;
+      logger.warn(msg);
+      captureWarnings.push(msg);
     }
   }
 
@@ -51,8 +76,32 @@ export async function captureErrorBaseline(
     try {
       baseline.eslint = parseEslintOutput(eslintResult.stdout + eslintResult.stderr);
     } catch (err: unknown) {
-      logger.warn(`baseline: eslint 출력 파싱 실패 — ${getErrorMessage(err)}`);
+      const msg = `baseline: eslint 출력 파싱 실패 — ${getErrorMessage(err)}`;
+      logger.warn(msg);
+      captureWarnings.push(msg);
     }
+  }
+
+  if (buildResult !== null) {
+    baseline.build = {
+      exitCode: 0,
+      hasErrors: false,
+      output: buildResult.stdout + buildResult.stderr,
+    };
+  }
+
+  if (testResult !== null) {
+    try {
+      baseline.test = parseVitestOutput(testResult.stdout + testResult.stderr);
+    } catch (err: unknown) {
+      const msg = `baseline: test 출력 파싱 실패 — ${getErrorMessage(err)}`;
+      logger.warn(msg);
+      captureWarnings.push(msg);
+    }
+  }
+
+  if (captureWarnings.length > 0) {
+    baseline.captureWarnings = captureWarnings;
   }
 
   return baseline;
@@ -63,5 +112,18 @@ export async function captureErrorBaseline(
  * 예: 'tsc 에러 3개, eslint 에러 12개 존재'
  */
 export function formatBaselineSummary(baseline: BaselineErrors): string {
-  return `tsc 에러 ${baseline.tsc.totalErrors}개, eslint 에러 ${baseline.eslint.totalErrors}개 존재`;
+  const parts: string[] = [
+    `tsc 에러 ${baseline.tsc.totalErrors}개`,
+    `eslint 에러 ${baseline.eslint.totalErrors}개`,
+  ];
+  if (baseline.build !== undefined) {
+    parts.push(`build ${baseline.build.hasErrors ? "실패" : "성공"}`);
+  }
+  if (baseline.test !== undefined) {
+    parts.push(`test 실패 파일 ${baseline.test.failedFiles.length}개`);
+  }
+  if (baseline.captureWarnings && baseline.captureWarnings.length > 0) {
+    parts.push(`캡처 경고 ${baseline.captureWarnings.length}개`);
+  }
+  return parts.join(", ") + " 존재";
 }

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -29,6 +29,8 @@ export interface PipelineReport {
   errorSummary?: string;
   /** Claude 기반 실패 진단 리포트 (실패 시에만 존재) */
   diagnosis?: DiagnosisReport;
+  /** baseline 캡처 실패로 인해 검증이 불완전한 경우 경고 목록 */
+  verificationIncomplete?: string[];
 }
 
 /**
@@ -90,6 +92,13 @@ export function printResult(report: PipelineReport): void {
 
   if (report.prUrl) {
     console.log(`\nPR: ${report.prUrl}`);
+  }
+
+  if (report.verificationIncomplete && report.verificationIncomplete.length > 0) {
+    console.log("\n[WARN] 검증 불완전: baseline 캡처 실패로 일부 검증이 누락되었을 수 있습니다.");
+    for (const warning of report.verificationIncomplete) {
+      console.log(`  - ${warning}`);
+    }
   }
 
   if (report.diagnosis) {

--- a/src/pipeline/reporting/verification-parser.ts
+++ b/src/pipeline/reporting/verification-parser.ts
@@ -84,12 +84,22 @@ export function parseVitestOutput(output: string): VitestParseResult {
   };
 }
 
+export interface BuildBaselineResult {
+  exitCode: number;
+  hasErrors: boolean;
+  output: string;
+}
+
 /**
- * Baseline snapshot of tsc + eslint errors for diffing against new runs.
+ * Baseline snapshot of tsc + eslint + build + test errors for diffing against new runs.
+ * captureWarnings records any failures that occurred while capturing the baseline.
  */
 export interface BaselineErrors {
   tsc: TscParseResult;
   eslint: EslintParseResult;
+  build?: BuildBaselineResult;
+  test?: VitestParseResult;
+  captureWarnings?: string[];
 }
 
 /**

--- a/src/pipeline/setup/pipeline-validation.ts
+++ b/src/pipeline/setup/pipeline-validation.ts
@@ -138,6 +138,9 @@ export async function runValidationPhase(
 
       checkpoint({ plan: context.plan, phaseResults: context.phaseResults });
       const report = formatResult(issueNumber, repo, context.plan, context.phaseResults, startTime);
+      if (context.baseline?.captureWarnings && context.baseline.captureWarnings.length > 0) {
+        report.verificationIncomplete = context.baseline.captureWarnings;
+      }
       printResult(report);
       saveResult(config, _aqRoot ?? _projectRoot ?? process.cwd(), issueNumber, report);
 

--- a/tests/pipeline/baseline.test.ts
+++ b/tests/pipeline/baseline.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { printResult } from "../../src/pipeline/reporting/result-reporter.js";
+import type { PipelineReport } from "../../src/pipeline/reporting/result-reporter.js";
+
+function makeReport(overrides: Partial<PipelineReport> = {}): PipelineReport {
+  return {
+    issueNumber: 1,
+    repo: "test/repo",
+    success: true,
+    plan: { title: "Test Plan", phaseCount: 1 },
+    phases: [{ name: "Phase 1", success: true, durationMs: 100 }],
+    totalDurationMs: 100,
+    ...overrides,
+  };
+}
+
+describe("printResult — verificationIncomplete", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("prints verification incomplete warning when verificationIncomplete is set", () => {
+    const report = makeReport({
+      verificationIncomplete: ["baseline: tsc 실행 실패 — tsc not found"],
+    });
+    printResult(report);
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).toContain("검증 불완전");
+    expect(output).toContain("baseline: tsc 실행 실패 — tsc not found");
+  });
+
+  it("does not print verification warning when verificationIncomplete is undefined", () => {
+    const report = makeReport();
+    printResult(report);
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).not.toContain("검증 불완전");
+  });
+
+  it("does not print verification warning when verificationIncomplete is empty array", () => {
+    const report = makeReport({ verificationIncomplete: [] });
+    printResult(report);
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).not.toContain("검증 불완전");
+  });
+
+  it("prints all entries when multiple verificationIncomplete warnings exist", () => {
+    const report = makeReport({
+      verificationIncomplete: [
+        "baseline: tsc 실행 실패 — err1",
+        "baseline: eslint 실행 실패 — err2",
+        "baseline: build 실행 실패 — err3",
+      ],
+    });
+    printResult(report);
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).toContain("baseline: tsc 실행 실패 — err1");
+    expect(output).toContain("baseline: eslint 실행 실패 — err2");
+    expect(output).toContain("baseline: build 실행 실패 — err3");
+  });
+
+  it("still prints SUCCESS even when verificationIncomplete is set", () => {
+    const report = makeReport({
+      success: true,
+      verificationIncomplete: ["baseline: tsc 실행 실패 — err"],
+    });
+    printResult(report);
+    const output = vi.mocked(console.log).mock.calls.flat().join("\n");
+    expect(output).toContain("SUCCESS");
+    expect(output).toContain("검증 불완전");
+  });
+});

--- a/tests/pipeline/error-baseline.test.ts
+++ b/tests/pipeline/error-baseline.test.ts
@@ -110,6 +110,180 @@ describe("captureErrorBaseline", () => {
   });
 });
 
+describe("captureErrorBaseline — build and test commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const COMMANDS_FULL = {
+    typecheck: "npx tsc --noEmit",
+    lint: "npx eslint src/",
+    build: "npm run build",
+    test: "npx vitest run",
+  };
+
+  it("captures build result when build command succeeds", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockResolvedValueOnce({ stdout: "Build successful", stderr: "", exitCode: 0 }) // build
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.build).toBeDefined();
+    expect(baseline.build!.hasErrors).toBe(false);
+    expect(baseline.build!.output).toBe("Build successful");
+  });
+
+  it("sets build captureWarning when build command throws", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockRejectedValueOnce(new Error("build tool missing")) // build
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.build).toBeUndefined();
+    expect(baseline.captureWarnings).toBeDefined();
+    expect(baseline.captureWarnings).toHaveLength(1);
+    expect(baseline.captureWarnings![0]).toContain("baseline: build 실행 실패");
+    expect(baseline.captureWarnings![0]).toContain("build tool missing");
+  });
+
+  it("captures test result when test command succeeds", async () => {
+    const vitestOutput = " PASS  tests/foo.test.ts\n PASS  tests/bar.test.ts";
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // build
+      .mockResolvedValueOnce({ stdout: vitestOutput, stderr: "", exitCode: 0 }); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.test).toBeDefined();
+    expect(baseline.test!.hasFailures).toBe(false);
+    expect(baseline.test!.passedFiles).toHaveLength(2);
+  });
+
+  it("sets test captureWarning when test command throws", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // build
+      .mockRejectedValueOnce(new Error("test runner crashed")); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.test).toBeUndefined();
+    expect(baseline.captureWarnings).toBeDefined();
+    expect(baseline.captureWarnings).toHaveLength(1);
+    expect(baseline.captureWarnings![0]).toContain("baseline: test 실행 실패");
+    expect(baseline.captureWarnings![0]).toContain("test runner crashed");
+  });
+
+  it("accumulates captureWarnings when multiple commands fail", async () => {
+    mockRunShell
+      .mockRejectedValueOnce(new Error("tsc not found")) // typecheck
+      .mockRejectedValueOnce(new Error("eslint not found")) // lint
+      .mockRejectedValueOnce(new Error("build tool missing")) // build
+      .mockRejectedValueOnce(new Error("vitest not found")); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.captureWarnings).toBeDefined();
+    expect(baseline.captureWarnings!.length).toBe(4);
+    expect(baseline.captureWarnings![0]).toContain("baseline: tsc 실행 실패");
+    expect(baseline.captureWarnings![1]).toContain("baseline: eslint 실행 실패");
+    expect(baseline.captureWarnings![2]).toContain("baseline: build 실행 실패");
+    expect(baseline.captureWarnings![3]).toContain("baseline: test 실행 실패");
+  });
+
+  it("does not set captureWarnings when all commands succeed", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // build
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.captureWarnings).toBeUndefined();
+  });
+
+  it("skips build and test runShell calls when not provided in commands", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // lint
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS);
+
+    expect(mockRunShell).toHaveBeenCalledTimes(2);
+    expect(baseline.build).toBeUndefined();
+    expect(baseline.test).toBeUndefined();
+  });
+
+  it("captures failed test files from vitest output", async () => {
+    const vitestOutput = [
+      " × tests/unit/foo.test.ts (2 tests | 1 failed) 300ms",
+      " ✓ tests/unit/bar.test.ts (3 tests) 100ms",
+    ].join("\n");
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // lint
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // build
+      .mockResolvedValueOnce({ stdout: vitestOutput, stderr: "", exitCode: 1 }); // test
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS_FULL);
+
+    expect(baseline.test).toBeDefined();
+    expect(baseline.test!.hasFailures).toBe(true);
+    expect(baseline.test!.failedFiles).toHaveLength(1);
+    expect(baseline.test!.passedFiles).toHaveLength(1);
+  });
+});
+
+describe("captureErrorBaseline — captureWarnings on tsc/eslint failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets captureWarnings when typecheck command throws", async () => {
+    mockRunShell
+      .mockRejectedValueOnce(new Error("tsc command failed")) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // lint
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS);
+
+    expect(baseline.captureWarnings).toBeDefined();
+    expect(baseline.captureWarnings).toHaveLength(1);
+    expect(baseline.captureWarnings![0]).toContain("baseline: tsc 실행 실패");
+  });
+
+  it("sets captureWarnings when lint command throws", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockRejectedValueOnce(new Error("eslint command failed")); // lint
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS);
+
+    expect(baseline.captureWarnings).toBeDefined();
+    expect(baseline.captureWarnings).toHaveLength(1);
+    expect(baseline.captureWarnings![0]).toContain("baseline: eslint 실행 실패");
+  });
+
+  it("does not set captureWarnings when both tsc and eslint succeed", async () => {
+    mockRunShell
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // typecheck
+      .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // lint
+
+    const baseline = await captureErrorBaseline(CWD, COMMANDS);
+
+    expect(baseline.captureWarnings).toBeUndefined();
+  });
+});
+
 describe("formatBaselineSummary", () => {
   it("returns correct summary with error counts", () => {
     const baseline: BaselineErrors = {
@@ -141,6 +315,86 @@ describe("formatBaselineSummary", () => {
         totalWarnings: 0,
         hasErrors: false,
       },
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 0개, eslint 에러 0개 존재"
+    );
+  });
+
+  it("includes build success in summary when build is present", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 0, hasErrors: false },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 0, totalWarnings: 0, hasErrors: false },
+      build: { exitCode: 0, hasErrors: false, output: "Build successful" },
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 0개, eslint 에러 0개, build 성공 존재"
+    );
+  });
+
+  it("includes build failure in summary when build has errors", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 0, hasErrors: false },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 0, totalWarnings: 0, hasErrors: false },
+      build: { exitCode: 1, hasErrors: true, output: "Build failed" },
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 0개, eslint 에러 0개, build 실패 존재"
+    );
+  });
+
+  it("includes test failed files count in summary when test is present", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 0, hasErrors: false },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 0, totalWarnings: 0, hasErrors: false },
+      test: {
+        failedFiles: ["tests/a.test.ts", "tests/b.test.ts"],
+        passedFiles: [],
+        failedTests: [],
+        totalFiles: 2,
+        hasFailures: true,
+      },
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 0개, eslint 에러 0개, test 실패 파일 2개 존재"
+    );
+  });
+
+  it("includes captureWarnings count in summary when warnings are present", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 0, hasErrors: false },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 0, totalWarnings: 0, hasErrors: false },
+      captureWarnings: ["baseline: tsc 실행 실패 — err1", "baseline: build 실행 실패 — err2"],
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 0개, eslint 에러 0개, 캡처 경고 2개 존재"
+    );
+  });
+
+  it("includes all fields in summary when all are present", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 1, hasErrors: true },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 2, totalWarnings: 0, hasErrors: true },
+      build: { exitCode: 1, hasErrors: true, output: "failed" },
+      test: {
+        failedFiles: ["tests/x.test.ts"],
+        passedFiles: [],
+        failedTests: [],
+        totalFiles: 1,
+        hasFailures: true,
+      },
+      captureWarnings: ["baseline: 경고 1개"],
+    };
+    expect(formatBaselineSummary(baseline)).toBe(
+      "tsc 에러 1개, eslint 에러 2개, build 실패, test 실패 파일 1개, 캡처 경고 1개 존재"
+    );
+  });
+
+  it("omits captureWarnings from summary when array is empty", () => {
+    const baseline: BaselineErrors = {
+      tsc: { errorsByFile: {}, totalErrors: 0, hasErrors: false },
+      eslint: { errorsByFile: {}, warningsByFile: {}, totalErrors: 0, totalWarnings: 0, hasErrors: false },
+      captureWarnings: [],
     };
     expect(formatBaselineSummary(baseline)).toBe(
       "tsc 에러 0개, eslint 에러 0개 존재"


### PR DESCRIPTION
## Summary

Resolves #638 — feat: baseline 확장 + 캡처 실패 침묵 제거

현재 baseline 시스템의 3가지 문제: (1) captureErrorBaseline() 실패 시 빈 baseline으로 조용히 넘어가서 실패 원인을 추적할 수 없음, (2) baseline이 tsc/eslint만 커버하고 build/test 단계 결과를 포함하지 않음, (3) parser 실패 시 결과 리포트에 해당 사실이 표시되지 않아 검증이 불완전한지 알 수 없음

## Requirements

- captureErrorBaseline() 실패 시 빈 baseline 대신 warning 이벤트로 노출 (어떤 도구가 실패했는지 추적 가능)
- BaselineErrors에 build/test 단계 결과 추가 (현재 tsc/eslint → tsc/eslint/build/test)
- parser 실패 시 PipelineReport에 '검증 불완전' 상태 명시
- 기존 테스트 유지 + 새 시나리오 테스트 추가

## Implementation Phases

- Phase 0: BaselineErrors 타입 확장 + captureErrorBaseline 실패 노출 — SUCCESS (b7a06f4f)
- Phase 1: PipelineReport에 '검증 불완전' 상태 추가 — SUCCESS (dcfa10bb)
- Phase 2: 테스트 작성 — SUCCESS (3b4f3003)

## Risks

- captureErrorBaseline의 시그니처 변경으로 호출부(core-loop.ts) 수정 필요 — commands 파라미터 확장
- BaselineErrors 타입 변경이 phase-executor.ts, pipeline-validation.ts 등 다수 import 지점에 영향 — 하위 호환 유지 필요 (새 필드는 optional)
- build/test 명령이 비어있을 수 있음(빈 문자열) — 빈 명령은 스킵 처리 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.2753 (review: $0.1793)
- **Phases**: 3/3 completed
- **Branch**: `aq/638-feat-baseline` → `develop`
- **Tokens**: 147 input, 36782 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| BaselineErrors 타입 확장 + captureErrorBaseline 실패 노출 | $0.6443 | 0 | $0.0000 |
| PipelineReport에 '검증 불완전' 상태 추가 | $0.4109 | 0 | $0.0000 |
| 테스트 작성 | $0.6579 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.7132 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #638