### PR TITLE
[AQ-#673] [P2-high] fix: Job 코스트 리포트 항목 일관성 — Total 분해 공개

### DIFF
--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -28,18 +28,31 @@ export interface PrContext {
 }
 
 export function buildPhaseCostTable(breakdown?: CostBreakdown): string {
-  if (!breakdown?.phaseCosts.length) return '';
-  const rows = breakdown.phaseCosts.map(p =>
-    `| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |`
-  ).join('\n');
-  return `\n### Phase Cost Breakdown\n\n| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|\n${rows}\n`;
+  if (!breakdown) return '';
+  const rows: string[] = [];
+  for (const p of breakdown.phaseCosts) {
+    rows.push(`| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |`);
+  }
+  if (breakdown.setupCostUsd && breakdown.setupCostUsd > 0) {
+    rows.push(`| setup | $${breakdown.setupCostUsd.toFixed(4)} | - | - |`);
+  }
+  if (breakdown.publishCostUsd && breakdown.publishCostUsd > 0) {
+    rows.push(`| publish | $${breakdown.publishCostUsd.toFixed(4)} | - | - |`);
+  }
+  if (breakdown.overheadCostUsd && breakdown.overheadCostUsd > 0) {
+    rows.push(`| overhead | $${breakdown.overheadCostUsd.toFixed(4)} | - | - |`);
+  }
+  if (!rows.length) return '';
+  return `\n### Phase Cost Breakdown\n\n| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|\n${rows.join('\n')}\n`;
 }
 
 export function buildModelSummary(breakdown?: CostBreakdown): string {
   if (!breakdown?.modelSummary.length) return '';
-  const rows = breakdown.modelSummary.map(m =>
-    `| ${m.model} | $${m.costUsd.toFixed(4)} |`
-  ).join('\n');
+  const rows = breakdown.modelSummary
+    .filter(m => m.costUsd > 0)
+    .map(m => `| ${m.model} | $${m.costUsd.toFixed(4)} |`)
+    .join('\n');
+  if (!rows) return '';
   return `\n### Model Usage\n\n| Model | Cost |\n|-------|------|\n${rows}\n`;
 }
 

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -44,8 +44,8 @@ export function buildCostBreakdown(
   phaseResults: PhaseResult[],
   reviewCostUsd: number = 0,
 ): CostBreakdown {
-  // pseudo-phase(phaseIndex < 0)는 비용 집계에서 제외한다.
-  // 이미 planCostUsd 등 별도 항목으로 추적되므로 이중 계산 방지.
+  // pseudo-phase(phaseIndex < 0)는 phaseCosts에서 제외한다.
+  // plan 비용은 planCostUsd 파라미터로, setup/publish 비용은 별도 항목으로 집계한다.
   const phaseCosts = phaseResults.filter(r => r.phaseIndex >= 0).map(r => ({
     phaseIndex: r.phaseIndex,
     phaseName: r.phaseName,
@@ -54,6 +54,16 @@ export function buildCostBreakdown(
     retryCount: r.retryCount ?? 0,
     modelCosts: r.modelCosts ?? [],
   }));
+
+  // setup pseudo-phase 비용 집계 (setup:worktree, setup:dependency)
+  const setupCostUsd = phaseResults
+    .filter(r => r.phaseName === "setup:worktree" || r.phaseName === "setup:dependency")
+    .reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
+
+  // publish pseudo-phase 비용 집계 (publish:pr)
+  const publishCostUsd = phaseResults
+    .filter(r => r.phaseName === "publish:pr")
+    .reduce((sum, r) => sum + (r.costUsd ?? 0), 0);
 
   // model별 비용 집계
   const modelMap = new Map<string, ModelCostEntry>();
@@ -83,7 +93,9 @@ export function buildCostBreakdown(
 
   const modelSummary = Array.from(modelMap.values());
   const phasesTotalCost = phaseCosts.reduce((sum, p) => sum + p.costUsd + p.retryCostUsd, 0);
-  const totalCostUsd = (planCostUsd ?? 0) + phasesTotalCost + reviewCostUsd;
+  const totalCostUsd = (planCostUsd ?? 0) + phasesTotalCost + reviewCostUsd + setupCostUsd + publishCostUsd;
+  // overhead: 위 항목으로 모두 설명되므로 0 (사후 mutate 시 pipeline-phases에서 재산출)
+  const overheadCostUsd = 0;
 
   return {
     planCostUsd: planCostUsd ?? 0,
@@ -91,6 +103,9 @@ export function buildCostBreakdown(
     reviewCostUsd,
     totalCostUsd,
     modelSummary,
+    setupCostUsd: setupCostUsd > 0 ? setupCostUsd : undefined,
+    publishCostUsd: publishCostUsd > 0 ? publishCostUsd : undefined,
+    overheadCostUsd: overheadCostUsd > 0 ? overheadCostUsd : undefined,
   };
 }
 

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -629,11 +629,16 @@ export async function executePostProcessingPhases(
   }
 
   // Update costBreakdown with review costs collected during post-processing
-  const updatedTotalCostUsd = (coreResult.totalCostUsd ?? 0) + reviewCostUsd;
+  // totalCostUsd를 breakdown 구성요소(retryCostUsd + setup + publish 포함)에서 재산출하여 정합성 보장
   if (coreResult.costBreakdown) {
-    coreResult.costBreakdown.reviewCostUsd = reviewCostUsd;
-    coreResult.costBreakdown.totalCostUsd = updatedTotalCostUsd;
+    const cb = coreResult.costBreakdown;
+    cb.reviewCostUsd = reviewCostUsd;
+    const phasesTotal = cb.phaseCosts.reduce((sum, p) => sum + p.costUsd + p.retryCostUsd, 0);
+    cb.totalCostUsd = cb.planCostUsd + phasesTotal + reviewCostUsd
+      + (cb.setupCostUsd ?? 0) + (cb.publishCostUsd ?? 0);
+    cb.overheadCostUsd = undefined;
   }
+  const updatedTotalCostUsd = coreResult.costBreakdown?.totalCostUsd ?? (coreResult.totalCostUsd ?? 0) + reviewCostUsd;
 
   const publishContext = {
     issueNumber,

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -1,4 +1,4 @@
-import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport } from "../../types/pipeline.js";
+import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown } from "../../types/pipeline.js";
 import { getLogger } from "../../utils/logger.js";
 
 export type { DiagnosisReport };
@@ -31,6 +31,8 @@ export interface PipelineReport {
   diagnosis?: DiagnosisReport;
   /** baseline 캡처 실패로 인해 검증이 불완전한 경우 경고 목록 */
   verificationIncomplete?: string[];
+  /** phase/model별 비용 세분화 (Total 분해 출력용) */
+  costBreakdown?: CostBreakdown;
 }
 
 /**
@@ -102,6 +104,18 @@ export function printResult(report: PipelineReport): void {
 
   if (report.prUrl) {
     console.log(`\nPR: ${report.prUrl}`);
+  }
+
+  if (report.costBreakdown) {
+    const bd = report.costBreakdown;
+    const phaseTotal = bd.phaseCosts.reduce((sum, p) => sum + p.costUsd + p.retryCostUsd, 0);
+    console.log(`\nCost: $${bd.totalCostUsd.toFixed(4)}`);
+    if (bd.planCostUsd > 0) console.log(`  plan     $${bd.planCostUsd.toFixed(4)}`);
+    if (phaseTotal > 0) console.log(`  phases   $${phaseTotal.toFixed(4)}`);
+    if (bd.reviewCostUsd > 0) console.log(`  review   $${bd.reviewCostUsd.toFixed(4)}`);
+    if (bd.setupCostUsd && bd.setupCostUsd > 0) console.log(`  setup    $${bd.setupCostUsd.toFixed(4)}`);
+    if (bd.publishCostUsd && bd.publishCostUsd > 0) console.log(`  publish  $${bd.publishCostUsd.toFixed(4)}`);
+    if (bd.overheadCostUsd && bd.overheadCostUsd > 0) console.log(`  overhead $${bd.overheadCostUsd.toFixed(4)}`);
   }
 
   if (report.verificationIncomplete && report.verificationIncomplete.length > 0) {

--- a/src/server/public/js/render-jobs.js
+++ b/src/server/public/js/render-jobs.js
@@ -357,6 +357,16 @@ function renderCostBreakdown(job) {
       html += '</tr>';
     });
 
+    // Setup row
+    if (cb.setupCostUsd > 0) {
+      html += '<tr class="border-b border-outline-variant/5">';
+      html += '<td class="p-3 text-on-surface/70 font-mono">Setup</td>';
+      html += '<td class="p-3 text-right font-mono text-tertiary">' + fmtCost(cb.setupCostUsd) + '</td>';
+      html += '<td class="p-3 text-right text-outline">—</td>';
+      html += '<td class="p-3 text-right text-outline">—</td>';
+      html += '</tr>';
+    }
+
     // Review row
     if (cb.reviewCostUsd > 0) {
       html += '<tr class="border-b border-outline-variant/5">';
@@ -367,10 +377,38 @@ function renderCostBreakdown(job) {
       html += '</tr>';
     }
 
-    // Total row
+    // Publish row
+    if (cb.publishCostUsd > 0) {
+      html += '<tr class="border-b border-outline-variant/5">';
+      html += '<td class="p-3 text-on-surface/70 font-mono">Publish</td>';
+      html += '<td class="p-3 text-right font-mono text-tertiary">' + fmtCost(cb.publishCostUsd) + '</td>';
+      html += '<td class="p-3 text-right text-outline">—</td>';
+      html += '<td class="p-3 text-right text-outline">—</td>';
+      html += '</tr>';
+    }
+
+    // Total row with decomposition and mismatch check
+    var executorCost = cb.phaseCosts.reduce(function(sum, p) { return sum + p.costUsd; }, 0);
+    var sumOfParts = (cb.planCostUsd || 0) + executorCost + (cb.reviewCostUsd || 0) + (cb.setupCostUsd || 0) + (cb.publishCostUsd || 0) + (cb.overheadCostUsd || 0);
+    var hasMismatch = Math.abs((cb.totalCostUsd || 0) - sumOfParts) >= 0.0001;
+
+    var decomposeParts = [];
+    if (executorCost > 0) decomposeParts.push('executor ' + fmtCost(executorCost));
+    if (cb.planCostUsd > 0) decomposeParts.push('plan ' + fmtCost(cb.planCostUsd));
+    if (cb.reviewCostUsd > 0) decomposeParts.push('review ' + fmtCost(cb.reviewCostUsd));
+    if (cb.setupCostUsd > 0) decomposeParts.push('setup ' + fmtCost(cb.setupCostUsd));
+    if (cb.publishCostUsd > 0) decomposeParts.push('publish ' + fmtCost(cb.publishCostUsd));
+    if (cb.overheadCostUsd > 0) decomposeParts.push('overhead ' + fmtCost(cb.overheadCostUsd));
+    var decomposeHtml = decomposeParts.length > 1
+      ? '<span class="text-[10px] text-outline font-normal font-mono ml-2 opacity-70">= ' + decomposeParts.join(' + ') + '</span>'
+      : '';
+    var mismatchBadge = hasMismatch
+      ? '<span class="ml-2 text-[10px] bg-[#d29922]/10 text-[#d29922] border border-[#d29922]/30 px-1.5 py-0.5 rounded font-bold">⚠️ Mismatch</span>'
+      : '';
+
     html += '<tr class="bg-surface-container">';
     html += '<td class="p-3 font-bold text-on-surface">합계</td>';
-    html += '<td class="p-3 text-right font-bold font-mono text-primary" colspan="3">' + fmtCost(cb.totalCostUsd) + '</td>';
+    html += '<td class="p-3 text-right font-bold font-mono text-primary" colspan="3"><span class="inline-flex items-center flex-wrap gap-1 justify-end">' + fmtCost(cb.totalCostUsd) + decomposeHtml + mismatchBadge + '</span></td>';
     html += '</tr>';
 
     html += '</tbody></table></div>';
@@ -382,6 +420,7 @@ function renderCostBreakdown(job) {
     html += '<div class="space-y-2">';
     html += '<div class="text-[10px] text-outline font-bold uppercase tracking-wider">모델별 비용</div>';
     cb.modelSummary.forEach(function(entry) {
+      if (entry.costUsd === 0) return;
       var pct = total > 0 ? Math.round((entry.costUsd / total) * 100) : 0;
       html += '<div class="space-y-1">';
       html += '<div class="flex justify-between text-xs">';

--- a/src/server/public/js/render-jobs.js
+++ b/src/server/public/js/render-jobs.js
@@ -358,7 +358,7 @@ function renderCostBreakdown(job) {
     });
 
     // Setup row
-    if (cb.setupCostUsd > 0) {
+    if (cb.setupCostUsd && cb.setupCostUsd > 0) {
       html += '<tr class="border-b border-outline-variant/5">';
       html += '<td class="p-3 text-on-surface/70 font-mono">Setup</td>';
       html += '<td class="p-3 text-right font-mono text-tertiary">' + fmtCost(cb.setupCostUsd) + '</td>';
@@ -378,7 +378,7 @@ function renderCostBreakdown(job) {
     }
 
     // Publish row
-    if (cb.publishCostUsd > 0) {
+    if (cb.publishCostUsd && cb.publishCostUsd > 0) {
       html += '<tr class="border-b border-outline-variant/5">';
       html += '<td class="p-3 text-on-surface/70 font-mono">Publish</td>';
       html += '<td class="p-3 text-right font-mono text-tertiary">' + fmtCost(cb.publishCostUsd) + '</td>';
@@ -396,9 +396,9 @@ function renderCostBreakdown(job) {
     if (executorCost > 0) decomposeParts.push('executor ' + fmtCost(executorCost));
     if (cb.planCostUsd > 0) decomposeParts.push('plan ' + fmtCost(cb.planCostUsd));
     if (cb.reviewCostUsd > 0) decomposeParts.push('review ' + fmtCost(cb.reviewCostUsd));
-    if (cb.setupCostUsd > 0) decomposeParts.push('setup ' + fmtCost(cb.setupCostUsd));
-    if (cb.publishCostUsd > 0) decomposeParts.push('publish ' + fmtCost(cb.publishCostUsd));
-    if (cb.overheadCostUsd > 0) decomposeParts.push('overhead ' + fmtCost(cb.overheadCostUsd));
+    if (cb.setupCostUsd && cb.setupCostUsd > 0) decomposeParts.push('setup ' + fmtCost(cb.setupCostUsd));
+    if (cb.publishCostUsd && cb.publishCostUsd > 0) decomposeParts.push('publish ' + fmtCost(cb.publishCostUsd));
+    if (cb.overheadCostUsd && cb.overheadCostUsd > 0) decomposeParts.push('overhead ' + fmtCost(cb.overheadCostUsd));
     var decomposeHtml = decomposeParts.length > 1
       ? '<span class="text-[10px] text-outline font-normal font-mono ml-2 opacity-70">= ' + decomposeParts.join(' + ') + '</span>'
       : '';

--- a/src/server/public/js/types.js
+++ b/src/server/public/js/types.js
@@ -66,6 +66,9 @@
  * @property {number} reviewCostUsd
  * @property {number} totalCostUsd
  * @property {ModelCostEntry[]} modelSummary
+ * @property {number} [setupCostUsd]
+ * @property {number} [publishCostUsd]
+ * @property {number} [overheadCostUsd]
  */
 
 /**

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -43,6 +43,12 @@ export interface CostBreakdown {
   reviewCostUsd: number;
   totalCostUsd: number;
   modelSummary: ModelCostEntry[];
+  /** setup 단계(worktree, dependency) 비용 합계 */
+  setupCostUsd?: number;
+  /** publish 단계(PR 생성) 비용 */
+  publishCostUsd?: number;
+  /** 분류되지 않은 잔여 비용 (totalCostUsd - 모든 분류 항목 합계) */
+  overheadCostUsd?: number;
 }
 
 export interface Plan {

--- a/tests/cost-breakdown.test.ts
+++ b/tests/cost-breakdown.test.ts
@@ -271,6 +271,78 @@ describe("buildCostBreakdown", () => {
     });
   });
 
+  describe("pseudo-phase 비용 집계", () => {
+    it("setup:worktree 비용이 setupCostUsd에 집계된다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -2, phaseName: "setup:worktree", costUsd: 0.01 }),
+        makePhaseResult({ phaseIndex: 0, costUsd: 0.02 }),
+      ];
+      const result = buildCostBreakdown(0.005, phaseResults);
+      expect(result.setupCostUsd).toBeCloseTo(0.01, 6);
+    });
+
+    it("setup:dependency 비용이 setupCostUsd에 집계된다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -3, phaseName: "setup:dependency", costUsd: 0.008 }),
+        makePhaseResult({ phaseIndex: 0, costUsd: 0.02 }),
+      ];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.setupCostUsd).toBeCloseTo(0.008, 6);
+    });
+
+    it("setup:worktree + setup:dependency 비용이 합산된다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -2, phaseName: "setup:worktree", costUsd: 0.005 }),
+        makePhaseResult({ phaseIndex: -3, phaseName: "setup:dependency", costUsd: 0.003 }),
+      ];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.setupCostUsd).toBeCloseTo(0.008, 6);
+    });
+
+    it("publish:pr 비용이 publishCostUsd에 집계된다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -10, phaseName: "publish:pr", costUsd: 0.007 }),
+      ];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.publishCostUsd).toBeCloseTo(0.007, 6);
+    });
+
+    it("pseudo-phase 비용이 totalCostUsd에 포함된다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -2, phaseName: "setup:worktree", costUsd: 0.005 }),
+        makePhaseResult({ phaseIndex: -10, phaseName: "publish:pr", costUsd: 0.003 }),
+        makePhaseResult({ phaseIndex: 0, costUsd: 0.02 }),
+      ];
+      const result = buildCostBreakdown(0.01, phaseResults, 0.002);
+      // 0.01 + 0.005 + 0.003 + 0.02 + 0.002 = 0.04
+      expect(result.totalCostUsd).toBeCloseTo(0.04, 6);
+    });
+
+    it("pseudo-phase는 phaseCosts에 포함되지 않는다", () => {
+      const phaseResults = [
+        makePhaseResult({ phaseIndex: -2, phaseName: "setup:worktree", costUsd: 0.005 }),
+        makePhaseResult({ phaseIndex: -3, phaseName: "setup:dependency", costUsd: 0.003 }),
+        makePhaseResult({ phaseIndex: -10, phaseName: "publish:pr", costUsd: 0.007 }),
+        makePhaseResult({ phaseIndex: 0, phaseName: "Phase 1", costUsd: 0.02 }),
+      ];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.phaseCosts).toHaveLength(1);
+      expect(result.phaseCosts[0].phaseName).toBe("Phase 1");
+    });
+
+    it("setupCostUsd가 0이면 undefined로 반환된다", () => {
+      const phaseResults = [makePhaseResult({ phaseIndex: 0, costUsd: 0.02 })];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.setupCostUsd).toBeUndefined();
+    });
+
+    it("publishCostUsd가 0이면 undefined로 반환된다", () => {
+      const phaseResults = [makePhaseResult({ phaseIndex: 0, costUsd: 0.02 })];
+      const result = buildCostBreakdown(0, phaseResults);
+      expect(result.publishCostUsd).toBeUndefined();
+    });
+  });
+
   describe("edge case", () => {
     it("phaseResults에 비용 필드가 일부만 있는 경우 합산이 정상 동작한다", () => {
       const phaseResults = [


### PR DESCRIPTION
## Summary

Resolves #673 — [P2-high] fix: Job 코스트 리포트 항목 일관성 — Total 분해 공개

PR #636 사례에서 Total $1.9011 vs Phase 합계 $1.1506 + review $0.1605 → $0.5900 미분류. 원인: buildCostBreakdown()이 pseudo-phase(setup, validation, publish) 비용을 totalCostUsd에는 포함하지만 breakdown 항목에는 누락. 또한 pipeline-phases.ts에서 reviewCostUsd를 사후 합산하면서 costBreakdown.totalCostUsd만 갱신하고 개별 항목과의 정합성 검증이 없음. 대시보드(render-jobs.js)는 breakdown 테이블의 plan + phases + review 합만 표시하므로 사용자가 Total과의 차이를 확인할 수 없음.

## Requirements

- Phase Cost Breakdown 테이블에 setup/plan/review/publish 단계 비용 추가 — buildCostBreakdown이 pseudo-phase 비용도 집계
- Model Usage 테이블에 실제 사용된 모든 모델(haiku/sonnet/opus) 포함, costUsd가 0이면 생략
- Total 옆에 내역 분해 노출: executor $X + plan $Y + review $Z + overhead $W
- Total과 내역 합 차이가 ±$0.0001 이상이면 리포트 상단에 경고 배지
- 기존 테스트 전체 통과, tsc --noEmit 통과

## Implementation Phases

- Phase 0: 타입 및 집계 로직 수정 — SUCCESS (265e7363)
- Phase 1: PR body 및 리포터 연동 — SUCCESS (72a9852a)
- Phase 2: 대시보드 표시 로직 수정 — SUCCESS (72a9852a)
- Phase 3: 테스트 및 검증 — SUCCESS (b1f551c7)

## Risks

- CostBreakdown 타입 변경 시 기존 저장된 Job 데이터(SQLite)와의 호환성 — optional 필드로 추가하여 마이그레이션 불필요하게 처리
- buildCostBreakdown 변경 시 PR body(pr-creator.ts)의 cost table도 영향받음 — 동시 수정 필요
- overhead 계산이 음수가 될 수 있음(부동소수점 오차) — Math.abs로 임계값 비교

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.7681 (review: $0.2168)
- **Phases**: 4/4 completed
- **Branch**: `aq/673-p2-high-fix-job-total` → `develop`
- **Tokens**: 86 input, 20540 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 타입 및 집계 로직 수정 | $0.1783 | 1 | $0.1783 |
| PR body 및 리포터 연동 | $0.7360 | 0 | $0.0000 |
| 대시보드 표시 로직 수정 | $0.4316 | 0 | $0.0000 |
| 테스트 및 검증 | $0.6090 | 2 | $0.6090 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.9550 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #673