### PR TITLE
[AQ-#680] [P3-medium] fix: Hono server graceful shutdown 경로 확립

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -3,6 +3,7 @@ import type { ClaudeCliConfig } from "../types/config.js";
 import { withRetry } from "../utils/rate-limiter.js";
 import { classifyError } from "../pipeline/errors/error-classifier.js";
 import { calculateCostFromUsage } from "./token-pricing.js";
+import { getLogger } from "../utils/logger.js";
 
 const activeProcesses: Map<number, { process: ChildProcess; lastActivity: number }> = new Map();
 
@@ -22,6 +23,29 @@ export function getLastActivityMs(): number {
 
 export function getActiveProcessPids(): number[] {
   return Array.from(activeProcesses.keys());
+}
+
+export async function killAllActiveProcesses(): Promise<void> {
+  if (activeProcesses.size === 0) return;
+
+  const logger = getLogger();
+  const entries = Array.from(activeProcesses.entries());
+
+  logger.info(`[claude-runner] Sending SIGTERM to ${entries.length} active process(es)...`);
+
+  for (const [pid, { process: child }] of entries) {
+    logger.info(`[claude-runner] SIGTERM → PID ${pid}`);
+    child.kill("SIGTERM");
+  }
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 3000));
+
+  for (const [pid, { process: child }] of entries) {
+    if (!child.killed && activeProcesses.has(pid)) {
+      logger.warn(`[claude-runner] PID ${pid} did not exit after SIGTERM — sending SIGKILL`);
+      child.kill("SIGKILL");
+    }
+  }
 }
 
 import type { UsageInfo } from "../types/pipeline.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { getErrorMessage } from "./utils/error-utils.js";
 import { JobStore } from "./queue/job-store.js";
 import { JobQueue } from "./queue/job-queue.js";
 import { createWebhookApp, startServer } from "./server/webhook-server.js";
+import { killAllActiveProcesses } from "./claude/claude-runner.js";
 import { createDashboardRoutes, cleanupDashboardResources } from "./server/dashboard-api.js";
 import { createHealthRoutes } from "./server/health.js";
 import { writePidFile, cleanupStalePid, removePidFile, readPidFile } from "./server/pid-manager.js";
@@ -464,7 +465,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
     process.exit(1);
   }
 
-  startServer(app, port, host);
+  const server = startServer(app, port, host);
   initDispatcher(scheduler);
   scheduler.start();
   writePidFile(pidPath);
@@ -472,14 +473,34 @@ export async function startCommand(args: CliArgs): Promise<void> {
   const cleanup = () => removePidFile(pidPath);
   process.on("exit", cleanup);
 
+  let isShuttingDown = false;
   const gracefulShutdown = async (signal: string) => {
-    logger.info(`${signal} received — shutting down gracefully, waiting for running jobs...`);
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+    logger.info(`${signal} received — shutting down gracefully...`);
+
+    logger.info("[shutdown] 1/6 poller/scheduler 중지 중...");
     poller?.stop();
     scheduler.stop();
     configWatcher.stopWatching();
-    cleanupDashboardResources();
+
+    logger.info("[shutdown] 2/6 HTTP 서버 종료 중 (새 요청 차단)...");
+    server.close();
+
+    logger.info("[shutdown] 3/6 실행 중인 job 완료 대기 중 (최대 30초)...");
     await queue.shutdown(30000);
+
+    logger.info("[shutdown] 4/6 남은 Claude 서브프로세스 정리 중...");
+    await killAllActiveProcesses();
+
+    logger.info("[shutdown] 5/6 JobStore 종료 중...");
+    store.close();
+
+    logger.info("[shutdown] 6/6 대시보드 리소스 정리 및 PID 파일 제거...");
+    cleanupDashboardResources();
     cleanup();
+
+    logger.info("Shutdown complete.");
     process.exit(0);
   };
 

--- a/tests/claude-runner.test.ts
+++ b/tests/claude-runner.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../src/utils/logger.js", () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("../src/utils/rate-limiter.js", () => ({
+  withRetry: vi.fn(async (fn: () => unknown) => fn()),
+}));
+
+vi.mock("../src/pipeline/errors/error-classifier.js", () => ({
+  classifyError: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../src/claude/token-pricing.js", () => ({
+  calculateCostFromUsage: vi.fn().mockReturnValue(0),
+}));
+
+import {
+  killAllActiveProcesses,
+  isClaudeProcessAlive,
+  getActiveProcessPids,
+} from "../src/claude/claude-runner.js";
+
+describe("isClaudeProcessAlive", () => {
+  it("활성 프로세스가 없으면 false 반환", () => {
+    expect(isClaudeProcessAlive()).toBe(false);
+  });
+});
+
+describe("getActiveProcessPids", () => {
+  it("활성 프로세스가 없으면 빈 배열 반환", () => {
+    expect(getActiveProcessPids()).toEqual([]);
+  });
+});
+
+describe("killAllActiveProcesses", () => {
+  it("activeProcesses가 비어있으면 즉시 resolve", async () => {
+    await expect(killAllActiveProcesses()).resolves.toBeUndefined();
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -84,6 +84,9 @@ vi.mock("../src/learning/pattern-store.js", () => ({
 vi.mock("../src/git/worktree-cleaner.js", () => ({
   cleanOldWorktrees: vi.fn(),
 }));
+vi.mock("../src/claude/claude-runner.js", () => ({
+  killAllActiveProcesses: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("hono", () => ({
   Hono: class MockHono {
     route() { return this; }
@@ -1309,7 +1312,10 @@ describe("startCommand — gracefulShutdown", () => {
     vi.mocked(JobStore).mockImplementation(() => ({
       prune: vi.fn(),
       list: vi.fn().mockReturnValue([]),
+      close: vi.fn(),
     } as unknown as JobStore));
+
+    vi.mocked(startServer).mockReturnValue({ close: vi.fn() });
 
     vi.mocked(createWebhookApp).mockReturnValue({
       route: vi.fn(),

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -19,6 +19,7 @@ import { loadCheckpoint } from "../src/pipeline/errors/checkpoint.js";
 import { PatternStore } from "../src/learning/pattern-store.js";
 import { cleanOldWorktrees } from "../src/git/worktree-cleaner.js";
 import { listTriggerIssues, generateExecutionPlan, printExecutionPlan } from "../src/pipeline/automation/issue-orchestrator.js";
+import { killAllActiveProcesses } from "../src/claude/claude-runner.js";
 
 vi.mock("../src/pipeline/automation/issue-orchestrator.js", () => ({
   listTriggerIssues: vi.fn(),
@@ -1289,6 +1290,7 @@ describe("startCommand — gracefulShutdown", () => {
 
   let mockPollerStop: ReturnType<typeof vi.fn>;
   let mockQueueShutdown: ReturnType<typeof vi.fn>;
+  let mockStoreClose: ReturnType<typeof vi.fn>;
   let mockConfigWatcherStop: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -1309,10 +1311,11 @@ describe("startCommand — gracefulShutdown", () => {
       enqueue: vi.fn(),
     } as unknown as JobQueue));
 
+    mockStoreClose = vi.fn();
     vi.mocked(JobStore).mockImplementation(() => ({
       prune: vi.fn(),
       list: vi.fn().mockReturnValue([]),
-      close: vi.fn(),
+      close: mockStoreClose,
     } as unknown as JobStore));
 
     vi.mocked(startServer).mockReturnValue({ close: vi.fn() });
@@ -1421,6 +1424,53 @@ describe("startCommand — gracefulShutdown", () => {
     expect(mockPollerStop).not.toHaveBeenCalled();
     expect(mockQueueShutdown).toHaveBeenCalledWith(30000);
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("shutdown 시 killAllActiveProcesses가 호출됨", async () => {
+    const onSpy = vi.spyOn(process, "on");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as unknown as never);
+
+    await startCommand({});
+
+    const sigintCall = onSpy.mock.calls.find(([event]) => event === "SIGINT");
+    const sigintHandler = sigintCall?.[1] as (() => void) | undefined;
+    sigintHandler!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(killAllActiveProcesses).toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("shutdown 시 store.close가 호출됨", async () => {
+    const onSpy = vi.spyOn(process, "on");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as unknown as never);
+
+    await startCommand({});
+
+    const sigtermCall = onSpy.mock.calls.find(([event]) => event === "SIGTERM");
+    const sigtermHandler = sigtermCall?.[1] as (() => void) | undefined;
+    sigtermHandler!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mockStoreClose).toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("중복 shutdown 호출 시 queue.shutdown은 한 번만 실행됨", async () => {
+    const onSpy = vi.spyOn(process, "on");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as unknown as never);
+
+    await startCommand({});
+
+    const sigintCall = onSpy.mock.calls.find(([event]) => event === "SIGINT");
+    const sigintHandler = sigintCall?.[1] as (() => void) | undefined;
+
+    sigintHandler!();
+    sigintHandler!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mockQueueShutdown).toHaveBeenCalledTimes(1);
+    exitSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves #680 — [P3-medium] fix: Hono server graceful shutdown 경로 확립

현재 `aqm stop` (SIGTERM/SIGINT) 시 graceful shutdown에 구멍이 있다: (1) HTTP 서버를 닫지 않아 새 요청이 계속 들어옴, (2) Claude CLI 서브프로세스를 정리하지 않아 고아 프로세스 위험, (3) JobStore를 닫지 않아 SQLite WAL 미정리 가능, (4) shutdown 순서가 명시적이지 않음 (queue.shutdown → store.close → server.close 순서 보장 필요), (5) shutdown 과정의 로그 가시성 부족.

## Requirements

- SIGTERM/SIGINT 핸들러에서 올바른 순서로 shutdown: (1) 새 요청 차단 (server.close) (2) poller/scheduler 중지 (3) queue.shutdown으로 실행 중 잡 대기 (4) Claude 서브프로세스 정리 (5) store.close
- 진행 중인 Claude CLI 서브프로세스를 SIGTERM→SIGKILL 순서로 정리하는 함수 추가 (고아 방지)
- aqm stop 경로에서 10초 타임아웃 전 graceful 완료 검증
- shutdown 각 단계별 로그 출력으로 과정 가시화

## Implementation Phases

- Phase 0: Claude 서브프로세스 정리 함수 추가 — SUCCESS (94cec1de)
- Phase 1: gracefulShutdown 순서 확립 및 서버 종료 — SUCCESS (703e88ca)
- Phase 2: 테스트 작성 — SUCCESS (6ae44dea)

## Risks

- queue.shutdown 타임아웃(30초) 내에 장시간 실행 중인 파이프라인이 완료되지 않을 수 있음 — 이 경우 killAllActiveProcesses로 강제 종료
- store.close()를 queue.shutdown 완료 전에 호출하면 실행 중 잡의 상태 업데이트 실패 — 순서 엄수 필요
- SIGKILL은 Claude CLI가 임시 파일을 정리하지 못할 수 있음 — worktree-cleaner가 다음 시작 시 처리

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.9272 (review: $0.1344)
- **Phases**: 3/3 completed
- **Branch**: `aq/680-p3-medium-fix-hono-server-graceful-shutdown` → `develop`
- **Tokens**: 124 input, 17515 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| Claude 서브프로세스 정리 함수 추가 | $0.3075 | 0 | $0.0000 |
| gracefulShutdown 순서 확립 및 서버 종료 | $1.1661 | 0 | $0.0000 |
| 테스트 작성 | $0.7486 | 1 | $0.7486 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $2.2222 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #680