### PR TITLE
[AQ-#675] [P2-high] security: DASHBOARD_ALLOW_INSECURE=true 시 readOnly 강제

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ DASHBOARD_API_KEY=your-secret-key-here
    aqm start --host 0.0.0.0
    ```
    > `DASHBOARD_ALLOW_INSECURE=true`는 테스트/내부망 환경 전용입니다. 인터넷에 노출된 서버에서는 절대 사용하지 마세요.
+   > 이 모드에서는 dashboard가 read-only로 강제되어 config 수정, 잡 취소 등 쓰기 작업이 차단됩니다.
 
 ## 이슈 의존성
 
@@ -398,7 +399,7 @@ Dashboard API는 기본적으로 `127.0.0.1`에만 바인딩되어 외부 접근
 |------|--------|------|
 | `--host` | `127.0.0.1` | 바인드 주소. localhost 이외 설정 시 API 키 강제 |
 | `DASHBOARD_API_KEY` | (없음) | Bearer 토큰 인증. non-local bind 시 필수 |
-| `DASHBOARD_ALLOW_INSECURE` | `false` | `true`로 설정 시 API 키 없이 non-local bind 허용 (비권장) |
+| `DASHBOARD_ALLOW_INSECURE` | `false` | `true`로 설정 시 API 키 없이 non-local bind 허용하되 dashboard는 read-only로 강제됨 (비권장) |
 
 - non-local bind(`0.0.0.0`, 특정 IP 등)에서 `DASHBOARD_API_KEY`가 없으면 서버가 시작되지 않습니다
 - `DASHBOARD_ALLOW_INSECURE=true`는 폐쇄망/테스트 환경 전용이며 인터넷 노출 환경에서는 절대 사용하지 마세요

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -406,13 +406,16 @@ export async function startCommand(args: CliArgs): Promise<void> {
     console.error("       export DASHBOARD_ALLOW_INSECURE=true\n");
     process.exit(1);
   }
-  const wslReadOnly = !isLocalBind && !apiKey && isWSL;
-  if (wslReadOnly) {
+  const wslReadOnly = !isLocalBind && !apiKey && (isWSL || insecureAllowed);
+  if (!isLocalBind && !apiKey && isWSL) {
     logger.warn(
       `WSL 환경 감지: 대시보드를 ${host}:${port}에 read-only 모드로 바인딩합니다. ` +
       `쓰기 작업(config 수정, 잡 취소 등)은 차단됩니다. ` +
       `full access가 필요하면 DASHBOARD_API_KEY를 설정하세요.`
     );
+  }
+  if (!isLocalBind && !apiKey && insecureAllowed) {
+    console.error('⚠ insecure 모드 허용 — dashboard가 read-only로 강제됩니다');
   }
 
   const patternStore = new PatternStore(dataDir);

--- a/tests/cli/bind-security-integration.test.ts
+++ b/tests/cli/bind-security-integration.test.ts
@@ -228,4 +228,35 @@ describe("bind security CLI integration", () => {
     },
     30000
   );
+
+  it(
+    "DASHBOARD_ALLOW_INSECURE=true + 0.0.0.0 + API key 없음 → 서버 listening + read-only 경고 출력",
+    async () => {
+      const { dir, cleanup } = createTestAqRoot();
+      try {
+        const result = await spawnCliUntilPattern(
+          [
+            "start",
+            "--host", "0.0.0.0",
+            "--port", "39203",
+            "--mode", "polling",
+            "--config", join(dir, "config.yml"),
+          ],
+          makeEnv({
+            DASHBOARD_API_KEY: undefined,
+            DASHBOARD_ALLOW_INSECURE: "true",
+            WSL_DISTRO_NAME: undefined,
+            WSL_INTEROP: undefined,
+          }),
+          "listening",
+          20000
+        );
+        expect(result.found).toBe(true);
+        expect(result.stderr).toContain("insecure 모드");
+      } finally {
+        cleanup();
+      }
+    },
+    30000
+  );
 });


### PR DESCRIPTION
## Summary

Resolves #675 — [P2-high] security: DASHBOARD_ALLOW_INSECURE=true 시 readOnly 강제

현재 `src/cli.ts` L397-408의 보안 검사에서 `DASHBOARD_ALLOW_INSECURE=true`이면 non-local bind 차단을 완전히 우회한다. WSL 환경은 `wslReadOnly` 플래그로 write 엔드포인트를 차단하지만, insecure escape hatch 경로는 readOnlyGuard를 적용하지 않아 외부 바인드 + 무인증 + 모든 mutation 허용 상태가 된다. L409의 `wslReadOnly` 조건(`!isLocalBind && !apiKey && isWSL`)에 insecure 케이스가 누락된 것이 근본 원인이다.

## Requirements

- insecureAllowed && !isLocalBind && !apiKey인 경우 readOnly 모드를 강제 적용
- 전환 시 stderr에 경고 메시지 출력: insecure 모드 허용 — dashboard가 read-only로 강제됨
- 기존 rate-limit / session / bind-security 테스트에 회귀 없음
- README의 DASHBOARD_ALLOW_INSECURE 설명에 read-only 강제 동작 명시

## Implementation Phases

- Phase 0: cli.ts readOnly 강제 로직 추가 — SUCCESS (35ad1cea)
- Phase 1: 테스트 추가 및 회귀 확인 — SUCCESS (578abc66)
- Phase 2: README 문서 업데이트 — SUCCESS (578abc66)

## Risks

- wslReadOnly 변수명 변경 시 dashboard-api.ts의 readOnly 파라미터와의 호환성 — 이미 readOnly로 받고 있으므로 영향 없음
- insecureAllowed=true + isWSL=true 중복 케이스 — OR 조건이므로 둘 다 true여도 동일하게 readOnly 적용

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.3227 (review: $0.1007)
- **Phases**: 3/3 completed
- **Branch**: `aq/675-p2-high-security-dashboard-allow-insecure-true-rea` → `develop`
- **Tokens**: 39 input, 7071 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| cli.ts readOnly 강제 로직 추가 | $0.2504 | 0 | $0.0000 |
| 테스트 추가 및 회귀 확인 | $0.2465 | 1 | $0.2465 |
| README 문서 업데이트 | $0.2914 | 1 | $0.2914 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.7882 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #675