### PR TITLE
[AQ-#671] [P1-critical] fix: release smoke gate가 실제 aqm start를 검증하도록 확장

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,8 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_PREFIX=$(mktemp -d)
 TARBALL_PATH=""
+SMOKE_PORT=$(( 49152 + RANDOM % 11848 ))
+SMOKE_PID=""
 
 cleanup() {
+  if [ -n "${SMOKE_PID:-}" ] && kill -0 "$SMOKE_PID" 2>/dev/null; then
+    kill "$SMOKE_PID" 2>/dev/null || true
+    wait "$SMOKE_PID" 2>/dev/null || true
+  fi
+  fuser -k "${SMOKE_PORT}/tcp" 2>/dev/null || true
   if [ -n "$TARBALL_PATH" ] && [ -f "$TARBALL_PATH" ]; then
     rm -f "$TARBALL_PATH"
   fi
@@ -71,25 +78,93 @@ fi
 echo "PASS: aqm version → $VERSION_OUTPUT"
 
 # --------------------------------------------------------------------------
-# 5. aqm doctor — 프로세스 crash 불합격, FAIL은 허용
+# 5. aqm doctor — exit 0 필수 (FAIL은 더 이상 허용하지 않음)
 # --------------------------------------------------------------------------
 echo "[smoke] Testing: aqm doctor..."
 DOCTOR_EXIT=0
 DOCTOR_OUTPUT=$(AQM_HOME="$AQM_INSTALL_DIR" "$AQM_BIN" doctor 2>&1) || DOCTOR_EXIT=$?
 
-# 128+ = signal-based crash (SIGSEGV=139, SIGABRT=134 등)
-if [ "$DOCTOR_EXIT" -ge 128 ]; then
-  echo "FAIL: aqm doctor crashed with signal (exit $DOCTOR_EXIT)"
+if [ "$DOCTOR_EXIT" -ne 0 ]; then
+  echo "FAIL: aqm doctor exited $DOCTOR_EXIT"
   echo "$DOCTOR_OUTPUT"
   exit 1
 fi
 
-if echo "$DOCTOR_OUTPUT" | grep -q "Doctor 완료"; then
-  echo "PASS: aqm doctor → Doctor 완료"
-else
-  # gh/claude CLI 미설치 등 FAIL은 허용
-  echo "INFO: aqm doctor completed (exit $DOCTOR_EXIT) — tool failures tolerated in CI"
+echo "PASS: aqm doctor → exit 0"
+
+# --------------------------------------------------------------------------
+# 6. aqm start + /health 200 확인
+# --------------------------------------------------------------------------
+echo "[smoke] Testing: aqm start (port $SMOKE_PORT)..."
+
+SMOKE_HOME="$TMP_PREFIX/aqm-home"
+SMOKE_REPO="$TMP_PREFIX/smoke-repo"
+mkdir -p "$SMOKE_HOME" "$SMOKE_REPO"
+
+cat > "$SMOKE_HOME/config.yml" << EOF
+general:
+  serverMode: "polling"
+  logLevel: "warn"
+projects:
+  - repo: "smoke/repo"
+    path: "$SMOKE_REPO"
+    baseBranch: "main"
+EOF
+
+"$AQM_BIN" start --config "$SMOKE_HOME/config.yml" --port "$SMOKE_PORT" --mode polling &
+SMOKE_PID=$!
+
+HEALTH_PASS=0
+for i in $(seq 1 15); do
+  HEALTH_RESPONSE=$(curl -sf "http://127.0.0.1:$SMOKE_PORT/health" 2>/dev/null) || true
+  if echo "$HEALTH_RESPONSE" | grep -q '"status":"ok"'; then
+    HEALTH_PASS=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "$HEALTH_PASS" -ne 1 ]; then
+  echo "FAIL: aqm start /health did not respond within 15s"
+  exit 1
 fi
+
+echo "PASS: aqm start → /health returned {\"status\":\"ok\"}"
+
+# --------------------------------------------------------------------------
+# 7. 회귀 감지 — dist/ 제거 후 기동 실패 확인
+# --------------------------------------------------------------------------
+echo "[smoke] Testing: regression gate (dist/ 제거 후 기동 실패)..."
+
+kill "$SMOKE_PID" 2>/dev/null || true
+wait "$SMOKE_PID" 2>/dev/null || true
+SMOKE_PID=""
+
+rm -rf "$AQM_INSTALL_DIR/dist"
+
+REGRESSION_PORT=$(( SMOKE_PORT + 1 ))
+"$AQM_BIN" start --config "$SMOKE_HOME/config.yml" --port "$REGRESSION_PORT" --mode polling &
+SMOKE_PID=$!
+
+REGRESSION_HEALTH=0
+for i in $(seq 1 10); do
+  if curl -sf "http://127.0.0.1:$REGRESSION_PORT/health" 2>/dev/null | grep -q '"status":"ok"'; then
+    REGRESSION_HEALTH=1
+    break
+  fi
+  sleep 1
+done
+
+kill "$SMOKE_PID" 2>/dev/null || true
+wait "$SMOKE_PID" 2>/dev/null || true
+SMOKE_PID=""
+
+if [ "$REGRESSION_HEALTH" -eq 1 ]; then
+  echo "FAIL: regression gate broken — aqm start succeeded without dist/"
+  exit 1
+fi
+
+echo "PASS: regression gate — aqm start fails without dist/"
 
 # --------------------------------------------------------------------------
 echo "[smoke] Smoke test passed."


### PR DESCRIPTION
## Summary

Resolves #671 — [P1-critical] fix: release smoke gate가 실제 aqm start를 검증하도록 확장

현 smoke gate는 `aqm version`(package.json만 읽음) + `aqm doctor`(실패 tolerate)만 검증해서 bin/aqm 회귀를 전혀 잡지 못함. `aqm start`로 서버가 실제 기동되고 `/health` 200을 반환하는지까지 검증해야 진짜 릴리스 안전망이 된다.

## Requirements

- scripts/smoke-test.sh에 `aqm start --port <random> &` + curl `/health` 200 응답 확인 시나리오 추가
- aqm doctor 실패 tolerate 제거 — 반드시 exit 0 강제
- 회귀 감지 테스트: dist/ 제거한 pack으로 smoke gate 실패 확인
- scripts/smoke-test.sh 시작/종료 시 포트 정리 보장
- CI release-smoke 잡 타임아웃 필요 시 상향

## Implementation Phases

- Phase 0: smoke-test.sh 전체 재구성 — SUCCESS (012faa72)
- Phase 1: CI workflow 타임아웃 상향 — SUCCESS (0008ff3a)

## Risks

- aqm start가 CI 환경에서 config.yml 없이 기동 불가 — 임시 config + dummy git repo로 우회 필요
- CI에서 포트 충돌 가능성 — 랜덤 포트(49152-60999)로 완화
- health poll 타임아웃이 CI 환경 속도에 따라 부족할 수 있음 — 15초는 충분히 여유 있음
- 회귀 테스트에서 dist/ 삭제 후 node가 캐시된 모듈을 사용할 가능성 — 새 프로세스 실행이므로 문제 없음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.6484 (review: $0.1083)
- **Phases**: 2/2 completed
- **Branch**: `aq/671-p1-critical-fix-release-smoke-gate-aqm-start` → `develop`
- **Tokens**: 44 input, 7108 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| smoke-test.sh 전체 재구성 | $0.7325 | 0 | $0.0000 |
| CI workflow 타임아웃 상향 | $0.1798 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.9123 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #671