### PR TITLE
[AQ-#670] [P1-critical] fix: bin/aqm 래퍼를 npm 설치 시나리오와 호환되도록 재작성

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -1,8 +1,36 @@
 #!/usr/bin/env bash
-AQM_HOME="${AQM_HOME:-$HOME/.ai-quartermaster}"
-AQM_PID_FILE="$AQM_HOME/.aqm-server.pid"
-AQM_LOG_FILE="$AQM_HOME/logs/server.log"
-AQM_CLAUDE_PROFILE_FILE="$AQM_HOME/.claude-profile"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# --- 설치 모드 감지 ---
+AQM_MODE=""
+AQM_ROOT=""
+
+# npm 글로벌 모드: bin 옆의 lib/node_modules/ai-quartermaster/dist/cli.js 존재 여부
+NPM_ROOT="$SCRIPT_DIR/../lib/node_modules/ai-quartermaster"
+if [ -f "$NPM_ROOT/dist/cli.js" ]; then
+  AQM_MODE="npm"
+  AQM_ROOT=$(cd "$NPM_ROOT" && pwd)
+fi
+
+# git-clone 모드: AQM_HOME 환경변수 + 디렉토리 존재
+if [ -z "$AQM_MODE" ] && [ -n "$AQM_HOME" ] && [ -d "$AQM_HOME" ]; then
+  AQM_MODE="git"
+  AQM_ROOT="$AQM_HOME"
+fi
+
+if [ -z "$AQM_MODE" ]; then
+  echo "AI Quartermaster가 설치되어 있지 않습니다."
+  echo ""
+  echo "npm 글로벌 설치:  npm install -g ai-quartermaster"
+  echo "git-clone 설치:   curl -fsSL https://raw.githubusercontent.com/happytalkrz/AI-Quartermaster/main/install.sh | bash"
+  exit 1
+fi
+
+# PID/로그 파일은 항상 $HOME/.ai-quartermaster/ 고정
+AQM_DATA_DIR="$HOME/.ai-quartermaster"
+AQM_PID_FILE="$AQM_DATA_DIR/.aqm-server.pid"
+AQM_LOG_FILE="$AQM_DATA_DIR/logs/server.log"
+AQM_CLAUDE_PROFILE_FILE="$AQM_DATA_DIR/.claude-profile"
 
 # Resolve CLAUDE_CONFIG_DIR for the daemon so the dashboard shows the right profile.
 # Priority: current env > tmux global env > persisted .claude-profile file.
@@ -29,11 +57,22 @@ resolve_claude_config_dir() {
 }
 resolve_claude_config_dir
 
-if [ ! -d "$AQM_HOME" ]; then
-  echo "AI Quartermaster가 설치되어 있지 않습니다."
-  echo "설치: curl -fsSL https://raw.githubusercontent.com/happytalkrz/AI-Quartermaster/main/install.sh | bash"
-  exit 1
-fi
+# CLI 실행 헬퍼
+run_cli() {
+  if [ "$AQM_MODE" = "npm" ]; then
+    node "$AQM_ROOT/dist/cli.js" "$@"
+  else
+    npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "$@"
+  fi
+}
+
+exec_cli() {
+  if [ "$AQM_MODE" = "npm" ]; then
+    exec node "$AQM_ROOT/dist/cli.js" "$@"
+  else
+    exec npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "$@"
+  fi
+}
 
 # Check if server is running (PID file + port-based detection)
 is_server_running() {
@@ -66,6 +105,13 @@ find_server_pid() {
 
 case "${1:-}" in
   update)
+    if [ "$AQM_MODE" = "npm" ]; then
+      echo "npm 글로벌 설치 환경에서는 아래 명령으로 업데이트하세요:"
+      echo ""
+      echo "  npm update -g ai-quartermaster"
+      exit 0
+    fi
+
     BRANCH="main"
     CLEAN_FLAG=false
 
@@ -90,7 +136,7 @@ case "${1:-}" in
     done
 
     echo "AI Quartermaster 업데이트 중... (브랜치: $BRANCH)"
-    cd "$AQM_HOME"
+    cd "$AQM_ROOT"
     BEFORE=$(git rev-parse HEAD)
     git fetch --quiet origin
     git checkout --quiet "$BRANCH"
@@ -123,8 +169,8 @@ case "${1:-}" in
         exit 1
       fi
       # Update wrapper script
-      if [ -f "$AQM_HOME/bin/aqm" ]; then
-        cp "$AQM_HOME/bin/aqm" "$HOME/.local/bin/aqm"
+      if [ -f "$AQM_ROOT/bin/aqm" ]; then
+        cp "$AQM_ROOT/bin/aqm" "$HOME/.local/bin/aqm"
         chmod +x "$HOME/.local/bin/aqm"
       fi
       echo "업데이트 완료!"
@@ -139,15 +185,18 @@ case "${1:-}" in
       rm -f "$AQM_PID_FILE"
     fi
     echo "AI Quartermaster를 삭제합니다..."
-    rm -rf "$AQM_HOME"
+    rm -rf "$AQM_DATA_DIR"
     rm -f "$HOME/.local/bin/aqm"
     echo "삭제 완료."
     exit 0
     ;;
   version|--version|-v)
-    cd "$AQM_HOME"
-    VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)" 2>/dev/null || echo "unknown")
-    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$AQM_ROOT/package.json','utf8')).version)" 2>/dev/null || echo "unknown")
+    if [ "$AQM_MODE" = "git" ]; then
+      COMMIT=$(git -C "$AQM_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    else
+      COMMIT="npm"
+    fi
     echo "AI Quartermaster v${VERSION} (${COMMIT})"
     exit 0
     ;;
@@ -205,11 +254,15 @@ case "${1:-}" in
         exit 1
       fi
 
-      mkdir -p "$AQM_HOME/logs"
+      mkdir -p "$AQM_DATA_DIR/logs"
       echo "서버를 백그라운드에서 시작합니다..."
-      cd "$AQM_HOME"
-      nohup npx --prefix "$AQM_HOME" tsx "$AQM_HOME/src/cli.ts" start "${ARGS[@]}" \
-        >> "$AQM_LOG_FILE" 2>&1 &
+      if [ "$AQM_MODE" = "npm" ]; then
+        nohup node "$AQM_ROOT/dist/cli.js" start "${ARGS[@]}" \
+          >> "$AQM_LOG_FILE" 2>&1 &
+      else
+        nohup npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" start "${ARGS[@]}" \
+          >> "$AQM_LOG_FILE" 2>&1 &
+      fi
       echo $! > "$AQM_PID_FILE"
       sleep 2
 
@@ -228,14 +281,17 @@ case "${1:-}" in
     fi
 
     # Foreground mode — pass through
-    cd "$AQM_HOME"
-    exec npx --prefix "$AQM_HOME" tsx "$AQM_HOME/src/cli.ts" start "${ARGS[@]}"
+    exec_cli start "${ARGS[@]}"
     ;;
   stop)
     # Extract port from config or use default
     PORT=3000
-    if [ -f "$AQM_HOME/config.yml" ]; then
-      PORT=$(grep -E "^\s*port\s*:" "$AQM_HOME/config.yml" 2>/dev/null | sed -E 's/^\s*port\s*:\s*([0-9]+).*/\1/' | head -n1)
+    CONFIG_FILE="$AQM_DATA_DIR/config.yml"
+    if [ ! -f "$CONFIG_FILE" ] && [ "$AQM_MODE" = "git" ] && [ -f "$AQM_ROOT/config.yml" ]; then
+      CONFIG_FILE="$AQM_ROOT/config.yml"
+    fi
+    if [ -f "$CONFIG_FILE" ]; then
+      PORT=$(grep -E "^\s*port\s*:" "$CONFIG_FILE" 2>/dev/null | sed -E 's/^\s*port\s*:\s*([0-9]+).*/\1/' | head -n1)
       if [ -z "$PORT" ] || [ "$PORT" -eq 0 ] 2>/dev/null; then
         PORT=3000
       fi
@@ -286,5 +342,4 @@ case "${1:-}" in
 esac
 
 # Forward other commands to CLI
-cd "$AQM_HOME"
-exec npx --prefix "$AQM_HOME" tsx "$AQM_HOME/src/cli.ts" "$@"
+exec_cli "$@"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -60,7 +60,7 @@ fi
 # 4. aqm version — exit 0 + 버전 문자열
 # --------------------------------------------------------------------------
 echo "[smoke] Testing: aqm version..."
-VERSION_OUTPUT=$(AQM_HOME="$AQM_INSTALL_DIR" "$AQM_BIN" version 2>&1) || VERSION_EXIT=$?
+VERSION_OUTPUT=$("$AQM_BIN" version 2>&1) || VERSION_EXIT=$?
 VERSION_EXIT=${VERSION_EXIT:-0}
 
 if [ "$VERSION_EXIT" -ne 0 ]; then
@@ -82,7 +82,7 @@ echo "PASS: aqm version → $VERSION_OUTPUT"
 # --------------------------------------------------------------------------
 echo "[smoke] Testing: aqm doctor..."
 DOCTOR_EXIT=0
-DOCTOR_OUTPUT=$(AQM_HOME="$AQM_INSTALL_DIR" "$AQM_BIN" doctor 2>&1) || DOCTOR_EXIT=$?
+DOCTOR_OUTPUT=$("$AQM_BIN" doctor 2>&1) || DOCTOR_EXIT=$?
 
 if [ "$DOCTOR_EXIT" -ne 0 ]; then
   echo "FAIL: aqm doctor exited $DOCTOR_EXIT"
@@ -165,6 +165,27 @@ if [ "$REGRESSION_HEALTH" -eq 1 ]; then
 fi
 
 echo "PASS: regression gate — aqm start fails without dist/"
+
+# --------------------------------------------------------------------------
+# 6. git-clone 모드 테스트 — AQM_HOME을 프로젝트 루트로 설정
+# --------------------------------------------------------------------------
+echo "[smoke] Testing: git-clone mode (AQM_HOME=$PROJECT_ROOT)..."
+GIT_VERSION_OUTPUT=$(AQM_HOME="$PROJECT_ROOT" "$AQM_BIN" version 2>&1) || GIT_VERSION_EXIT=$?
+GIT_VERSION_EXIT=${GIT_VERSION_EXIT:-0}
+
+if [ "$GIT_VERSION_EXIT" -ne 0 ]; then
+  echo "FAIL: aqm version (git-clone mode) exited $GIT_VERSION_EXIT"
+  echo "$GIT_VERSION_OUTPUT"
+  exit 1
+fi
+
+if ! echo "$GIT_VERSION_OUTPUT" | grep -qE "v[0-9]+\.[0-9]+\.[0-9]+"; then
+  echo "FAIL: aqm version (git-clone mode) output missing version string"
+  echo "$GIT_VERSION_OUTPUT"
+  exit 1
+fi
+
+echo "PASS: aqm version (git-clone mode) → $GIT_VERSION_OUTPUT"
 
 # --------------------------------------------------------------------------
 echo "[smoke] Smoke test passed."


### PR DESCRIPTION
## Summary

Resolves #670 — [P1-critical] fix: bin/aqm 래퍼를 npm 설치 시나리오와 호환되도록 재작성

현재 `bin/aqm`은 `$AQM_HOME` 환경변수가 설정된 git-clone 설치만 지원한다. `npm install -g` 시 `src/` 디렉토리는 패키지에 포함되지 않는데(package.json files에 미포함), 래퍼가 `npx tsx $AQM_HOME/src/cli.ts`를 실행하므로 npm 글로벌 설치 사용자에게 `aqm start` 등 모든 명령이 즉시 실패한다. `dist/cli.js`는 이미 패키지에 포함되어 있으므로, npm 모드에서는 `node dist/cli.js`를 실행하도록 래퍼를 재작성해야 한다.

## Requirements

- bin/aqm이 두 설치 모드를 자동 감지: (a) npm 글로벌 — $(dirname $0)/../lib/node_modules/ai-quartermaster/dist/cli.js를 node로 실행, (b) git-clone($AQM_HOME 존재) — 기존 tsx 경로 유지
- package.json의 files 필드에 dist/ 포함 확인 (현재 이미 포함됨 — 변경 불필요)
- aqm version / aqm start / aqm doctor 양쪽 모드에서 동작
- smoke-test.sh를 npm 글로벌 설치 모드 자동 감지에 맞게 업데이트 (AQM_HOME 강제 설정 제거)
- 기존 git-clone 사용자의 동작이 깨지지 않아야 함

## Implementation Phases

- Phase 0: bin/aqm 래퍼 재작성 — SUCCESS (2ee181d9)
- Phase 1: smoke-test.sh 업데이트 — SUCCESS (460c8ab2)
- Phase 2: 검증 — npm pack + 글로벌 설치 E2E — SUCCESS (460c8ab2)

## Risks

- bin/aqm은 AQM 자체의 진입점 — 잘못 수정 시 git-clone 기존 사용자도 실행 불가
- npm 글로벌 설치 시 심볼릭 링크 구조가 OS/npm 버전마다 다를 수 있음 (SCRIPT_DIR 해석 주의)
- version 커맨드의 git rev-parse가 npm 모드에서 실패 — 적절한 폴백 필요
- update 커맨드는 git-clone 전용 — npm 모드에서 혼란 방지 메시지 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.3982 (review: $0.1401)
- **Phases**: 3/3 completed
- **Branch**: `aq/670-p1-critical-fix-bin-aqm-npm` → `develop`
- **Tokens**: 49 input, 11746 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| bin/aqm 래퍼 재작성 | $0.2865 | 0 | $0.0000 |
| smoke-test.sh 업데이트 | $0.2874 | 0 | $0.0000 |
| 검증 — npm pack + 글로벌 설치 E2E | $0.2335 | 1 | $0.2335 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.8074 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #670