### PR TITLE
[AQ-#643] fix: 파이프라인 전체 phase 기록 확장 — setup/plan/review/publish도 phaseResults에

### DIFF
--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -74,7 +74,7 @@ export async function createDraftPR(
         risks: ctx.plan.risks.join("\n- "),
       },
       phases: ctx.phaseResults.map(r =>
-        `- Phase ${r.phaseIndex}: ${r.phaseName} — ${r.success ? "SUCCESS" : "FAILED"} (${r.commitHash?.slice(0, 8) || "N/A"})`
+        `- Phase ${r.phaseIndex}: ${r.phaseName} — ${r.success ? "SUCCESS" : "FAILED"} (${r.commitHash?.slice(0, 8) || "-"})`
       ).join("\n"),
       branch: {
         base: ctx.baseBranch,

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -11,6 +11,7 @@ import { getErrorMessage } from "../../utils/error-utils.js";
 import type { JobLogger } from "../../queue/job-logger.js";
 import { PatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PLAN_GENERATED, phaseStart } from "../reporting/progress-tracker.js";
+import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
 import { createWorktree, removeWorktree } from "../../git/worktree-manager.js";
 import { createCheckpoint } from "../../safety/rollback-manager.js";
 import { createSlug } from "../../utils/slug.js";
@@ -209,6 +210,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
   let plan: Plan;
   let planCostUsd: number | undefined;
   let planUsage: import("../../types/pipeline.js").UsageInfo | undefined;
+  const planStartedAt = nowIso();
+  const planStartMs = Date.now();
   try {
     const planResult = await generatePlan({
       issue: ctx.issue,
@@ -235,6 +238,12 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     logger.error(`Plan generation failed for issue #${ctx.issue.number}: ${errorMessage}`);
     ctx.jobLogger?.log(`Plan 생성 실패: ${errorMessage}`);
 
+    const planDurationMs = Date.now() - planStartMs;
+    const planFailResult = makePseudoPhaseFailure("plan:generate", planDurationMs, errorMessage, {
+      startedAt: planStartedAt,
+      completedAt: nowIso(),
+    });
+
     // Plan 생성 실패 시 빈 결과 반환 (상위에서 적절한 실패 처리)
     return {
       plan: {
@@ -249,21 +258,28 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         verificationPoints: [],
         stopConditions: [],
       },
-      phaseResults: [],
+      phaseResults: [planFailResult],
       success: false,
       totalCostUsd: 0,
       totalUsage: undefined,
-      costBreakdown: buildCostBreakdown(undefined, []),
+      costBreakdown: buildCostBreakdown(undefined, [planFailResult]),
       baseline: ctx.baseline,
     };
   }
+
+  // plan:generate pseudo-phase를 phaseResults에 기록
+  const planGenerateResult = makePseudoPhaseSuccess("plan:generate", Date.now() - planStartMs, {
+    startedAt: planStartedAt,
+    completedAt: nowIso(),
+    costUsd: planCostUsd,
+  });
 
   checkPhaseLimit(plan.phases.length, ctx.config.safety.maxPhases);
 
   // Step 2: Execute phases sequentially with retry
   const jl = ctx.jobLogger;
   jl?.setProgress(PROGRESS_PLAN_GENERATED);
-  const phaseResults: PhaseResult[] = [...(ctx.previousPhaseResults ?? [])];
+  const phaseResults: PhaseResult[] = [...(ctx.previousPhaseResults ?? []), planGenerateResult];
   const maxRetries = ctx.config.safety.maxRetries;
   const repoFull = `${ctx.repo.owner}/${ctx.repo.name}`;
 
@@ -438,8 +454,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         const totalCostUsd = phaseResults.filter(r => r.phaseIndex >= 0).reduce((sum, r) => sum + (r.costUsd ?? 0), 0) + (planCostUsd ?? 0);
         const allUsages = [planUsage, ...phaseResults.map(r => r.usage)];
         const totalUsage = sumUsage(allUsages);
-        return { plan, phaseResults, success: false, totalCostUsd, totalUsage, costBreakdown: buildCostBreakdown(planCostUsd, phaseResults) };
-        return { plan, phaseResults, success: false, totalCostUsd, totalUsage, baseline: ctx.baseline };
+        return { plan, phaseResults, success: false, totalCostUsd, totalUsage, costBreakdown: buildCostBreakdown(planCostUsd, phaseResults), baseline: ctx.baseline };
       }
 
       logger.info(`Phase ${phase.index + 1} completed (commit: ${result.commitHash?.slice(0, 8)})`);
@@ -464,6 +479,5 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     logger.info(`Total usage: input=${totalUsage.input_tokens}, output=${totalUsage.output_tokens}, cache_creation=${totalUsage.cache_creation_input_tokens ?? 0}, cache_read=${totalUsage.cache_read_input_tokens ?? 0}`);
   }
 
-  return { plan, phaseResults, success: true, totalCostUsd, totalUsage, costBreakdown: buildCostBreakdown(planCostUsd, phaseResults) };
-  return { plan, phaseResults, success: true, totalCostUsd, totalUsage, baseline: ctx.baseline };
+  return { plan, phaseResults, success: true, totalCostUsd, totalUsage, costBreakdown: buildCostBreakdown(planCostUsd, phaseResults), baseline: ctx.baseline };
 }

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -43,7 +43,9 @@ export function buildCostBreakdown(
   phaseResults: PhaseResult[],
   reviewCostUsd: number = 0,
 ): CostBreakdown {
-  const phaseCosts = phaseResults.map(r => ({
+  // pseudo-phase(phaseIndex < 0)는 비용 집계에서 제외한다.
+  // 이미 planCostUsd 등 별도 항목으로 추적되므로 이중 계산 방지.
+  const phaseCosts = phaseResults.filter(r => r.phaseIndex >= 0).map(r => ({
     phaseIndex: r.phaseIndex,
     phaseName: r.phaseName,
     costUsd: r.costUsd ?? 0,
@@ -433,7 +435,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
       if (!result.success) {
         logger.error(`Phase ${phase.index + 1} failed after retries: ${result.error}`);
         jl?.log(`Phase ${phase.index + 1} 최종 실패: ${result.error}`);
-        const totalCostUsd = phaseResults.reduce((sum, r) => sum + (r.costUsd ?? 0), 0) + (planCostUsd ?? 0);
+        const totalCostUsd = phaseResults.filter(r => r.phaseIndex >= 0).reduce((sum, r) => sum + (r.costUsd ?? 0), 0) + (planCostUsd ?? 0);
         const allUsages = [planUsage, ...phaseResults.map(r => r.usage)];
         const totalUsage = sumUsage(allUsages);
         return { plan, phaseResults, success: false, totalCostUsd, totalUsage, costBreakdown: buildCostBreakdown(planCostUsd, phaseResults) };
@@ -448,8 +450,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     logger.info(`Level ${group.level} completed: ${remainingPhases.length} phases executed`);
   }
 
-  // Calculate total cost from phase results and plan generation
-  const phasesTotalCost = phaseResults.reduce((sum, result) => sum + (result.costUsd ?? 0), 0);
+  // Calculate total cost from phase results and plan generation (pseudo-phase 제외)
+  const phasesTotalCost = phaseResults.filter(r => r.phaseIndex >= 0).reduce((sum, result) => sum + (result.costUsd ?? 0), 0);
   const totalCostUsd = phasesTotalCost + (planCostUsd ?? 0);
 
   // Calculate total usage from plan and phase results

--- a/src/pipeline/core/orchestrator-helpers.ts
+++ b/src/pipeline/core/orchestrator-helpers.ts
@@ -12,6 +12,7 @@ import type { GitHubIssue } from "../../github/issue-fetcher.js";
 import type { PipelineMode } from "../../types/config.js";
 import type { PipelineCheckpoint } from "../errors/checkpoint.js";
 import type { JobLogger } from "../../queue/job-logger.js";
+import type { PhaseResult } from "../../types/pipeline.js";
 
 /**
  * Handle duplicate PR check and return early result if needed
@@ -57,6 +58,7 @@ export function createPostProcessingContext(params: {
   runtime: PipelineRuntime;
   checkpointFn: (overrides?: Partial<PipelineCheckpoint>) => void;
   jobLogger?: JobLogger;
+  accumulatedPhaseResults?: PhaseResult[];
 }): PostProcessingContext {
   return {
     issue: params.issue,
@@ -69,6 +71,7 @@ export function createPostProcessingContext(params: {
     preset: params.preset,
     timer: params.setupResult.timer,
     checkpoint: params.checkpointFn,
-    jobLogger: params.jobLogger
+    jobLogger: params.jobLogger,
+    accumulatedPhaseResults: params.accumulatedPhaseResults,
   };
 }

--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -11,6 +11,7 @@ import type {
   OrchestratorInput,
   OrchestratorResult,
 } from "./pipeline-context.js";
+import type { PhaseResult } from "../../types/pipeline.js";
 import { clearCache } from "../../github/github-cache.js";
 import {
   handleDuplicatePR,
@@ -37,6 +38,9 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
   // Initialize pipeline state
   const runtime = await initializePipelineState(input, config);
 
+  // 전체 파이프라인 수명 동안 유지되는 누적 phase 결과 배열
+  const accumulatedPhaseResults: PhaseResult[] = [];
+
   try {
     // Phase 1: Initial Setup (Project, Duplicate PR check, Issue validation)
     const setupResult = await executeInitialSetupPhases(input, runtime, config, aqRoot);
@@ -62,7 +66,7 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       checkpointFn
     );
 
-    checkpointFn({ plan: undefined, phaseResults: [] });
+    checkpointFn({ plan: undefined, phaseResults: [...accumulatedPhaseResults] });
 
     // Phase 3: Core Loop Execution (Plan generation + Phase execution)
     const coreResult = await executeCoreLoopPhase(
@@ -80,7 +84,7 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       hookExecutor
     );
 
-    checkpointFn({ plan: coreResult.coreResult.plan, phaseResults: coreResult.coreResult.phaseResults });
+    checkpointFn({ plan: coreResult.coreResult.plan, phaseResults: [...accumulatedPhaseResults, ...coreResult.coreResult.phaseResults] });
 
     // Phase 4: Post-processing (Review, Simplify, Validation, Publish)
     const postProcessingContext = createPostProcessingContext({
@@ -91,7 +95,8 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       preset: coreResult.preset,
       runtime,
       checkpointFn,
-      jobLogger: input.jobLogger
+      jobLogger: input.jobLogger,
+      accumulatedPhaseResults,
     });
     postProcessingContext.hookRegistry = hookRegistry;
     postProcessingContext.hookExecutor = hookExecutor;

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -23,6 +23,7 @@ import {
   PROGRESS_REVIEW_START,
   PROGRESS_DONE
 } from "../reporting/progress-tracker.js";
+import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
 import type { AQConfig, PipelineMode, ExecutionMode, GitConfig } from "../../types/config.js";
 import type { PipelineState, PhaseResult } from "../../types/pipeline.js";
 import type { OrchestratorInput } from "../core/pipeline-context.js";
@@ -72,6 +73,7 @@ export interface InitialSetupResult {
   mode?: PipelineMode;
   executionMode?: ExecutionMode;
   checkpoint?: (overrides?: Partial<PipelineCheckpoint>) => void;
+  phaseResults: PhaseResult[];
 }
 
 export interface EnvironmentSetupResult {
@@ -79,6 +81,7 @@ export interface EnvironmentSetupResult {
   skillsContext: string;
   repoStructure: string;
   rollbackHash?: string;
+  phaseResults: PhaseResult[];
 }
 
 export interface CoreLoopExecutionResult {
@@ -150,7 +153,8 @@ export async function executeInitialSetupPhases(
       project,
       dataDir,
       timer,
-      duplicatePRUrl: duplicateResult.prUrl
+      duplicatePRUrl: duplicateResult.prUrl,
+      phaseResults: []
     };
   }
 
@@ -191,7 +195,8 @@ export async function executeInitialSetupPhases(
     issue,
     mode,
     executionMode,
-    checkpoint
+    checkpoint,
+    phaseResults: []
   };
 }
 
@@ -210,8 +215,11 @@ export async function executeEnvironmentSetup(
 ): Promise<EnvironmentSetupResult> {
   const { issueNumber, repo } = input;
   const jl = input.jobLogger;
+  const phaseResults: PhaseResult[] = [];
 
   // Setup Git Environment
+  const worktreeStartedAt = nowIso();
+  const worktreeStart = Date.now();
   const gitSetupResult = await setupGitEnvironment({
     issueNumber,
     issueTitle: issue.title,
@@ -223,6 +231,10 @@ export async function executeEnvironmentSetup(
     isRetry: input.isRetry || false,
     jl,
   });
+  phaseResults.push(makePseudoPhaseSuccess("setup:worktree", Date.now() - worktreeStart, {
+    startedAt: worktreeStartedAt,
+    completedAt: nowIso(),
+  }));
 
   transitionState(runtime, gitSetupResult.state, {
     branchName: gitSetupResult.branchName,
@@ -239,6 +251,8 @@ export async function executeEnvironmentSetup(
   let envPrepResult: EnvironmentPrepResult;
 
   if (runtime.worktreePath) {
+    const depStartedAt = nowIso();
+    const depStart = Date.now();
     envPrepResult = await prepareWorkEnvironment({
       projectRoot,
       worktreePath: runtime.worktreePath,
@@ -247,6 +261,10 @@ export async function executeEnvironmentSetup(
       rollbackStrategy,
       jl,
     });
+    phaseResults.push(makePseudoPhaseSuccess("setup:dependency", Date.now() - depStart, {
+      startedAt: depStartedAt,
+      completedAt: nowIso(),
+    }));
   } else {
     envPrepResult = {
       rollbackHash: undefined,
@@ -261,6 +279,7 @@ export async function executeEnvironmentSetup(
     skillsContext: envPrepResult.skillsContext,
     repoStructure: envPrepResult.repoStructure,
     rollbackHash: envPrepResult.rollbackHash,
+    phaseResults,
   };
 }
 
@@ -447,7 +466,31 @@ export async function executePostProcessingPhases(
     checkpoint
   };
 
+  const reviewStartedAt = nowIso();
+  const reviewStartMs = Date.now();
   const reviewResult = await runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState);
+  const reviewDurationMs = Date.now() - reviewStartMs;
+  const reviewCompletedAt = nowIso();
+
+  if (context.accumulatedPhaseResults) {
+    if (reviewResult.success) {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseSuccess("review:code", reviewDurationMs, {
+          startedAt: reviewStartedAt,
+          completedAt: reviewCompletedAt,
+          costUsd: reviewResult.costUsd,
+        })
+      );
+    } else {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseFailure("review:code", reviewDurationMs, reviewResult.error ?? "Review phase failed", {
+          startedAt: reviewStartedAt,
+          completedAt: reviewCompletedAt,
+          costUsd: reviewResult.costUsd,
+        })
+      );
+    }
+  }
 
   if (!reviewResult.success) {
     const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
@@ -479,7 +522,31 @@ export async function executePostProcessingPhases(
       checkpoint
     };
 
+    const simplifyStartedAt = nowIso();
+    const simplifyStartMs = Date.now();
     const simplifyResult = await runSimplifyPhase(simplifyContext, executionModePreset, runtime.state, isPastState);
+    const simplifyDurationMs = Date.now() - simplifyStartMs;
+    const simplifyCompletedAt = nowIso();
+
+    if (context.accumulatedPhaseResults) {
+      if (simplifyResult.success) {
+        context.accumulatedPhaseResults.push(
+          makePseudoPhaseSuccess("review:simplify", simplifyDurationMs, {
+            startedAt: simplifyStartedAt,
+            completedAt: simplifyCompletedAt,
+            costUsd: simplifyResult.costUsd,
+          })
+        );
+      } else {
+        context.accumulatedPhaseResults.push(
+          makePseudoPhaseFailure("review:simplify", simplifyDurationMs, simplifyResult.error ?? "Simplify phase failed", {
+            startedAt: simplifyStartedAt,
+            completedAt: simplifyCompletedAt,
+            costUsd: simplifyResult.costUsd,
+          })
+        );
+      }
+    }
 
     if (!simplifyResult.success) {
       const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
@@ -505,6 +572,8 @@ export async function executePostProcessingPhases(
     baseline: coreResult.baseline,
   };
 
+  const validationStartedAt = nowIso();
+  const validationStartMs = Date.now();
   const validationResult = await runValidationPhase(
     validationContext,
     timer,
@@ -520,6 +589,26 @@ export async function executePostProcessingPhases(
     aqRoot,
     runtime.projectRoot
   );
+  const validationDurationMs = Date.now() - validationStartMs;
+  const validationCompletedAt = nowIso();
+
+  if (context.accumulatedPhaseResults) {
+    if (validationResult.success) {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseSuccess("validation:check", validationDurationMs, {
+          startedAt: validationStartedAt,
+          completedAt: validationCompletedAt,
+        })
+      );
+    } else {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseFailure("validation:check", validationDurationMs, validationResult.error ?? "Validation phase failed", {
+          startedAt: validationStartedAt,
+          completedAt: validationCompletedAt,
+        })
+      );
+    }
+  }
 
   if (!validationResult.success) {
     throw new Error(validationResult.error || "Validation phase failed");
@@ -565,7 +654,29 @@ export async function executePostProcessingPhases(
     costBreakdown: coreResult.costBreakdown,
   };
 
+  const publishStartedAt = nowIso();
+  const publishStartMs = Date.now();
   const publishResult = await pushAndCreatePR(publishContext);
+  const publishDurationMs = Date.now() - publishStartMs;
+  const publishCompletedAt = nowIso();
+
+  if (context.accumulatedPhaseResults) {
+    if (publishResult.success) {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseSuccess("publish:pr", publishDurationMs, {
+          startedAt: publishStartedAt,
+          completedAt: publishCompletedAt,
+        })
+      );
+    } else {
+      context.accumulatedPhaseResults.push(
+        makePseudoPhaseFailure("publish:pr", publishDurationMs, publishResult.error ?? "Publish phase failed", {
+          startedAt: publishStartedAt,
+          completedAt: publishCompletedAt,
+        })
+      );
+    }
+  }
 
   if (!publishResult.success) {
     throw new Error(publishResult.error || "Publish phase failed");

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -24,7 +24,7 @@ import {
   PROGRESS_DONE
 } from "../reporting/progress-tracker.js";
 import type { AQConfig, PipelineMode, ExecutionMode, GitConfig } from "../../types/config.js";
-import type { PipelineState } from "../../types/pipeline.js";
+import type { PipelineState, PhaseResult } from "../../types/pipeline.js";
 import type { OrchestratorInput } from "../core/pipeline-context.js";
 import type { CoreLoopResult } from "../core/core-loop.js";
 import type { ResolvedProject } from "../../config/project-resolver.js";
@@ -101,6 +101,7 @@ export interface PostProcessingContext {
   jobLogger?: JobLogger;
   hookRegistry?: HookRegistry;
   hookExecutor?: HookExecutor;
+  accumulatedPhaseResults?: PhaseResult[];
 }
 
 /**

--- a/src/pipeline/reporting/phase-result-helper.ts
+++ b/src/pipeline/reporting/phase-result-helper.ts
@@ -1,0 +1,93 @@
+import type { PhaseResult, ErrorCategory } from "../../types/pipeline.js";
+
+/**
+ * Pseudo-phase 이름 컨벤션.
+ * core-loop의 executor phase와 구분하기 위해 "카테고리:액션" 형식 사용.
+ */
+export type PseudoPhaseName =
+  | "setup:worktree"
+  | "setup:dependency"
+  | "plan:generate"
+  | "review:code"
+  | "review:simplify"
+  | "validation:check"
+  | "publish:pr";
+
+/**
+ * Pseudo-phase index 할당표.
+ * core-loop phase는 0부터 시작하는 양수 인덱스를 사용하므로
+ * pseudo-phase는 음수 인덱스로 구분한다.
+ */
+export const PSEUDO_PHASE_INDEX: Record<PseudoPhaseName, number> = {
+  "setup:worktree": -7,
+  "setup:dependency": -6,
+  "plan:generate": -5,
+  "review:code": -4,
+  "review:simplify": -3,
+  "validation:check": -2,
+  "publish:pr": -1,
+};
+
+/**
+ * 성공한 pseudo-phase PhaseResult를 생성한다.
+ */
+export function makePseudoPhaseSuccess(
+  name: PseudoPhaseName,
+  durationMs: number,
+  opts?: {
+    startedAt?: string;
+    completedAt?: string;
+    costUsd?: number;
+  }
+): PhaseResult {
+  return {
+    phaseIndex: PSEUDO_PHASE_INDEX[name],
+    phaseName: name,
+    success: true,
+    durationMs,
+    startedAt: opts?.startedAt,
+    completedAt: opts?.completedAt,
+    costUsd: opts?.costUsd,
+  };
+}
+
+/**
+ * 실패한 pseudo-phase PhaseResult를 생성한다.
+ */
+export function makePseudoPhaseFailure(
+  name: PseudoPhaseName,
+  durationMs: number,
+  error: string,
+  opts?: {
+    startedAt?: string;
+    completedAt?: string;
+    errorCategory?: ErrorCategory;
+    costUsd?: number;
+  }
+): PhaseResult {
+  return {
+    phaseIndex: PSEUDO_PHASE_INDEX[name],
+    phaseName: name,
+    success: false,
+    durationMs,
+    error,
+    startedAt: opts?.startedAt,
+    completedAt: opts?.completedAt,
+    errorCategory: opts?.errorCategory,
+    costUsd: opts?.costUsd,
+  };
+}
+
+/**
+ * pseudo-phase 여부를 판별한다 (phaseIndex < 0).
+ */
+export function isPseudoPhase(result: PhaseResult): boolean {
+  return result.phaseIndex < 0;
+}
+
+/**
+ * ISO 8601 타임스탬프를 반환하는 유틸리티.
+ */
+export function nowIso(): string {
+  return new Date().toISOString();
+}

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -32,6 +32,16 @@ export interface PipelineReport {
 }
 
 /**
+ * Renumbers phaseResults with sequential phaseIndex starting from 0,
+ * preserving their existing order.
+ * Useful when combining pseudo-phases (negative indices) with core-loop phases
+ * into a single array for reporting.
+ */
+export function reindexPhaseResults(results: PhaseResult[]): PhaseResult[] {
+  return results.map((r, i) => ({ ...r, phaseIndex: i }));
+}
+
+/**
  * Formats pipeline results into a structured report.
  */
 export function formatResult(

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -10,9 +10,10 @@ vi.mock("../../src/prompt/template-renderer.js", () => ({
 
 import { createDraftPR, closeIssue, checkPrConflict, commentOnIssue, listOpenPrs, enableAutoMerge, addIssueComment } from "../../src/github/pr-creator.js";
 import { runCli } from "../../src/utils/cli-runner.js";
-import { loadTemplate } from "../../src/prompt/template-renderer.js";
+import { renderTemplate, loadTemplate } from "../../src/prompt/template-renderer.js";
 
 const mockLoadTemplate = vi.mocked(loadTemplate);
+const mockRenderTemplate = vi.mocked(renderTemplate);
 
 const mockRunCli = vi.mocked(runCli);
 
@@ -154,6 +155,25 @@ describe("createDraftPR", () => {
       .mockResolvedValueOnce({ stdout: "", stderr: "API error", exitCode: 1 }); // retry fails
     const result = await createDraftPR(prConfig, ghConfig, ctx, options);
     expect(result).toBe(null);
+  });
+
+  it("should use '-' for pseudo-phase without commitHash in PR body phases", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/10", stderr: "", exitCode: 0 });
+    const ctxWithPseudo = {
+      ...ctx,
+      phaseResults: [
+        { phaseIndex: 0, phaseName: "setup:worktree", success: true, durationMs: 300 },
+        { phaseIndex: 1, phaseName: "Phase 1", success: true, commitHash: "abc12345", durationMs: 1000 },
+        { phaseIndex: 2, phaseName: "review:code", success: true, durationMs: 400 },
+      ],
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithPseudo, options);
+    // calls[0] = title renderTemplate, calls[1] = body renderTemplate
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const phasesText = templateVars.phases as string;
+    expect(phasesText).toContain("(-)");
+    expect(phasesText).not.toContain("(N/A)");
+    expect(phasesText).toContain("(abc12345)");
   });
 });
 

--- a/tests/pipeline/core-loop.test.ts
+++ b/tests/pipeline/core-loop.test.ts
@@ -239,7 +239,7 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(3);
+      expect(result.phaseResults).toHaveLength(4); // 3 phases + plan:generate pseudo-phase
       expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
       expect(mockExecutePhase).toHaveBeenCalledTimes(3);
 
@@ -281,7 +281,7 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(4);
+      expect(result.phaseResults).toHaveLength(5); // 4 phases + plan:generate pseudo-phase
       expect(mockSchedulePhases).toHaveBeenCalledWith(phases, false);
       expect(mockExecutePhase).toHaveBeenCalledTimes(4);
     });
@@ -304,7 +304,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.phaseResults).toEqual([]);
+      expect(result.phaseResults).toHaveLength(1); // plan:generate pseudo-phase recorded before scheduling
+      expect(result.phaseResults[0].phaseName).toBe("plan:generate");
       expect(mockExecutePhase).not.toHaveBeenCalled();
     });
 
@@ -371,8 +372,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].success).toBe(true);
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].success).toBe(true);
       expect(mockRetryPhase).toHaveBeenCalledWith(
         expect.objectContaining({
           phase: phases[0],
@@ -414,8 +415,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].errorCategory).toBe("TIMEOUT");
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].errorCategory).toBe("TIMEOUT");
       expect(mockRetryPhase).not.toHaveBeenCalled(); // No retry for timeout
     });
 
@@ -448,7 +449,7 @@ describe("runCoreLoop", () => {
       }));
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(2);
+      expect(result.phaseResults).toHaveLength(3); // previous(1) + plan:generate + phase 1
       expect(mockExecutePhase).toHaveBeenCalledTimes(1); // Only phase 1 executed
 
       // Verify phase 0 was skipped
@@ -596,9 +597,9 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(2);
-      expect(result.phaseResults[0].success).toBe(true); // Retry succeeded
-      expect(result.phaseResults[1].success).toBe(true); // Next phase succeeded
+      expect(result.phaseResults).toHaveLength(3); // plan:generate pseudo-phase + 2 phases
+      expect(result.phaseResults[1].success).toBe(true); // Retry succeeded
+      expect(result.phaseResults[2].success).toBe(true); // Next phase succeeded
 
       // Should have called retry with error history
       expect(mockRetryPhase).toHaveBeenCalledWith(expect.objectContaining({
@@ -635,8 +636,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].errorCategory).toBe("TIMEOUT");
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].errorCategory).toBe("TIMEOUT");
 
       // Should not attempt retry for timeout errors
       expect(mockRetryPhase).not.toHaveBeenCalled();
@@ -660,8 +661,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].errorCategory).toBe("SAFETY_VIOLATION");
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].errorCategory).toBe("SAFETY_VIOLATION");
 
       // Should not attempt retry for safety violations
       expect(mockRetryPhase).not.toHaveBeenCalled();
@@ -829,8 +830,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].success).toBe(true);
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].success).toBe(true);
       expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
     });
 
@@ -840,7 +841,9 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(false);
-      expect(result.phaseResults).toEqual([]);
+      expect(result.phaseResults).toHaveLength(1); // plan:generate failure pseudo-phase
+      expect(result.phaseResults[0].phaseName).toBe("plan:generate");
+      expect(result.phaseResults[0].success).toBe(false);
       expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
       expect(mockSchedulePhases).not.toHaveBeenCalled();
       expect(mockExecutePhase).not.toHaveBeenCalled();
@@ -878,7 +881,7 @@ describe("runCoreLoop", () => {
         cache_read_input_tokens: 50, // 50 (plan) + 0 + 0
         cache_creation_input_tokens: 25, // 25 (plan) + 0 + 0
       });
-      expect(result.phaseResults).toHaveLength(2);
+      expect(result.phaseResults).toHaveLength(3); // plan:generate pseudo-phase + 2 phases
       expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
     });
 
@@ -1013,8 +1016,8 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(1);
-      expect(result.phaseResults[0].phaseName).toBe("RetryPhase");
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
+      expect(result.phaseResults[1].phaseName).toBe("RetryPhase");
       expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
     });
 
@@ -1031,7 +1034,7 @@ describe("runCoreLoop", () => {
       const result = await runCoreLoop(makeContext());
 
       expect(result.success).toBe(true);
-      expect(result.phaseResults[0].phaseName).toBe("ValidPhase");
+      expect(result.phaseResults[1].phaseName).toBe("ValidPhase"); // phaseResults[0] is plan:generate pseudo-phase
       expect(mockGeneratePlan).toHaveBeenCalledTimes(1);
     });
 
@@ -1292,7 +1295,7 @@ describe("runCoreLoop", () => {
 
       // 캐시 실패에도 불구하고 실행이 성공해야 함
       expect(result.success).toBe(true);
-      expect(result.phaseResults).toHaveLength(1);
+      expect(result.phaseResults).toHaveLength(2); // plan:generate pseudo-phase + 1 phase
       expect(mockExecutePhase).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/pipeline/core/orchestrator-phaseresults.test.ts
+++ b/tests/pipeline/core/orchestrator-phaseresults.test.ts
@@ -1,0 +1,529 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock 선언 (모듈 로딩 전에 위치해야 함) ──────────────────────────────────
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock("../../../src/pipeline/setup/pipeline-git-setup.js", () => ({
+  setupGitEnvironment: vi.fn(),
+  prepareWorkEnvironment: vi.fn(),
+}));
+
+vi.mock("../../../src/pipeline/phases/pipeline-review.js", () => ({
+  runReviewPhase: vi.fn(),
+  runSimplifyPhase: vi.fn(),
+}));
+
+vi.mock("../../../src/pipeline/setup/pipeline-validation.js", () => ({
+  runValidationPhase: vi.fn(),
+}));
+
+vi.mock("../../../src/pipeline/phases/pipeline-publish.js", () => ({
+  pushAndCreatePR: vi.fn(),
+  cleanupOnSuccess: vi.fn(),
+}));
+
+vi.mock("../../../src/pipeline/automation/automation-dispatcher.js", () => ({
+  dispatchPipelineEvent: vi.fn(),
+}));
+
+vi.mock("../../../src/pipeline/reporting/result-reporter.js", () => ({
+  formatResult: vi.fn(() => ({
+    success: true,
+    issueNumber: 42,
+    repo: "test/repo",
+    phases: [],
+    startTime: Date.now(),
+  })),
+}));
+
+vi.mock("../../../src/config/mode-presets.js", () => ({
+  getModePreset: vi.fn(() => ({ planHint: "", skipFinalValidation: false })),
+  getExecutionModePreset: vi.fn(() => ({
+    skipReview: false,
+    skipSimplify: false,
+    skipValidation: false,
+  })),
+  detectExecutionModeFromLabels: vi.fn(() => "standard"),
+}));
+
+vi.mock("../../../src/pipeline/core/pipeline-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/pipeline/core/pipeline-context.js")>();
+  return {
+    ...actual,
+    saveResult: vi.fn(),
+  };
+});
+
+// 사용되지 않는 경로도 mock 처리 (module import 실패 방지)
+vi.mock("../../../src/pipeline/core/core-loop.js", () => ({ runCoreLoop: vi.fn() }));
+vi.mock("../../../src/config/project-resolver.js", () => ({ resolveProject: vi.fn() }));
+vi.mock("../../../src/learning/pattern-store.js", () => ({
+  PatternStore: vi.fn().mockImplementation(() => ({
+    getRecentFailures: vi.fn().mockReturnValue([]),
+    formatForPrompt: vi.fn().mockReturnValue(""),
+  })),
+}));
+vi.mock("../../../src/pipeline/errors/pipeline-error-handler.js", () => ({
+  handleCoreLoopFailure: vi.fn(),
+  routeError: vi.fn(),
+}));
+vi.mock("../../../src/pipeline/setup/pipeline-setup.js", () => ({
+  resolveResolvedProject: vi.fn(),
+  checkDuplicatePR: vi.fn(),
+  fetchAndValidateIssue: vi.fn(),
+}));
+vi.mock("../../../src/pipeline/automation/ci-checker.js", () => ({
+  pollCiStatus: vi.fn(),
+  autoFixCiFailures: vi.fn(),
+}));
+vi.mock("../../../src/hooks/hook-registry.js", () => ({
+  HookRegistry: vi.fn().mockImplementation(() => ({
+    hasHooks: vi.fn(() => false),
+    getHooks: vi.fn(() => []),
+  })),
+}));
+vi.mock("../../../src/hooks/hook-executor.js", () => ({
+  HookExecutor: vi.fn().mockImplementation(() => ({
+    executeHooks: vi.fn().mockResolvedValue([]),
+    updateVariables: vi.fn(),
+  })),
+}));
+
+// ── Import (mock 선언 이후) ──────────────────────────────────────────────────
+
+import {
+  executeEnvironmentSetup,
+  executePostProcessingPhases,
+} from "../../../src/pipeline/phases/pipeline-phases.js";
+import { setupGitEnvironment, prepareWorkEnvironment } from "../../../src/pipeline/setup/pipeline-git-setup.js";
+import { runReviewPhase, runSimplifyPhase } from "../../../src/pipeline/phases/pipeline-review.js";
+import { runValidationPhase } from "../../../src/pipeline/setup/pipeline-validation.js";
+import { pushAndCreatePR, cleanupOnSuccess } from "../../../src/pipeline/phases/pipeline-publish.js";
+import { PSEUDO_PHASE_INDEX } from "../../../src/pipeline/reporting/phase-result-helper.js";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults.js";
+import { PipelineTimer } from "../../../src/safety/timeout-manager.js";
+import type { PhaseResult } from "../../../src/types/pipeline.js";
+import type { PipelineRuntime } from "../../../src/pipeline/core/pipeline-context.js";
+
+const mockSetupGitEnvironment = vi.mocked(setupGitEnvironment);
+const mockPrepareWorkEnvironment = vi.mocked(prepareWorkEnvironment);
+const mockRunReviewPhase = vi.mocked(runReviewPhase);
+const mockRunSimplifyPhase = vi.mocked(runSimplifyPhase);
+const mockRunValidationPhase = vi.mocked(runValidationPhase);
+const mockPushAndCreatePR = vi.mocked(pushAndCreatePR);
+const mockCleanupOnSuccess = vi.mocked(cleanupOnSuccess);
+
+// ── 테스트 픽스처 헬퍼 ──────────────────────────────────────────────────────
+
+function makeConfig() {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.general.projectName = "test";
+  config.general.targetRoot = "/tmp/project";
+  config.git.allowedRepos = ["test/repo"];
+  return config;
+}
+
+function makeRuntime(overrides: Partial<PipelineRuntime> = {}): PipelineRuntime {
+  return {
+    state: "VALIDATED",
+    projectRoot: "/tmp/project",
+    gitConfig: {
+      gitPath: "git",
+      allowedRepos: ["test/repo"],
+      autoCreateBranch: true,
+      defaultBaseBranch: "main",
+      branchTemplate: "ax/{issue-number}-{slug}",
+    },
+    promptsDir: "/tmp/project/prompts",
+    rollbackStrategy: "none",
+    ...overrides,
+  };
+}
+
+function makeIssue() {
+  return { number: 42, title: "Fix bug", body: "Fix it", labels: [] };
+}
+
+function makeProject() {
+  return {
+    repo: "test/repo",
+    path: "/tmp/project",
+    baseBranch: "main",
+    branchTemplate: "ax/{issue-number}-{slug}",
+    commands: { claudeCli: "claude", ghPath: "gh", gitPath: "git", npmPath: "npm" },
+    review: { enabled: false, rounds: [], maxRetries: 0 },
+    pr: { draftByDefault: true, autoMerge: false, closeIssueOnMerge: true },
+    safety: { rollbackStrategy: "none" as const, maxRetries: 2, maxTotalDurationMs: 3600000 },
+  };
+}
+
+function makeCoreResult(): import("../../../src/pipeline/core/core-loop.js").CoreLoopResult {
+  return {
+    plan: {
+      issueNumber: 42,
+      title: "Fix bug",
+      problemDefinition: "Bug",
+      requirements: [],
+      affectedFiles: [],
+      risks: [],
+      phases: [{ index: 0, name: "Fix", description: "", targetFiles: [], commitStrategy: "", verificationCriteria: [], dependsOn: [] }],
+      verificationPoints: [],
+      stopConditions: [],
+    },
+    phaseResults: [{ phaseIndex: 0, phaseName: "Fix", success: true, commitHash: "abc12345", durationMs: 1000 }],
+    success: true,
+    totalCostUsd: 0.1,
+  };
+}
+
+// ── executeEnvironmentSetup 테스트 ─────────────────────────────────────────
+
+describe("executeEnvironmentSetup - phaseResults 누적", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("worktree + dependency 설정이 모두 성공하면 2개의 phaseResult가 반환된다", async () => {
+    mockSetupGitEnvironment.mockResolvedValue({
+      state: "WORKTREE_CREATED" as const,
+      branchName: "ax/42-fix-bug",
+      worktreePath: "/tmp/wt/42-fix-bug",
+    });
+    mockPrepareWorkEnvironment.mockResolvedValue({
+      rollbackHash: undefined,
+      projectConventions: "conventions",
+      skillsContext: "skills",
+      repoStructure: "structure",
+    });
+
+    const runtime = makeRuntime();
+    const result = await executeEnvironmentSetup(
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      runtime,
+      makeIssue(),
+      makeProject() as ReturnType<typeof makeProject>,
+      makeRuntime().gitConfig,
+      "/tmp/project",
+      makeConfig(),
+      vi.fn()
+    );
+
+    expect(result.phaseResults).toHaveLength(2);
+  });
+
+  it("첫 번째 phaseResult는 setup:worktree (phaseIndex -7) 성공이다", async () => {
+    mockSetupGitEnvironment.mockResolvedValue({
+      state: "WORKTREE_CREATED" as const,
+      branchName: "ax/42-fix-bug",
+      worktreePath: "/tmp/wt/42-fix-bug",
+    });
+    mockPrepareWorkEnvironment.mockResolvedValue({
+      rollbackHash: undefined,
+      projectConventions: "",
+      skillsContext: "",
+      repoStructure: "",
+    });
+
+    const result = await executeEnvironmentSetup(
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeRuntime(),
+      makeIssue(),
+      makeProject() as ReturnType<typeof makeProject>,
+      makeRuntime().gitConfig,
+      "/tmp/project",
+      makeConfig(),
+      vi.fn()
+    );
+
+    const worktreePhase = result.phaseResults[0];
+    expect(worktreePhase.phaseName).toBe("setup:worktree");
+    expect(worktreePhase.phaseIndex).toBe(PSEUDO_PHASE_INDEX["setup:worktree"]);
+    expect(worktreePhase.phaseIndex).toBe(-7);
+    expect(worktreePhase.success).toBe(true);
+    expect(worktreePhase.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("두 번째 phaseResult는 setup:dependency (phaseIndex -6) 성공이다", async () => {
+    mockSetupGitEnvironment.mockResolvedValue({
+      state: "WORKTREE_CREATED" as const,
+      branchName: "ax/42-fix-bug",
+      worktreePath: "/tmp/wt/42-fix-bug",
+    });
+    mockPrepareWorkEnvironment.mockResolvedValue({
+      rollbackHash: "abc123",
+      projectConventions: "conventions",
+      skillsContext: "skills",
+      repoStructure: "structure",
+    });
+
+    const result = await executeEnvironmentSetup(
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeRuntime(),
+      makeIssue(),
+      makeProject() as ReturnType<typeof makeProject>,
+      makeRuntime().gitConfig,
+      "/tmp/project",
+      makeConfig(),
+      vi.fn()
+    );
+
+    const depPhase = result.phaseResults[1];
+    expect(depPhase.phaseName).toBe("setup:dependency");
+    expect(depPhase.phaseIndex).toBe(PSEUDO_PHASE_INDEX["setup:dependency"]);
+    expect(depPhase.phaseIndex).toBe(-6);
+    expect(depPhase.success).toBe(true);
+  });
+
+  it("worktreePath가 설정되지 않으면 setup:dependency가 기록되지 않는다", async () => {
+    // worktreePath를 undefined로 반환하면 transitionState 후 runtime.worktreePath가 없음
+    mockSetupGitEnvironment.mockResolvedValue({
+      state: "WORKTREE_CREATED" as const,
+      branchName: "ax/42-fix-bug",
+      worktreePath: undefined as unknown as string,
+    });
+
+    // runtime에 worktreePath가 없는 상태로 시작
+    const runtime = makeRuntime({ worktreePath: undefined });
+
+    const result = await executeEnvironmentSetup(
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      runtime,
+      makeIssue(),
+      makeProject() as ReturnType<typeof makeProject>,
+      makeRuntime().gitConfig,
+      "/tmp/project",
+      makeConfig(),
+      vi.fn()
+    );
+
+    // setup:worktree만 기록되고, setup:dependency는 기록되지 않는다
+    expect(result.phaseResults).toHaveLength(1);
+    expect(result.phaseResults[0].phaseName).toBe("setup:worktree");
+    expect(mockPrepareWorkEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("phaseResult에 startedAt, completedAt 타임스탬프가 포함된다", async () => {
+    mockSetupGitEnvironment.mockResolvedValue({
+      state: "WORKTREE_CREATED" as const,
+      branchName: "ax/42-fix-bug",
+      worktreePath: "/tmp/wt/42-fix-bug",
+    });
+    mockPrepareWorkEnvironment.mockResolvedValue({
+      rollbackHash: undefined,
+      projectConventions: "",
+      skillsContext: "",
+      repoStructure: "",
+    });
+
+    const result = await executeEnvironmentSetup(
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeRuntime(),
+      makeIssue(),
+      makeProject() as ReturnType<typeof makeProject>,
+      makeRuntime().gitConfig,
+      "/tmp/project",
+      makeConfig(),
+      vi.fn()
+    );
+
+    for (const phase of result.phaseResults) {
+      expect(phase.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(phase.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    }
+  });
+});
+
+// ── executePostProcessingPhases - phaseResults 누적 테스트 ──────────────────
+
+describe("executePostProcessingPhases - accumulatedPhaseResults 누적", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCleanupOnSuccess.mockResolvedValue(undefined);
+  });
+
+  function makePostProcessingContext(
+    accumulatedPhaseResults: PhaseResult[] = []
+  ) {
+    const timer = new PipelineTimer(3_600_000); // 1시간 타임아웃
+    return {
+      issue: makeIssue(),
+      coreResult: makeCoreResult(),
+      gitConfig: makeRuntime().gitConfig,
+      project: makeProject() as ReturnType<typeof makeProject>,
+      worktreePath: "/tmp/wt/42-fix-bug",
+      promptsDir: "/tmp/project/prompts",
+      skillsContext: "",
+      preset: { planHint: "", skipFinalValidation: false },
+      timer,
+      checkpoint: vi.fn(),
+      accumulatedPhaseResults,
+    };
+  }
+
+  it("정상 파이프라인: review:code, validation:check, publish:pr이 accumulatedPhaseResults에 추가된다", async () => {
+    mockRunReviewPhase.mockResolvedValue({ success: true, costUsd: 0, reviewVariables: undefined });
+    mockRunValidationPhase.mockResolvedValue({ success: true });
+    mockPushAndCreatePR.mockResolvedValue({ success: true, prUrl: "https://github.com/test/repo/pull/1", prNumber: 1 });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    const context = makePostProcessingContext(accumulatedPhaseResults);
+    const runtime = makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" });
+
+    await executePostProcessingPhases(context, runtime, {
+      issueNumber: 42,
+      repo: "test/repo",
+      config: makeConfig(),
+      projectRoot: "/tmp/project",
+    }, makeConfig(), Date.now());
+
+    // review:code, validation:check, publish:pr 세 phase가 추가되어야 한다
+    expect(accumulatedPhaseResults.length).toBeGreaterThanOrEqual(2);
+    const names = accumulatedPhaseResults.map((r) => r.phaseName);
+    expect(names).toContain("review:code");
+    expect(names).toContain("validation:check");
+    expect(names).toContain("publish:pr");
+  });
+
+  it("review:code phase 성공 시 success=true로 기록된다", async () => {
+    mockRunReviewPhase.mockResolvedValue({ success: true, costUsd: 0.05, reviewVariables: undefined });
+    mockRunValidationPhase.mockResolvedValue({ success: true });
+    mockPushAndCreatePR.mockResolvedValue({ success: true, prUrl: "https://github.com/test/repo/pull/1", prNumber: 1 });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    await executePostProcessingPhases(
+      makePostProcessingContext(accumulatedPhaseResults),
+      makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" }),
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeConfig(),
+      Date.now()
+    );
+
+    const reviewPhase = accumulatedPhaseResults.find((r) => r.phaseName === "review:code");
+    expect(reviewPhase).toBeDefined();
+    expect(reviewPhase!.success).toBe(true);
+    expect(reviewPhase!.phaseIndex).toBe(PSEUDO_PHASE_INDEX["review:code"]);
+    expect(reviewPhase!.phaseIndex).toBe(-4);
+  });
+
+  it("review:simplify는 reviewVariables가 없으면 기록되지 않는다", async () => {
+    // reviewVariables가 undefined이면 simplify 단계를 건너뜀
+    mockRunReviewPhase.mockResolvedValue({ success: true, costUsd: 0, reviewVariables: undefined });
+    mockRunValidationPhase.mockResolvedValue({ success: true });
+    mockPushAndCreatePR.mockResolvedValue({ success: true, prUrl: "https://github.com/test/repo/pull/1", prNumber: 1 });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    await executePostProcessingPhases(
+      makePostProcessingContext(accumulatedPhaseResults),
+      makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" }),
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeConfig(),
+      Date.now()
+    );
+
+    const simplifyPhase = accumulatedPhaseResults.find((r) => r.phaseName === "review:simplify");
+    expect(simplifyPhase).toBeUndefined();
+    expect(mockRunSimplifyPhase).not.toHaveBeenCalled();
+  });
+
+  it("review:simplify는 reviewVariables가 있으면 기록된다", async () => {
+    mockRunReviewPhase.mockResolvedValue({
+      success: true,
+      costUsd: 0.03,
+      reviewVariables: { diff: "some diff", findings: [] },
+    });
+    mockRunSimplifyPhase.mockResolvedValue({ success: true, costUsd: 0.02 });
+    mockRunValidationPhase.mockResolvedValue({ success: true });
+    mockPushAndCreatePR.mockResolvedValue({ success: true, prUrl: "https://github.com/test/repo/pull/1", prNumber: 1 });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    await executePostProcessingPhases(
+      makePostProcessingContext(accumulatedPhaseResults),
+      makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" }),
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeConfig(),
+      Date.now()
+    );
+
+    const simplifyPhase = accumulatedPhaseResults.find((r) => r.phaseName === "review:simplify");
+    expect(simplifyPhase).toBeDefined();
+    expect(simplifyPhase!.success).toBe(true);
+    expect(simplifyPhase!.phaseIndex).toBe(PSEUDO_PHASE_INDEX["review:simplify"]);
+    expect(simplifyPhase!.phaseIndex).toBe(-3);
+  });
+
+  it("review 실패 시 review:code가 success=false로 기록된다", async () => {
+    mockRunReviewPhase.mockResolvedValue({
+      success: false,
+      costUsd: 0.01,
+      error: "Review failed: missing tests",
+      reviewVariables: undefined,
+    });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    const context = makePostProcessingContext(accumulatedPhaseResults);
+    const runtime = makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" });
+
+    await expect(
+      executePostProcessingPhases(context, runtime, {
+        issueNumber: 42,
+        repo: "test/repo",
+        config: makeConfig(),
+        projectRoot: "/tmp/project",
+      }, makeConfig(), Date.now())
+    ).rejects.toThrow("Review failed: missing tests");
+
+    const reviewPhase = accumulatedPhaseResults.find((r) => r.phaseName === "review:code");
+    expect(reviewPhase).toBeDefined();
+    expect(reviewPhase!.success).toBe(false);
+    expect(reviewPhase!.error).toBe("Review failed: missing tests");
+  });
+
+  it("publish:pr phase의 phaseIndex는 -1이다", async () => {
+    mockRunReviewPhase.mockResolvedValue({ success: true, costUsd: 0, reviewVariables: undefined });
+    mockRunValidationPhase.mockResolvedValue({ success: true });
+    mockPushAndCreatePR.mockResolvedValue({ success: true, prUrl: "https://github.com/test/repo/pull/1", prNumber: 1 });
+
+    const accumulatedPhaseResults: PhaseResult[] = [];
+    await executePostProcessingPhases(
+      makePostProcessingContext(accumulatedPhaseResults),
+      makeRuntime({ worktreePath: "/tmp/wt/42-fix-bug", branchName: "ax/42-fix-bug" }),
+      { issueNumber: 42, repo: "test/repo", config: makeConfig(), projectRoot: "/tmp/project" },
+      makeConfig(),
+      Date.now()
+    );
+
+    const publishPhase = accumulatedPhaseResults.find((r) => r.phaseName === "publish:pr");
+    expect(publishPhase).toBeDefined();
+    expect(publishPhase!.phaseIndex).toBe(-1);
+    expect(publishPhase!.phaseIndex).toBe(PSEUDO_PHASE_INDEX["publish:pr"]);
+  });
+});
+
+// ── phaseIndex 재번호 정확성 테스트 ────────────────────────────────────────
+
+describe("phaseIndex 재번호 정확성", () => {
+  it("pseudo-phase 인덱스는 core-loop phase 인덱스(0 이상)와 겹치지 않는다", () => {
+    const pseudoIndices = Object.values(PSEUDO_PHASE_INDEX);
+    for (const idx of pseudoIndices) {
+      expect(idx).toBeLessThan(0);
+    }
+    // core-loop phase 인덱스는 0부터 시작
+    const corePhaseIndices = [0, 1, 2, 3, 4];
+    for (const coreIdx of corePhaseIndices) {
+      expect(pseudoIndices).not.toContain(coreIdx);
+    }
+  });
+
+  it("pseudo-phase 인덱스 순서: setup:worktree < setup:dependency < ... < publish:pr", () => {
+    expect(PSEUDO_PHASE_INDEX["setup:worktree"]).toBeLessThan(PSEUDO_PHASE_INDEX["setup:dependency"]);
+    expect(PSEUDO_PHASE_INDEX["setup:dependency"]).toBeLessThan(PSEUDO_PHASE_INDEX["plan:generate"]);
+    expect(PSEUDO_PHASE_INDEX["plan:generate"]).toBeLessThan(PSEUDO_PHASE_INDEX["review:code"]);
+    expect(PSEUDO_PHASE_INDEX["review:code"]).toBeLessThan(PSEUDO_PHASE_INDEX["review:simplify"]);
+    expect(PSEUDO_PHASE_INDEX["review:simplify"]).toBeLessThan(PSEUDO_PHASE_INDEX["validation:check"]);
+    expect(PSEUDO_PHASE_INDEX["validation:check"]).toBeLessThan(PSEUDO_PHASE_INDEX["publish:pr"]);
+    expect(PSEUDO_PHASE_INDEX["publish:pr"]).toBe(-1); // 가장 마지막
+  });
+});

--- a/tests/pipeline/reporting/phase-result-helper.test.ts
+++ b/tests/pipeline/reporting/phase-result-helper.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import {
+  makePseudoPhaseSuccess,
+  makePseudoPhaseFailure,
+  isPseudoPhase,
+  PSEUDO_PHASE_INDEX,
+  nowIso,
+  type PseudoPhaseName,
+} from "../../../src/pipeline/reporting/phase-result-helper.js";
+
+describe("PSEUDO_PHASE_INDEX", () => {
+  it("모든 pseudo-phase 인덱스는 음수이다", () => {
+    for (const [, value] of Object.entries(PSEUDO_PHASE_INDEX)) {
+      expect(value).toBeLessThan(0);
+    }
+  });
+
+  it("각 phase의 인덱스 값이 올바르다", () => {
+    expect(PSEUDO_PHASE_INDEX["setup:worktree"]).toBe(-7);
+    expect(PSEUDO_PHASE_INDEX["setup:dependency"]).toBe(-6);
+    expect(PSEUDO_PHASE_INDEX["plan:generate"]).toBe(-5);
+    expect(PSEUDO_PHASE_INDEX["review:code"]).toBe(-4);
+    expect(PSEUDO_PHASE_INDEX["review:simplify"]).toBe(-3);
+    expect(PSEUDO_PHASE_INDEX["validation:check"]).toBe(-2);
+    expect(PSEUDO_PHASE_INDEX["publish:pr"]).toBe(-1);
+  });
+
+  it("7개의 pseudo-phase가 정의되어 있다", () => {
+    const names: PseudoPhaseName[] = [
+      "setup:worktree",
+      "setup:dependency",
+      "plan:generate",
+      "review:code",
+      "review:simplify",
+      "validation:check",
+      "publish:pr",
+    ];
+    expect(Object.keys(PSEUDO_PHASE_INDEX)).toHaveLength(names.length);
+    for (const name of names) {
+      expect(PSEUDO_PHASE_INDEX[name]).toBeDefined();
+    }
+  });
+
+  it("인덱스 값이 모두 고유하다", () => {
+    const values = Object.values(PSEUDO_PHASE_INDEX);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});
+
+describe("makePseudoPhaseSuccess", () => {
+  it("success=true인 PhaseResult를 반환한다", () => {
+    const result = makePseudoPhaseSuccess("setup:worktree", 1234);
+    expect(result.success).toBe(true);
+    expect(result.phaseIndex).toBe(-7);
+    expect(result.phaseName).toBe("setup:worktree");
+    expect(result.durationMs).toBe(1234);
+  });
+
+  it("error 필드가 없다", () => {
+    const result = makePseudoPhaseSuccess("plan:generate", 500);
+    expect(result.error).toBeUndefined();
+    expect(result.errorCategory).toBeUndefined();
+  });
+
+  it("opts 없이 호출 시 timestamp 필드는 undefined이다", () => {
+    const result = makePseudoPhaseSuccess("publish:pr", 999);
+    expect(result.startedAt).toBeUndefined();
+    expect(result.completedAt).toBeUndefined();
+    expect(result.costUsd).toBeUndefined();
+  });
+
+  it("opts.startedAt, completedAt, costUsd를 포함한다", () => {
+    const result = makePseudoPhaseSuccess("review:code", 2000, {
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:02.000Z",
+      costUsd: 0.05,
+    });
+    expect(result.startedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.completedAt).toBe("2026-01-01T00:00:02.000Z");
+    expect(result.costUsd).toBe(0.05);
+  });
+
+  it("각 pseudo-phase 이름에 대해 올바른 phaseIndex를 할당한다", () => {
+    const cases: PseudoPhaseName[] = [
+      "setup:worktree",
+      "setup:dependency",
+      "plan:generate",
+      "review:code",
+      "review:simplify",
+      "validation:check",
+      "publish:pr",
+    ];
+    for (const name of cases) {
+      const result = makePseudoPhaseSuccess(name, 100);
+      expect(result.phaseIndex).toBe(PSEUDO_PHASE_INDEX[name]);
+      expect(result.phaseName).toBe(name);
+    }
+  });
+});
+
+describe("makePseudoPhaseFailure", () => {
+  it("success=false인 PhaseResult를 반환한다", () => {
+    const result = makePseudoPhaseFailure("setup:dependency", 300, "install failed");
+    expect(result.success).toBe(false);
+    expect(result.phaseIndex).toBe(-6);
+    expect(result.phaseName).toBe("setup:dependency");
+    expect(result.durationMs).toBe(300);
+    expect(result.error).toBe("install failed");
+  });
+
+  it("opts 없이 호출 시 optional 필드는 undefined이다", () => {
+    const result = makePseudoPhaseFailure("validation:check", 100, "timeout");
+    expect(result.startedAt).toBeUndefined();
+    expect(result.completedAt).toBeUndefined();
+    expect(result.errorCategory).toBeUndefined();
+    expect(result.costUsd).toBeUndefined();
+  });
+
+  it("opts.errorCategory, timestamps, costUsd를 포함한다", () => {
+    const result = makePseudoPhaseFailure("review:code", 5000, "review failed", {
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T00:00:05.000Z",
+      errorCategory: "VERIFICATION_FAILED",
+      costUsd: 0.12,
+    });
+    expect(result.errorCategory).toBe("VERIFICATION_FAILED");
+    expect(result.startedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.completedAt).toBe("2026-01-01T00:00:05.000Z");
+    expect(result.costUsd).toBe(0.12);
+  });
+
+  it("각 pseudo-phase 이름에 대해 올바른 phaseIndex를 할당한다", () => {
+    const cases: PseudoPhaseName[] = [
+      "setup:worktree",
+      "setup:dependency",
+      "review:code",
+      "publish:pr",
+    ];
+    for (const name of cases) {
+      const result = makePseudoPhaseFailure(name, 50, "err");
+      expect(result.phaseIndex).toBe(PSEUDO_PHASE_INDEX[name]);
+    }
+  });
+});
+
+describe("isPseudoPhase", () => {
+  it("phaseIndex < 0이면 true를 반환한다", () => {
+    expect(isPseudoPhase({ phaseIndex: -1, phaseName: "publish:pr", success: true, durationMs: 0 })).toBe(true);
+    expect(isPseudoPhase({ phaseIndex: -7, phaseName: "setup:worktree", success: true, durationMs: 0 })).toBe(true);
+    expect(isPseudoPhase({ phaseIndex: -100, phaseName: "x", success: false, durationMs: 0 })).toBe(true);
+  });
+
+  it("phaseIndex >= 0이면 false를 반환한다", () => {
+    expect(isPseudoPhase({ phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 0 })).toBe(false);
+    expect(isPseudoPhase({ phaseIndex: 1, phaseName: "Phase 2", success: true, durationMs: 0 })).toBe(false);
+    expect(isPseudoPhase({ phaseIndex: 99, phaseName: "Phase 99", success: false, durationMs: 0 })).toBe(false);
+  });
+
+  it("makePseudoPhaseSuccess로 생성된 결과는 항상 isPseudoPhase=true이다", () => {
+    const names: PseudoPhaseName[] = [
+      "setup:worktree",
+      "setup:dependency",
+      "plan:generate",
+      "review:code",
+      "review:simplify",
+      "validation:check",
+      "publish:pr",
+    ];
+    for (const name of names) {
+      const result = makePseudoPhaseSuccess(name, 0);
+      expect(isPseudoPhase(result)).toBe(true);
+    }
+  });
+
+  it("makePseudoPhaseFailure로 생성된 결과는 항상 isPseudoPhase=true이다", () => {
+    const result = makePseudoPhaseFailure("review:code", 0, "err");
+    expect(isPseudoPhase(result)).toBe(true);
+  });
+});
+
+describe("nowIso", () => {
+  it("ISO 8601 형식의 문자열을 반환한다", () => {
+    const iso = nowIso();
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("반환값이 현재 시각 기준 유효한 Date이다", () => {
+    const before = Date.now();
+    const iso = nowIso();
+    const after = Date.now();
+    const parsed = new Date(iso).getTime();
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
+  });
+});

--- a/tests/pipeline/result-reporter.test.ts
+++ b/tests/pipeline/result-reporter.test.ts
@@ -4,7 +4,7 @@ vi.mock("../../src/utils/logger.js", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
-import { formatResult, printResult } from "../../src/pipeline/reporting/result-reporter.js";
+import { formatResult, printResult, reindexPhaseResults } from "../../src/pipeline/reporting/result-reporter.js";
 import type { Plan, PhaseResult } from "../../src/types/pipeline.js";
 
 function makePlan(overrides: Partial<Plan> = {}): Plan {
@@ -105,6 +105,66 @@ describe("formatResult", () => {
     expect(report.phases[0].error).toBe("build error");
     expect(report.phases[0].errorCategory).toBe("CLI_CRASH");
     expect(report.phases[0].durationMs).toBe(750);
+  });
+});
+
+describe("reindexPhaseResults", () => {
+  it("assigns sequential phaseIndex starting from 0", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: -7, phaseName: "setup:worktree", success: true, durationMs: 500 },
+      { phaseIndex: -6, phaseName: "setup:dependency", success: true, durationMs: 300 },
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, commitHash: "abc12345", durationMs: 1000 },
+      { phaseIndex: 1, phaseName: "Phase 2", success: true, commitHash: "feedcafe", durationMs: 2000 },
+      { phaseIndex: -4, phaseName: "review:code", success: true, durationMs: 400 },
+    ];
+    const reindexed = reindexPhaseResults(results);
+    expect(reindexed.map(r => r.phaseIndex)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("preserves insertion order of results", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: -7, phaseName: "setup:worktree", success: true, durationMs: 100 },
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 200 },
+      { phaseIndex: -1, phaseName: "publish:pr", success: true, durationMs: 300 },
+    ];
+    const reindexed = reindexPhaseResults(results);
+    expect(reindexed[0].phaseName).toBe("setup:worktree");
+    expect(reindexed[1].phaseName).toBe("Phase 1");
+    expect(reindexed[2].phaseName).toBe("publish:pr");
+  });
+
+  it("does not mutate the original array", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: -5, phaseName: "plan:generate", success: true, durationMs: 500 },
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    reindexPhaseResults(results);
+    expect(results[0].phaseIndex).toBe(-5);
+    expect(results[1].phaseIndex).toBe(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(reindexPhaseResults([])).toEqual([]);
+  });
+
+  it("preserves all other fields of each PhaseResult", () => {
+    const results: PhaseResult[] = [
+      {
+        phaseIndex: -4,
+        phaseName: "review:code",
+        success: false,
+        error: "review failed",
+        errorCategory: "UNKNOWN",
+        durationMs: 800,
+        costUsd: 0.01,
+      },
+    ];
+    const reindexed = reindexPhaseResults(results);
+    expect(reindexed[0].phaseIndex).toBe(0);
+    expect(reindexed[0].phaseName).toBe("review:code");
+    expect(reindexed[0].success).toBe(false);
+    expect(reindexed[0].error).toBe("review failed");
+    expect(reindexed[0].costUsd).toBe(0.01);
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves #643 — fix: 파이프라인 전체 phase 기록 확장 — setup/plan/review/publish도 phaseResults에

현재 phaseResults에는 core-loop에서 실행하는 plan 실행 phase만 기록됨. setup(worktree/dependency), plan 생성, review/simplify, validation, publish 단계는 전혀 기록되지 않아 25분 이상의 시간이 추적 불가. 이 이슈는 모든 파이프라인 단계를 pseudo-phase로 phaseResults에 기록하여 전체 파이프라인 가시성을 확보하는 것이 목표.

## Requirements

- pipeline setup (worktree/dependency) 단계를 phaseResults에 pseudo-phase로 append
- plan 생성 / review / publish 단계를 동일하게 phaseResults에 append
- phase 이름에 단계 구분이 드러나도록 네이밍 규칙 정의 (예: setup:worktree, plan:generate, review:codex, publish:pr)
- 기존 core-loop phaseResults와 자연스럽게 병합 — phaseIndex 연속성 유지
- depends: #642 (startedAt/completedAt 필드) — 이미 PhaseResult 타입에 존재 확인

## Implementation Phases

- Phase 0: pseudo-phase 헬퍼 유틸리티 — SUCCESS (2597f99e)
- Phase 1: orchestrator에 phaseResults 누적 배열 도입 — SUCCESS (6f02105b)
- Phase 2: setup 단계 phaseResults 기록 — SUCCESS (1714e3d8)
- Phase 3: plan 생성 단계 phaseResults 기록 — SUCCESS (5d2d5926)
- Phase 4: review/simplify/validation/publish 단계 phaseResults 기록 — SUCCESS (5d2d5926)
- Phase 5: phaseIndex 재번호 및 리포팅 통합 — SUCCESS (d10018a6)
- Phase 6: 테스트 작성 — SUCCESS (0bd3fbbb)

## Risks

- orchestrator/pipeline-phases.ts 시그니처 변경으로 기존 호출부 영향 — 하위 호환 유지 필요
- phaseResults 배열이 커지면 checkpoint 직렬화 크기 증가 — pseudo-phase는 lastOutput 없이 경량 유지
- core-loop 내 phaseIndex와 pseudo-phase phaseIndex 충돌 — 최종 재번호로 해결

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $8.8436 (review: $0.2901)
- **Phases**: 7/7 completed
- **Branch**: `aq/643-fix-phase-setup-plan-review-publish-phaseresults` → `develop`
- **Tokens**: 291 input, 80359 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| pseudo-phase 헬퍼 유틸리티 | $0.4290 | 0 | $0.0000 |
| orchestrator에 phaseResults 누적 배열 도입 | $0.5822 | 0 | $0.0000 |
| setup 단계 phaseResults 기록 | $0.9651 | 0 | $0.0000 |
| plan 생성 단계 phaseResults 기록 | $1.7345 | 1 | $1.7345 |
| review/simplify/validation/publish 단계 phaseResults 기록 | $2.1948 | 1 | $2.1948 |
| phaseIndex 재번호 및 리포팅 통합 | $0.9733 | 0 | $0.0000 |
| 테스트 작성 | $1.1016 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $7.9805 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #643