### PR TITLE
[AQ-#677] [P2-high] fix: better-sqlite3 native build preflight + 실패 진단

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,30 @@ GitHub Issue에 라벨을 붙이면 Claude가 자동으로 구현하고 Draft PR
 curl -fsSL https://raw.githubusercontent.com/happytalkrz/AI-Quartermaster/main/install.sh | bash
 ```
 
+**지원 플랫폼:**
+
+| 플랫폼 | 지원 여부 | 비고 |
+|--------|----------|------|
+| Linux (glibc, Ubuntu/Debian/RHEL 계열) | ✅ | 권장 환경 |
+| macOS arm64 (Apple Silicon) | ✅ | Node.js 20+ 필수 |
+| macOS x86_64 | ✅ | |
+| WSL2 (Windows Subsystem for Linux) | ✅ | glibc 기반 배포판 사용 |
+| Windows 네이티브 | ❌ | 미지원 |
+| Alpine Linux / musl libc | ❌ | better-sqlite3 prebuilt binary 미지원 |
+
+> **Alpine/musl 환경 주의**: better-sqlite3는 musl libc 환경에서 prebuilt binary를 제공하지 않으며, 소스 빌드 시에도 호환성 문제가 발생할 수 있습니다.
+
 **필수 요구사항:**
-- macOS / Linux / WSL (Windows 네이티브 미지원)
 - Node.js 20+
 - Git
 - [GitHub CLI](https://cli.github.com) (`gh auth login` 완료)
 - [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (Claude Max 요금제 권장)
+- **Native build 도구** (시스템에 없으면 `install.sh`가 설치를 안내합니다):
+  - `python3`
+  - `make`
+  - `g++` (또는 `build-essential` 패키지)
+
+> better-sqlite3는 prebuilt binary가 현재 Node.js 버전과 맞지 않을 경우 소스 빌드(node-gyp)를 시도합니다. 위 도구가 없으면 설치가 실패할 수 있습니다.
 
 **Public / Private 레포 모두 지원** — `gh auth login` 인증 토큰에 repo 접근 권한이 있으면 Private 레포에서도 동작합니다.
 

--- a/install.sh
+++ b/install.sh
@@ -35,12 +35,51 @@ check_cmd "npm" "Node.js 설치 시 함께 설치됩니다"
 check_cmd "gh" "https://cli.github.com 에서 설치 후 gh auth login 하세요"
 check_cmd "claude" "https://docs.anthropic.com/en/docs/claude-code 에서 설치하세요"
 
+# Native build tools preflight (warning only — prebuilt binary로 충분할 수 있음)
+echo ""
+echo -e "${YELLOW}  [native build tools 확인]${NC}"
+NATIVE_WARN=0
+for tool in python3 make g++; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo -e "  ${YELLOW}⚠ $tool 없음 — prebuilt binary 없을 경우 better-sqlite3 소스 빌드 실패 가능${NC}"
+    NATIVE_WARN=1
+  else
+    echo -e "  ${GREEN}✓ $tool${NC}"
+  fi
+done
+if [ "$NATIVE_WARN" -eq 1 ]; then
+  echo -e "  ${YELLOW}→ 소스 빌드가 필요한 환경(Alpine Linux, 구버전 macOS arm64 등)에서는"
+  echo -e "    python3, make, g++ 설치 후 다시 시도하세요${NC}"
+fi
+
 # Print claude version
 CLAUDE_VERSION=$(claude --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 if [ -n "$CLAUDE_VERSION" ]; then
   echo -e "  ${GREEN}  claude 버전: v${CLAUDE_VERSION}${NC}"
 fi
 echo ""
+
+# better-sqlite3 로드 검증 함수
+verify_better_sqlite3() {
+  echo -e "${YELLOW}  [better-sqlite3 로드 검증]${NC}"
+  if node -e "require('better-sqlite3')" 2>/dev/null; then
+    echo -e "  ${GREEN}✓ better-sqlite3 정상 로드${NC}"
+  else
+    echo -e "  ${RED}✗ better-sqlite3 로드 실패${NC}"
+    echo ""
+    echo -e "  ${YELLOW}── 진단 정보 ──${NC}"
+    echo -e "  Node.js 버전: $(node -v 2>&1)"
+    echo -e "  시스템: $(uname -a 2>&1)"
+    echo -e "  패키지 상태:"
+    npm ls better-sqlite3 2>&1 | sed 's/^/    /'
+    echo ""
+    echo -e "  ${YELLOW}해결 방법:${NC}"
+    echo -e "  1. python3, make, g++ 설치 후 npm rebuild better-sqlite3 실행"
+    echo -e "  2. 문제가 지속되면 위 진단 정보와 함께 이슈를 제보하세요:"
+    echo -e "     https://github.com/happytalkrz/AI-Quartermaster/issues"
+    exit 1
+  fi
+}
 
 # 2. Install or update
 if [ -d "$AQM_HOME" ]; then
@@ -49,12 +88,14 @@ if [ -d "$AQM_HOME" ]; then
   git pull --quiet
   npm install --silent 2>/dev/null
   echo -e "  ${GREEN}✓ 업데이트 완료${NC}"
+  verify_better_sqlite3
 else
   echo -e "${YELLOW}2. AI Quartermaster 설치...${NC}"
   git clone --depth 1 "$REPO_URL" "$AQM_HOME" --quiet
   cd "$AQM_HOME"
   npm install --silent 2>/dev/null
   echo -e "  ${GREEN}✓ 설치 완료: $AQM_HOME${NC}"
+  verify_better_sqlite3
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

Resolves #677 — [P2-high] fix: better-sqlite3 native build preflight + 실패 진단

better-sqlite3는 prebuilt native binary를 사용하며, Node minor 버전 차이나 Linux musl(Alpine), macOS arm64 구버전 등에서 prebuilt binary 매칭 실패 시 node-gyp fallback으로 소스 빌드를 시도한다. 이때 시스템에 python3/make/g++가 없으면 npm install 전체가 실패하며, 사용자는 원인을 파악하기 어렵다. install.sh에 native build 도구 preflight 검사와 설치 후 better-sqlite3 로드 검증을 추가하고, README에 지원 플랫폼을 명시하여 설치 실패를 예방하고 진단을 돕는다.

## Requirements

- install.sh 초반에 python3, make, g++ 존재 확인 → 없으면 경고 + 설치 가이드 링크
- 설치 완료 후 node -e "require('better-sqlite3')" 검증 스텝 추가 → 실패 시 원인 안내(플랫폼/node 버전)
- README에 지원 플랫폼 목록 명시: Linux glibc / macOS arm64 (Node 20+), WSL2, Windows 미지원
- 설치 실패 시 사용자가 이슈 제보할 수 있도록 진단 명령(node -v, uname -a) 안내

## Implementation Phases

- Phase 0: install.sh preflight + 검증 — SUCCESS (f845aacc)
- Phase 1: README 플랫폼 요구사항 섹션 — SUCCESS (f845aacc)

## Risks

- preflight를 hard fail로 만들면 prebuilt binary로 충분한 환경에서도 설치가 차단됨 → warning으로 처리
- better-sqlite3 검증 실패 시 install.sh 전체를 exit 1로 중단할지 경고만 할지 판단 필요 — DB 없이는 동작 불가하므로 exit 1이 적절

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.0833 (review: $0.1495)
- **Phases**: 2/2 completed
- **Branch**: `aq/677-p2-high-fix-better-sqlite3-native-build-preflight` → `develop`
- **Tokens**: 55 input, 8450 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| install.sh preflight + 검증 | $0.3265 | 0 | $0.0000 |
| README 플랫폼 요구사항 섹션 | $0.2222 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.5487 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #677