### PR TITLE
[AQ-#700] fix: Dashboard mutation Zod 검증 1/2 — @hono/zod-validator 도입 + 스키마/공통 hook 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
+        "@hono/zod-validator": "^0.4.3",
         "better-sqlite3": "^12.8.0",
         "hono": "^4.12.8",
         "minimatch": "^9.0.9",
@@ -620,6 +621,16 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.4.3.tgz",
+      "integrity": "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.19.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.11",
+    "@hono/zod-validator": "^0.4.3",
     "better-sqlite3": "^12.8.0",
     "hono": "^4.12.8",
     "minimatch": "^9.0.9",

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -23,6 +23,8 @@ import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { existsSync, statSync } from "fs";
 import { detectProjectCommands, detectBaseBranch } from "../config/project-detector.js";
+import { zValidator } from "@hono/zod-validator";
+import type { ZodError } from "zod";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -191,6 +193,27 @@ export function cleanupDashboardResources(): void {
 function isValidSessionToken(token: string): boolean {
   return sessionManager.validate(token);
 }
+
+/**
+ * Common validation hook for zValidator middleware.
+ * Returns a 400 response with formatted error details when validation fails.
+ */
+export function zodValidationHook(
+  result: { success: true } | { success: false; error: ZodError },
+  c: Context
+): Response | void {
+  if (!result.success) {
+    return c.json(
+      {
+        error: "Invalid request body",
+        details: formatZodError(result.error),
+      },
+      400
+    );
+  }
+}
+
+export { zValidator };
 
 /**
  * Validates and normalizes path parameters to prevent path traversal attacks.

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -441,6 +441,18 @@ export const SuccessRateResponseSchema = z.object({
 
 export type SuccessRateResponse = z.infer<typeof SuccessRateResponseSchema>;
 
+// Phase 2: zValidator용 뮤테이션 스키마 (짧은 이름으로 export)
+export const configUpdateSchema = UpdateConfigRequestSchema;
+export const projectCreateSchema = CreateProjectRequestSchema;
+export const projectUpdateSchema = UpdateProjectRequestSchema;
+export const jobPrioritySchema = UpdateJobPriorityRequestSchema;
+
+// POST /api/jobs/:id/cancel — request body 없음
+export const jobCancelSchema = z.object({}).strict();
+
+// POST /api/jobs/:id/retry — request body 없음
+export const jobRetrySchema = z.object({}).strict();
+
 // Zod 에러를 클라이언트 친화적 형태로 변환
 export function formatZodError(error: z.ZodError): { field: string; message: string }[] {
   return error.issues.map((issue) => ({


### PR DESCRIPTION
## Summary

Resolves #700 — fix: Dashboard mutation Zod 검증 1/2 — @hono/zod-validator 도입 + 스키마/공통 hook 작성

현재 dashboard-api.ts의 mutation 엔드포인트들은 각각 수동으로 `await c.req.json()` → `safeParse()` → 에러 응답 패턴을 반복하고 있다. `@hono/zod-validator`의 `zValidator` 미들웨어를 도입하면 이 보일러플레이트를 제거하고, 검증 실패 시 통일된 400 응답 포맷을 공통 hook으로 보장할 수 있다. 이 이슈는 1/2로, 의존성 추가 + 스키마 정의 + 공통 hook 작성까지만 수행하며, 실제 엔드포인트 적용은 후속 이슈에서 처리한다.

## Requirements

- @hono/zod-validator 의존성을 package.json에 추가
- 5개 mutation 엔드포인트용 Zod 스키마를 src/types/api.ts에 정의 (config update, project create/update, job cancel/priority/retry) — cancel과 retry는 body 없이 path param만 사용하므로 별도 body 스키마 불필요, 기존 스키마 재확인
- zValidator 공통 hook 작성 — invalid payload 시 400 + Zod 에러 메시지를 formatZodError 기반 통일 포맷으로 반환
- npx tsc --noEmit 통과
- npx vitest run 전체 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 의존성 추가 — SUCCESS (6ae5a2da)
- Phase 1: Mutation 스키마 점검 및 보완 — SUCCESS (6ae5a2da)
- Phase 2: zValidator 공통 hook 작성 — SUCCESS (051fa91d)

## Risks

- @hono/zod-validator 버전과 기존 hono/zod 버전 호환성 — 설치 시 peer dependency 확인 필요
- 공통 hook의 타입 시그니처가 zValidator의 hook 옵션 타입과 정확히 맞아야 함

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.4489 (review: $0.1428)
- **Phases**: 4/4 completed
- **Branch**: `aq/700-fix-dashboard-mutation-zod-1-2-hono-zod-validator-` → `develop`
- **Tokens**: 84 input, 12020 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 의존성 추가 | $0.2015 | 0 | $0.0000 |
| Mutation 스키마 점검 및 보완 | $0.2020 | 0 | $0.0000 |
| zValidator 공통 hook 작성 | $0.4340 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.8375 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #700