### PR TITLE
[AQ-#678] [P2-high] fix: phase retry budget 중앙화 + 무한 루프 방지 통합 테스트

### DIFF
--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -8,6 +8,7 @@ import type { Plan, PhaseResult, ErrorHistoryEntry, ErrorCategory, PlanWithCost,
 import type { GitHubIssue } from "../../github/issue-fetcher.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
+import { resolveRetryBudget } from "../execution/retry-config.js";
 import type { JobLogger } from "../../queue/job-logger.js";
 import { PatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PLAN_GENERATED, phaseStart } from "../reporting/progress-tracker.js";
@@ -281,7 +282,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
   const jl = ctx.jobLogger;
   jl?.setProgress(PROGRESS_PLAN_GENERATED);
   const phaseResults: PhaseResult[] = [...(ctx.previousPhaseResults ?? []), planGenerateResult];
-  const maxRetries = ctx.config.safety.maxRetries;
+  const maxRetries = resolveRetryBudget(ctx.config, "phase");
   const repoFull = `${ctx.repo.owner}/${ctx.repo.name}`;
 
   // Load past failures for this repo to inject into phase prompts

--- a/src/pipeline/execution/phase-retry.ts
+++ b/src/pipeline/execution/phase-retry.ts
@@ -10,6 +10,7 @@ import type { Plan, Phase, PhaseResult, ErrorCategory, ErrorHistoryEntry, ModelC
 import { classifyError } from "../errors/error-classifier.js";
 import type { GitHubIssue } from "../../github/issue-fetcher.js";
 import { getLogger } from "../../utils/logger.js";
+import { DEFAULT_PHASE_MAX_RETRIES } from "./retry-config.js";
 import type { JobLogger } from "../../queue/job-logger.js";
 import { autoCommitIfDirty, getHeadHash } from "../../git/commit-helper.js";
 import { phaseProgress } from "../reporting/progress-tracker.js";
@@ -71,7 +72,7 @@ export interface PhaseRetryContext {
   errorCategory: ErrorCategory;
   errorHistory?: ErrorHistoryEntry[];
   attempt: number;
-  maxRetries: number;
+  maxRetries?: number;
   lastOutput?: string;
   claudeConfig: ClaudeCliConfig;
   promptsDir: string;
@@ -94,6 +95,7 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
   const startTime = Date.now();
   const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
+  const maxRetries = ctx.maxRetries ?? DEFAULT_PHASE_MAX_RETRIES;
   let claudeResult: ClaudeRunResult | undefined;
 
   try {
@@ -147,7 +149,7 @@ export async function retryPhase(ctx: PhaseRetryContext): Promise<PhaseResult> {
       },
       retry: {
         attempt: String(ctx.attempt),
-        maxRetries: String(ctx.maxRetries),
+        maxRetries: String(maxRetries),
         errorCategory: ctx.errorCategory,
         errorMessage,
         errorHistory: errorHistory as unknown as import("../../prompt/template-renderer.js").TemplateVariables,

--- a/src/pipeline/execution/retry-config.ts
+++ b/src/pipeline/execution/retry-config.ts
@@ -1,0 +1,60 @@
+import type { AQConfig } from "../../types/config.js";
+
+/**
+ * 각 파이프라인 단계별 retry 상한 상수 (중앙화)
+ *
+ * config.safety.maxRetries가 기본값이며, 단계별로 override 가능한 구조.
+ * 이 파일의 상수를 변경하면 모든 단계의 retry 동작이 일괄 조정된다.
+ */
+
+/** Phase 구현 재시도 상한 (config.safety.maxRetries fallback) */
+export const DEFAULT_PHASE_MAX_RETRIES = 3;
+
+/** Plan 생성 재시도 상한 */
+export const DEFAULT_PLAN_MAX_RETRIES = 2;
+
+/** Review 재시도 상한 */
+export const DEFAULT_REVIEW_MAX_RETRIES = 2;
+
+/** Final validation 재시도 상한 (config.safety.maxRetries fallback) */
+export const DEFAULT_VALIDATION_MAX_RETRIES = 3;
+
+/** CI 자동 수정 재시도 상한 (config.safety.maxRetries fallback) */
+export const DEFAULT_CI_FIX_MAX_RETRIES = 3;
+
+export type RetryStage = "phase" | "plan" | "review" | "validation" | "ci-fix";
+
+/**
+ * config.safety.maxRetries를 기반으로 각 단계별 retry 상한을 반환한다.
+ *
+ * @param config AQConfig (없으면 DEFAULT_* 상수 사용)
+ * @param stage 파이프라인 단계
+ * @returns 해당 단계의 retry 상한
+ */
+export function resolveRetryBudget(config: AQConfig | undefined, stage: RetryStage): number {
+  const globalMax = config?.safety.maxRetries;
+
+  switch (stage) {
+    case "phase":
+      return globalMax ?? DEFAULT_PHASE_MAX_RETRIES;
+    case "plan":
+      return DEFAULT_PLAN_MAX_RETRIES;
+    case "review":
+      return globalMax ?? DEFAULT_REVIEW_MAX_RETRIES;
+    case "validation":
+      return globalMax ?? DEFAULT_VALIDATION_MAX_RETRIES;
+    case "ci-fix":
+      return globalMax ?? DEFAULT_CI_FIX_MAX_RETRIES;
+  }
+}
+
+/**
+ * retry 상한 도달 시 사용하는 표준 실패 reason 메시지 템플릿.
+ *
+ * @param stage 파이프라인 단계 이름 (로그/에러 메시지용)
+ * @param maxRetries 실제 상한값
+ * @returns 실패 reason 문자열
+ */
+export function retryBudgetExhaustedReason(stage: string, maxRetries: number): string {
+  return `[RETRY_BUDGET_EXHAUSTED] ${stage} failed after ${maxRetries} attempt(s). No further retries to prevent API token exhaustion.`;
+}

--- a/src/pipeline/execution/retry-with-fix.ts
+++ b/src/pipeline/execution/retry-with-fix.ts
@@ -3,6 +3,7 @@ import type { ClaudeCliConfig, ExecutionMode } from "../../types/config.js";
 import { configForTaskWithMode } from "../../claude/model-router.js";
 import { autoCommitIfDirty } from "../../git/commit-helper.js";
 import { getLogger } from "../../utils/logger.js";
+import { retryBudgetExhaustedReason } from "./retry-config.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { estimateTokenCount } from "../../review/token-estimator.js";
 
@@ -203,7 +204,7 @@ export async function retryWithClaudeFix<T>(
     success: false,
     result: currentResult,
     attempts: maxRetries,
-    error: `Failed after ${maxRetries} attempts`
+    error: retryBudgetExhaustedReason("retry-with-fix", maxRetries)
   };
 }
 

--- a/src/pipeline/phases/plan-generator.ts
+++ b/src/pipeline/phases/plan-generator.ts
@@ -50,6 +50,7 @@ export type PlanTemplateData = PlanTemplateBaseData | PlanTemplateRetryData;
 import { notifyPlanRetryContext } from "../../notification/notifier.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
+import { DEFAULT_PLAN_MAX_RETRIES } from "../execution/retry-config.js";
 import { analyzeTokenUsage, truncateRepoStructure, truncateToTokenBudget } from "../../review/token-estimator.js";
 
 const logger = getLogger();
@@ -71,7 +72,7 @@ export interface PlanGeneratorContext {
 }
 
 export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithCost> {
-  const maxRetries = 2;
+  const maxRetries = DEFAULT_PLAN_MAX_RETRIES;
   const retryContext: PlanRetryContext = {
     currentAttempt: 0,
     maxRetries,

--- a/tests/pipeline/execution/retry-budget.test.ts
+++ b/tests/pipeline/execution/retry-budget.test.ts
@@ -1,0 +1,515 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// === Mocks for retryWithClaudeFix ===
+vi.mock("../../../src/claude/claude-runner.js", () => ({
+  runClaude: vi.fn(),
+}));
+vi.mock("../../../src/claude/model-router.js", () => ({
+  configForTask: vi.fn(),
+  configForTaskWithMode: vi.fn().mockReturnValue({ model: "fallback-model" }),
+}));
+vi.mock("../../../src/git/commit-helper.js", () => ({
+  autoCommitIfDirty: vi.fn(),
+  getHeadHash: vi.fn(),
+}));
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+// === Mocks for core-loop ===
+vi.mock("../../../src/pipeline/phases/plan-generator.js", () => ({
+  generatePlan: vi.fn(),
+}));
+vi.mock("../../../src/pipeline/execution/phase-executor.js", () => ({
+  executePhase: vi.fn(),
+}));
+vi.mock("../../../src/pipeline/execution/phase-retry.js", () => ({
+  retryPhase: vi.fn(),
+}));
+vi.mock("../../../src/safety/phase-limit-guard.js", () => ({
+  checkPhaseLimit: vi.fn(),
+}));
+vi.mock("../../../src/pipeline/execution/phase-scheduler.js", () => ({
+  schedulePhases: vi.fn(),
+}));
+vi.mock("../../../src/learning/pattern-store.js", () => ({
+  PatternStore: vi.fn().mockImplementation(() => ({
+    getRecentFailures: vi.fn().mockReturnValue([]),
+    formatForPrompt: vi.fn().mockReturnValue(""),
+  })),
+}));
+vi.mock("../../../src/prompt/template-renderer.js", () => ({
+  buildBaseLayer: vi.fn().mockReturnValue({
+    role: "시니어 개발자",
+    rules: [],
+    outputFormat: "",
+    progressReporting: "",
+    parallelWorkGuide: "",
+  }),
+  buildProjectLayer: vi.fn().mockReturnValue({
+    conventions: "",
+    structure: "",
+    testCommand: "npm test",
+    lintCommand: "npm run lint",
+    safetyRules: [],
+  }),
+  buildStaticContent: vi.fn().mockReturnValue("static-content"),
+  loadTemplate: vi.fn().mockImplementation(() => {
+    throw new Error("Template not found: /tmp/prompts/phase-implementation.md");
+  }),
+  computeLayerCacheKey: vi.fn().mockReturnValue("mock-cache-key"),
+}));
+
+import { retryWithClaudeFix, type RetryWithFixOptions } from "../../../src/pipeline/execution/retry-with-fix.js";
+import { runClaude } from "../../../src/claude/claude-runner.js";
+import { configForTaskWithMode } from "../../../src/claude/model-router.js";
+import { autoCommitIfDirty } from "../../../src/git/commit-helper.js";
+import { runCoreLoop, type CoreLoopContext } from "../../../src/pipeline/core/core-loop.js";
+import { generatePlan } from "../../../src/pipeline/phases/plan-generator.js";
+import { executePhase } from "../../../src/pipeline/execution/phase-executor.js";
+import { retryPhase } from "../../../src/pipeline/execution/phase-retry.js";
+import { schedulePhases } from "../../../src/pipeline/execution/phase-scheduler.js";
+import type { Plan, Phase, PhaseResult } from "../../../src/types/pipeline.js";
+
+const mockRunClaude = vi.mocked(runClaude);
+const mockConfigForTaskWithMode = vi.mocked(configForTaskWithMode);
+const mockAutoCommitIfDirty = vi.mocked(autoCommitIfDirty);
+const mockGeneratePlan = vi.mocked(generatePlan);
+const mockExecutePhase = vi.mocked(executePhase);
+const mockRetryPhase = vi.mocked(retryPhase);
+const mockSchedulePhases = vi.mocked(schedulePhases);
+
+// ============================================================
+// Test helpers
+// ============================================================
+
+function makePhase(index: number, name: string): Phase {
+  return {
+    index,
+    name,
+    description: `Phase ${name} description`,
+    targetFiles: [`src/${name.toLowerCase()}.ts`],
+    commitStrategy: "atomic",
+    verificationCriteria: [`${name} complete`],
+  };
+}
+
+function makePlan(phases: Phase[]): Plan {
+  return {
+    issueNumber: 1,
+    title: "Test Plan",
+    problemDefinition: "Test problem",
+    requirements: ["Req 1"],
+    affectedFiles: ["src/app.ts"],
+    risks: [],
+    phases,
+    verificationPoints: [],
+    stopConditions: [],
+  };
+}
+
+function makePhaseFailure(
+  phaseIndex: number,
+  phaseName: string,
+  error = "TS compilation error",
+): PhaseResult {
+  return {
+    phaseIndex,
+    phaseName,
+    success: false,
+    error,
+    errorCategory: "TS_ERROR",
+    durationMs: 500,
+  };
+}
+
+function makePhaseSuccess(phaseIndex: number, phaseName: string): PhaseResult {
+  return {
+    phaseIndex,
+    phaseName,
+    success: true,
+    commitHash: "abc123",
+    durationMs: 1000,
+  };
+}
+
+function makeCoreLoopContext(overrides: Partial<CoreLoopContext> = {}): CoreLoopContext {
+  return {
+    issue: { number: 1, title: "Test Issue", body: "Body", labels: [] },
+    repo: { owner: "test", name: "repo" },
+    branch: { base: "main", work: "feature-branch" },
+    repoStructure: "src/\n  app.ts\n",
+    config: {
+      commands: {
+        claudeCli: { path: "claude", model: "test", maxTurns: 1, timeout: 5000, additionalArgs: [] },
+        test: "npm test",
+        lint: "npm run lint",
+      },
+      safety: {
+        maxPhases: 10,
+        maxRetries: 2,
+        sensitivePaths: [".env"],
+      },
+      git: {
+        gitPath: "git",
+        allowedRepos: ["test/repo"],
+        autoCreateBranch: true,
+        defaultBaseBranch: "main",
+      },
+      general: {
+        projectName: "test",
+        targetRoot: "/tmp",
+        tempDir: "/tmp",
+      },
+      queue: {
+        concurrency: 1,
+        retryDelayMs: 1000,
+        stuckTimeoutMs: 300000,
+        persistenceFile: "/tmp/queue.json",
+      },
+      github: {
+        token: "token",
+        webhookSecret: "secret",
+        enableAutoMerge: false,
+      },
+      server: {
+        port: 3000,
+        host: "localhost",
+      },
+      features: {
+        parallelPhases: false,
+      },
+    } as any,
+    promptsDir: "/tmp/prompts",
+    cwd: "/tmp/project",
+    // baseline을 미리 제공하여 captureErrorBaseline 호출을 건너뜀
+    baseline: {
+      tsc: { totalErrors: 0, errorsByFile: {} },
+      eslint: { totalErrors: 0, errorsByFile: {} },
+    } as any,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// 1. retryWithClaudeFix — retry budget 소진 검증
+// ============================================================
+
+describe("retryWithClaudeFix — retry budget 소진 시 RETRY_BUDGET_EXHAUSTED", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfigForTaskWithMode.mockReturnValue({ model: "fallback-model" });
+    mockAutoCommitIfDirty.mockResolvedValue(false);
+  });
+
+  it("revalidateFn이 계속 실패하면 maxRetries 소진 후 RETRY_BUDGET_EXHAUSTED 에러로 실패한다", async () => {
+    const failedResult = { errors: ["compilation error"] };
+
+    mockRunClaude.mockResolvedValue({ success: true, output: "applied fix" });
+
+    const options: RetryWithFixOptions<typeof failedResult> = {
+      checkFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      buildFixPromptFn: vi.fn().mockReturnValue("Fix these errors: compilation error"),
+      revalidateFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      maxRetries: 2,
+      claudeConfig: { model: "test-model" } as any,
+      cwd: "/tmp",
+      gitPath: "/usr/bin/git",
+      commitMessageTemplate: "fix: retry {attempt}",
+    };
+
+    const result = await retryWithClaudeFix(options);
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(2);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("RETRY_BUDGET_EXHAUSTED");
+    // runClaude는 maxRetries 횟수만큼 호출됨
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+  });
+
+  it("maxRetries=1일 때 1회 시도 후 RETRY_BUDGET_EXHAUSTED로 실패하며 attempt 횟수가 1임을 검증한다", async () => {
+    const failedResult = { errors: ["error"] };
+
+    mockRunClaude.mockResolvedValue({ success: true, output: "ok" });
+
+    const options: RetryWithFixOptions<typeof failedResult> = {
+      checkFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      buildFixPromptFn: vi.fn().mockReturnValue("fix prompt"),
+      revalidateFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      maxRetries: 1,
+      claudeConfig: { model: "test-model" } as any,
+      cwd: "/tmp",
+      gitPath: "/usr/bin/git",
+      commitMessageTemplate: "fix: retry {attempt}",
+    };
+
+    const result = await retryWithClaudeFix(options);
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(1);
+    expect(result.error).toContain("RETRY_BUDGET_EXHAUSTED");
+    expect(result.error).toContain("1 attempt");
+  });
+
+  it("Claude CLI가 에러를 반환해도(throw) maxRetries 소진 후 success=false를 반환한다", async () => {
+    const failedResult = { errors: ["error"] };
+
+    // runClaude가 매번 throw — Claude CLI 에러 시뮬레이션
+    mockRunClaude.mockRejectedValue(new Error("Claude CLI failed: exit code 1"));
+
+    const options: RetryWithFixOptions<typeof failedResult> = {
+      checkFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      buildFixPromptFn: vi.fn().mockReturnValue("fix prompt"),
+      revalidateFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      maxRetries: 3,
+      claudeConfig: { model: "test-model" } as any,
+      cwd: "/tmp",
+      gitPath: "/usr/bin/git",
+      commitMessageTemplate: "fix: retry {attempt}",
+    };
+
+    const result = await retryWithClaudeFix(options);
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.error).toBeDefined();
+  });
+
+  it("onFailure 콜백이 maxRetries 도달 시 정확히 1회 호출된다", async () => {
+    const failedResult = { errors: ["error"] };
+    const onFailure = vi.fn();
+
+    mockRunClaude.mockResolvedValue({ success: true, output: "ok" });
+
+    const options: RetryWithFixOptions<typeof failedResult> = {
+      checkFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      buildFixPromptFn: vi.fn().mockReturnValue("fix prompt"),
+      revalidateFn: vi.fn().mockResolvedValue({ success: false, result: failedResult }),
+      maxRetries: 2,
+      claudeConfig: { model: "test-model" } as any,
+      cwd: "/tmp",
+      gitPath: "/usr/bin/git",
+      commitMessageTemplate: "fix: retry {attempt}",
+      onFailure,
+    };
+
+    await retryWithClaudeFix(options);
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledWith(2, failedResult);
+  });
+});
+
+// ============================================================
+// 2. retryPhase — core-loop에서 상한 초과 시 정상 실패 검증
+// ============================================================
+
+describe("retryPhase — core-loop에서 retry 상한 초과 시 정상 실패", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSchedulePhases.mockReturnValue({ success: true, groups: [] });
+  });
+
+  it("retryPhase가 maxRetries(=2) 횟수만큼만 호출되고 그 이상 호출되지 않는다 (무한 루프 방지)", async () => {
+    const phases = [makePhase(0, "BuggyPhase")];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [{ level: 0, phases }],
+    });
+
+    // 초기 실행 실패 (TS_ERROR → retryable)
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "BuggyPhase"));
+
+    // retryPhase: maxRetries(=2)번 모두 실패
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(0, "BuggyPhase", "Retry 1 failed"))
+      .mockResolvedValueOnce(makePhaseFailure(0, "BuggyPhase", "Retry 2 failed"));
+
+    const result = await runCoreLoop(makeCoreLoopContext());
+
+    // 정확히 maxRetries(=2)번만 호출됨
+    expect(mockRetryPhase).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(false);
+  });
+
+  it("retry 상한 도달 후 마지막 실패 결과가 phaseResults에 포함된다", async () => {
+    const phases = [makePhase(0, "FailingPhase")];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [{ level: 0, phases }],
+    });
+
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "FailingPhase", "Initial error"));
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(0, "FailingPhase", "Retry 1 error"))
+      .mockResolvedValueOnce(makePhaseFailure(0, "FailingPhase", "Retry 2 error — budget exhausted"));
+
+    const result = await runCoreLoop(makeCoreLoopContext());
+
+    expect(result.success).toBe(false);
+
+    const failedResult = result.phaseResults.find(r => r.phaseIndex === 0);
+    expect(failedResult).toBeDefined();
+    expect(failedResult!.success).toBe(false);
+    // 마지막 retry 결과가 최종 결과로 기록됨
+    expect(failedResult!.error).toContain("Retry 2 error");
+  });
+
+  it("retryPhase 호출 시 attempt 번호가 1부터 maxRetries까지 순서대로 전달된다", async () => {
+    const phases = [makePhase(0, "CheckAttempt")];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [{ level: 0, phases }],
+    });
+
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "CheckAttempt"));
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(0, "CheckAttempt", "Attempt 1"))
+      .mockResolvedValueOnce(makePhaseFailure(0, "CheckAttempt", "Attempt 2"));
+
+    await runCoreLoop(makeCoreLoopContext());
+
+    expect(mockRetryPhase).toHaveBeenNthCalledWith(1, expect.objectContaining({ attempt: 1, maxRetries: 2 }));
+    expect(mockRetryPhase).toHaveBeenNthCalledWith(2, expect.objectContaining({ attempt: 2, maxRetries: 2 }));
+  });
+});
+
+// ============================================================
+// 3. core-loop — 전체 retry 소진 후 파이프라인 failed 확정
+// ============================================================
+
+describe("core-loop — 전체 retry 소진 후 파이프라인 failed 확정", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSchedulePhases.mockReturnValue({ success: true, groups: [] });
+  });
+
+  it("단일 phase가 모든 retry를 소진하면 파이프라인 전체가 failed로 끝난다", async () => {
+    const phases = [makePhase(0, "AlwaysFails")];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [{ level: 0, phases }],
+    });
+
+    // 초기 실행 + retry 2회 모두 실패 (maxRetries=2)
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "AlwaysFails"));
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(0, "AlwaysFails", "Attempt 1 failed"))
+      .mockResolvedValueOnce(makePhaseFailure(0, "AlwaysFails", "Attempt 2 failed"));
+
+    const result = await runCoreLoop(makeCoreLoopContext());
+
+    expect(result.success).toBe(false);
+    expect(result.plan).toBeDefined();
+    // phaseResults에 plan:generate pseudo-phase + failed phase 포함
+    expect(result.phaseResults.length).toBeGreaterThanOrEqual(2);
+    expect(result.phaseResults.some(r => r.phaseIndex === 0 && !r.success)).toBe(true);
+  });
+
+  it("retry 소진으로 실패한 phase 이후의 phase는 실행되지 않는다", async () => {
+    const phases = [
+      makePhase(0, "FailPhase"),
+      makePhase(1, "NextPhase"),
+    ];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    // 순차 그룹: phase 0 실패 시 phase 1은 실행 안 됨
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [
+        { level: 0, phases: [phases[0]] },
+        { level: 1, phases: [phases[1]] },
+      ],
+    });
+
+    // Phase 0: 초기 실패 + 모든 retry 소진
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "FailPhase"));
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(0, "FailPhase", "Retry 1"))
+      .mockResolvedValueOnce(makePhaseFailure(0, "FailPhase", "Retry 2 — final"));
+
+    const result = await runCoreLoop(makeCoreLoopContext());
+
+    expect(result.success).toBe(false);
+    // Phase 1은 실행되지 않음
+    expect(result.phaseResults.find(r => r.phaseIndex === 1)).toBeUndefined();
+    // Phase 0 실패 결과는 포함됨
+    const phase0Result = result.phaseResults.find(r => r.phaseIndex === 0);
+    expect(phase0Result).toBeDefined();
+    expect(phase0Result!.success).toBe(false);
+  });
+
+  it("maxRetries=0이면 retry 없이 즉시 파이프라인이 failed로 끝난다", async () => {
+    const phases = [makePhase(0, "NoRetryPhase")];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [{ level: 0, phases }],
+    });
+
+    mockExecutePhase.mockResolvedValueOnce(makePhaseFailure(0, "NoRetryPhase"));
+
+    const context = makeCoreLoopContext();
+    (context.config.safety as any).maxRetries = 0;
+
+    const result = await runCoreLoop(context);
+
+    expect(result.success).toBe(false);
+    // retry 없이 즉시 실패 — retryPhase 미호출
+    expect(mockRetryPhase).not.toHaveBeenCalled();
+  });
+
+  it("성공한 phase 이후 다음 phase가 retry 소진으로 실패하면 파이프라인은 failed이다", async () => {
+    const phases = [
+      makePhase(0, "SuccessPhase"),
+      makePhase(1, "ExhaustedPhase"),
+    ];
+    const plan = makePlan(phases);
+
+    mockGeneratePlan.mockResolvedValue({ plan });
+    mockSchedulePhases.mockReturnValue({
+      success: true,
+      groups: [
+        { level: 0, phases: [phases[0]] },
+        { level: 1, phases: [phases[1]] },
+      ],
+    });
+
+    // Phase 0 성공
+    mockExecutePhase
+      .mockResolvedValueOnce(makePhaseSuccess(0, "SuccessPhase"))
+      // Phase 1 초기 실패
+      .mockResolvedValueOnce(makePhaseFailure(1, "ExhaustedPhase", "Phase 1 initial error"));
+
+    // Phase 1 retry 2회 모두 실패
+    mockRetryPhase
+      .mockResolvedValueOnce(makePhaseFailure(1, "ExhaustedPhase", "Phase 1 retry 1"))
+      .mockResolvedValueOnce(makePhaseFailure(1, "ExhaustedPhase", "Phase 1 retry 2"));
+
+    const result = await runCoreLoop(makeCoreLoopContext());
+
+    expect(result.success).toBe(false);
+    // Phase 0은 성공 결과 보존
+    const phase0Result = result.phaseResults.find(r => r.phaseIndex === 0);
+    expect(phase0Result?.success).toBe(true);
+    // Phase 1은 실패
+    const phase1Result = result.phaseResults.find(r => r.phaseIndex === 1);
+    expect(phase1Result?.success).toBe(false);
+  });
+}, { timeout: 300000 });

--- a/tests/pipeline/retry-with-fix.test.ts
+++ b/tests/pipeline/retry-with-fix.test.ts
@@ -129,7 +129,7 @@ describe("retryWithClaudeFix", () => {
     expect(result.success).toBe(false);
     expect(result.result).toEqual(failedResult);
     expect(result.attempts).toBe(2);
-    expect(result.error).toBe("Failed after 2 attempts");
+    expect(result.error).toBe("[RETRY_BUDGET_EXHAUSTED] retry-with-fix failed after 2 attempt(s). No further retries to prevent API token exhaustion.");
 
     expect(mockRunClaude).toHaveBeenCalledTimes(2);
     expect(mockAutoCommitIfDirty).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Resolves #678 — [P2-high] fix: phase retry budget 중앙화 + 무한 루프 방지 통합 테스트

retry budget이 상위(core-loop의 config.safety.maxRetries)와 하위(plan-generator 하드코딩 2, retry-with-fix 파라미터)로 분산되어 있어 "끝나지 않는 잡" 가능성이 있다. phase retry 시 상한 도달 여부를 명확히 판단할 중앙 상수가 없고, API 토큰 소진 방지를 위한 명확한 reason 기록도 부재.

## Requirements

- retry-config.ts 신설 — 모든 retry 상한을 단일 파일 상수로 중앙화
- retry-with-fix.ts와 phase-retry.ts가 동일 중앙 상수를 참조하도록 변경
- core-loop.ts의 maxRetries도 중앙 상수 참조로 전환
- plan-generator.ts의 하드코딩된 maxRetries=2도 중앙 상수로 통합
- Claude CLI가 항상 에러 반환하는 mock 시나리오로 통합 테스트 작성 — 잡이 retry 상한 내에 failed로 확정되는지 검증
- retry 상한 도달 시 명확한 reason 기록 (API 토큰 소진 방지)

## Implementation Phases

- Phase 0: retry-config.ts 신설 및 중앙 상수 정의 — SUCCESS (94f37cfb)
- Phase 1: 기존 파일들이 중앙 상수를 참조하도록 변경 — SUCCESS (47220e67)
- Phase 2: 통합 테스트 작성 — retry budget 소진 시 failed 확정 검증 — SUCCESS (400bd766)

## Risks

- 기존 config.safety.maxRetries와 중앙 상수 간 우선순위 혼동 — config 값이 있으면 config 우선, 없으면 중앙 상수 fallback 원칙 적용
- plan-generator의 maxRetries 변경(2→중앙상수)으로 기존 동작이 달라질 수 있음 — PLAN_MAX_RETRIES 기본값을 2로 유지하여 동작 호환성 보장
- 통합 테스트에서 실제 Claude CLI 호출을 mock하지 않으면 토큰 소진 — 반드시 mock 사용

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $4.0972 (review: $0.1508)
- **Phases**: 3/3 completed
- **Branch**: `aq/678-p2-high-fix-phase-retry-budget` → `develop`
- **Tokens**: 95 input, 13871 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| retry-config.ts 신설 및 중앙 상수 정의 | $0.7286 | 0 | $0.0000 |
| 기존 파일들이 중앙 상수를 참조하도록 변경 | $0.9033 | 0 | $0.0000 |
| 통합 테스트 작성 — retry budget 소진 시 failed 확정 검증 | $1.7221 | 1 | $1.7221 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $3.3540 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #678