### PR TITLE
[AQ-#641] feat: release PR 머지 후 develop ← main back-merge 자동화

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,0 +1,111 @@
+name: Back-merge main → develop
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  back-merge:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'develop' &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch develop
+        run: git fetch origin develop
+
+      - name: Attempt fast-forward merge
+        id: ff_merge
+        run: |
+          git checkout develop
+          if git merge --ff-only origin/main; then
+            echo "result=ff_success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=ff_failed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push develop (fast-forward)
+        if: steps.ff_merge.outputs.result == 'ff_success'
+        run: git push origin develop
+
+      - name: Attempt clean merge
+        id: clean_merge
+        if: steps.ff_merge.outputs.result == 'ff_failed'
+        run: |
+          if git merge --no-commit --no-edit origin/main; then
+            echo "result=clean_success" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push (clean merge)
+        if: |
+          steps.ff_merge.outputs.result == 'ff_failed' &&
+          steps.clean_merge.outputs.result == 'clean_success'
+        run: |
+          git commit -m "chore: sync main → develop"
+          git push origin develop
+
+      - name: Collect conflict files
+        id: conflict_files
+        if: |
+          steps.ff_merge.outputs.result == 'ff_failed' &&
+          steps.clean_merge.outputs.result == 'conflict'
+        run: |
+          git fetch origin develop
+          git checkout develop
+          git merge --no-commit --no-edit origin/main || true
+          CONFLICT_LIST=$(git diff --name-only --diff-filter=U | tr '\n' '\n')
+          git merge --abort
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CONFLICT_LIST" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create back-merge PR
+        if: |
+          steps.ff_merge.outputs.result == 'ff_failed' &&
+          steps.clean_merge.outputs.result == 'conflict'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="back-merge/main-to-develop-${{ github.run_number }}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+
+          BODY="## Back-merge: main → develop
+
+          Release PR #${{ github.event.pull_request.number }} 머지 후 자동 back-merge를 시도했으나 충돌이 발생했습니다.
+          충돌을 해소한 후 이 PR을 머지하세요.
+
+          ### 충돌 파일 목록
+
+          \`\`\`
+          ${{ steps.conflict_files.outputs.files }}
+          \`\`\`
+          "
+
+          gh pr create \
+            --title "chore: sync main → develop (충돌 해소 필요)" \
+            --body "$BODY" \
+            --base develop \
+            --head "$BRANCH" \
+            --label "back-merge"


### PR DESCRIPTION
## Summary

Resolves #641 — feat: release PR 머지 후 develop ← main back-merge 자동화

release PR(develop → main)이 머지된 후, main의 변경사항이 develop에 자동으로 반영되지 않아 수동 back-merge가 필요하다. #630→#631→#632 사이클에서 squash 머지 후 develop 충돌이 두 번 발생한 이력이 있다. GitHub Actions 워크플로우로 back-merge를 자동화하여, fast-forward 가능 시 자동 push하고 충돌 시 back-merge PR을 생성하는 방식으로 해결한다.

## Requirements

- release: develop → main 패턴 PR 머지 시 main → develop back-merge job 자동 트리거
- fast-forward / clean merge 가능 시 자동 push, 충돌 시 즉시 중단 + 알림
- 충돌 시 자동으로 back-merge PR 생성 (chore: sync main → develop)
- 자동 충돌 해결 절대 금지 — 알림/PR 생성으로만 처리
- release 스킬 문서에 운영 절차 추가

## Implementation Phases

- Phase 0: GitHub Actions back-merge 워크플로우 생성 — SUCCESS (2205ffb9)
- Phase 1: release 스킬 문서 운영 절차 추가 — SUCCESS (2205ffb9)

## Risks

- GitHub Actions 권한 부족으로 develop push 실패 가능 — GITHUB_TOKEN permissions 확인 필요
- branch protection rule이 develop에 걸려있으면 직접 push 불가 — PR 방식으로 fallback 필요할 수 있음
- squash merge 패턴에서는 거의 항상 충돌 발생 — back-merge PR 생성이 주 경로가 될 수 있음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.0618 (review: $0.1227)
- **Phases**: 2/2 completed
- **Branch**: `aq/641-feat-release-pr-develop-main-back-merge` → `develop`
- **Tokens**: 35 input, 9468 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| GitHub Actions back-merge 워크플로우 생성 | $0.2246 | 0 | $0.0000 |
| release 스킬 문서 운영 절차 추가 | $0.2148 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.4394 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #641