### PR TITLE
[AQ-#669] ci: visual-regression 회복탄력성 — advisory 모드 + baseline regen 워크플로 + PR 체크리스트

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## 변경 사항
+
+<!-- 이 PR에서 무엇을 변경했는지 간략히 설명하세요 -->
+
+## 체크리스트
+
+- [ ] 코드 빌드 확인 (`npx tsc --noEmit`)
+- [ ] 테스트 통과 확인 (`npx vitest run`)
+- [ ] 린트 통과 확인 (`npx eslint src/ tests/`)
+
+### UI 변경 포함 시
+
+- [ ] UI 변경이 없거나 visual baseline 재생성이 불필요함
+- [ ] UI 변경 포함 — visual baseline 재생성 완료 (`gh workflow run regen-visual-baseline.yml`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,10 @@ jobs:
           path: tests/visual/__snapshots__/
 
   visual-regression:
-    name: visual-regression
+    name: visual-regression (advisory)
     runs-on: ubuntu-latest
     if: (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event_name == 'workflow_dispatch'
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -93,7 +94,7 @@ jobs:
           EOF
       - run: npx playwright test --project=visual-desktop --project=visual-mobile
       - name: Upload test artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/.github/workflows/visual-baseline-regen.yml
+++ b/.github/workflows/visual-baseline-regen.yml
@@ -1,0 +1,25 @@
+name: Visual Baseline Regen
+
+on:
+  workflow_dispatch:
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Seed test config.yml
+        run: cp config.reference.yml config.yml
+      - run: npx playwright test --update-snapshots --project=visual-desktop --project=visual-mobile
+      - name: Create PR with updated snapshots
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-visual-baselines
+          commit-message: "chore: visual baseline 재생성"
+          title: "chore: visual baseline 재생성"
+          body: "workflow_dispatch로 트리거된 visual baseline 재생성"


### PR DESCRIPTION
## Summary

Resolves #669 — ci: visual-regression 회복탄력성 — advisory 모드 + baseline regen 워크플로 + PR 체크리스트

visual-regression 잡이 현재 `if: false`로 비활성화되어 있다. #668에서 baseline이 생성되면 이 잡을 재활성화하되, Playwright 인프라 실패가 릴리스를 블록하지 않도록 advisory 모드로 전환해야 한다. 추가로 baseline 재생성 워크플로와 PR 템플릿 체크리스트가 필요하다.

## Requirements

- visual-regression 잡을 advisory 모드로 재활성화 (continue-on-error: true, 실패해도 PR 머지 비블록)
- baseline-regen 워크플로 신규 생성 (workflow_dispatch → playwright --update-snapshots → 자동 PR)
- PR 템플릿에 UI 변경 baseline 재생성 체크박스 추가
- 실패 시 artifact 업로드 유지 + job 결과는 warning 수준 노출

## Implementation Phases

- Phase 0: visual-regression advisory 전환 — SUCCESS (e5c1bd65)
- Phase 1: baseline-regen 워크플로 생성 — SUCCESS (e5c1bd65)
- Phase 2: PR 템플릿 체크리스트 추가 — SUCCESS (e5c1bd65)

## Risks

- continue-on-error: true 시 artifact 업로드 step의 if: failure()가 동작하지 않을 수 있음 → if: always()로 변경 필요
- peter-evans/create-pull-request 액션의 GITHUB_TOKEN 권한(contents: write, pull-requests: write) 필요 — 기본 토큰으로 충분한지 확인
- baseline-regen 워크플로에서 webServer가 필요한 경우 config.yml 시딩 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.1295 (review: $0.1408)
- **Phases**: 3/3 completed
- **Branch**: `aq/669-ci-visual-regression-advisory-baseline-regen-pr` → `develop`
- **Tokens**: 64 input, 7796 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| visual-regression advisory 전환 | $0.1929 | 0 | $0.0000 |
| baseline-regen 워크플로 생성 | $0.2636 | 0 | $0.0000 |
| PR 템플릿 체크리스트 추가 | $0.1803 | 1 | $0.1803 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.6368 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #669