### PR TITLE
[AQ-#702] feat: 파이프라인 실패 코멘트에 카테고리별 권장 액션 인사이트 추가

### DIFF
--- a/src/notification/notifier.ts
+++ b/src/notification/notifier.ts
@@ -46,6 +46,19 @@ export async function notifySuccess(
 }
 
 /**
+ * errorCategory에 따라 권장 액션 인사이트 텍스트를 반환합니다.
+ */
+function getActionInsight(errorCategory?: string): string {
+  if (errorCategory === "MAX_TURNS_EXCEEDED") {
+    return "이슈가 너무 복잡합니다. **이슈 분할**을 권장하거나, config의 `maxTurns` 값을 높여 주세요.";
+  }
+  if (errorCategory === "TIMEOUT") {
+    return "Phase 타임아웃이 발생했습니다. **이슈 분할**을 권장하거나, config의 phase timeout 설정을 확인해 주세요.";
+  }
+  return "수동 확인이 필요합니다.";
+}
+
+/**
  * Notifies failure on an issue.
  */
 export async function notifyFailure(
@@ -60,7 +73,8 @@ export async function notifyFailure(
     ? `\n<details><summary>마지막 출력 (최대 50줄)</summary>\n\n\`\`\`\n${options.lastOutput.split("\n").slice(-50).join("\n")}\n\`\`\`\n</details>\n`
     : "";
   const rollback = options?.rollbackInfo ? `\n**롤백**: ${options.rollbackInfo}\n` : "";
-  const message = `## AI Quartermaster${instancePrefix} - 파이프라인 실패\n\n자동 구현에 실패했습니다.\n\n${category}**에러**: ${error.slice(0, 500)}\n${rollback}${output}\n수동 확인이 필요합니다.`;
+  const actionInsight = getActionInsight(options?.errorCategory);
+  const message = `## AI Quartermaster${instancePrefix} - 파이프라인 실패\n\n자동 구현에 실패했습니다.\n\n${category}**에러**: ${error.slice(0, 500)}\n${rollback}${output}\n${actionInsight}`;
   await notifyIssue(repo, issueNumber, message, options);
 }
 

--- a/src/pipeline/errors/error-classifier.ts
+++ b/src/pipeline/errors/error-classifier.ts
@@ -11,7 +11,7 @@ export function classifyError(error: string): ErrorCategory {
   if (lower.includes("prompt is too long") || lower.includes("prompt too long") || lower.includes("context length") || lower.includes("token limit")) {
     return "PROMPT_TOO_LONG";
   }
-  if (lower.includes("max turns exceeded") || lower.includes("error_max_turns") || lower.includes("maximum number of turns")) {
+  if (lower.includes("max turns exceeded") || lower.includes("error_max_turns") || lower.includes("maximum number of turns") || lower.includes("maximum turns") || lower.includes("turn limit exceeded")) {
     return "MAX_TURNS_EXCEEDED";
   }
   if (lower.includes("timeout") || lower.includes("timed out") || lower.includes("sigterm")) {

--- a/tests/notification/notifier.test.ts
+++ b/tests/notification/notifier.test.ts
@@ -251,6 +251,68 @@ describe("notifier", () => {
       const [, , , , , , body] = mockRunCli.mock.calls[0][1] as string[];
       expect(body.length).toBeLessThan(longError.length + 200); // Message should be truncated
     });
+
+    it("should show MAX_TURNS_EXCEEDED insight when errorCategory is MAX_TURNS_EXCEEDED", async () => {
+      mockRunCli.mockResolvedValue({
+        stdout: "Success",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await notifyFailure("owner/repo", 123, "Too many turns", {
+        errorCategory: "MAX_TURNS_EXCEEDED"
+      });
+
+      const [, , , , , , body] = mockRunCli.mock.calls[0][1] as string[];
+      expect(body).toContain("이슈 분할");
+      expect(body).toContain("maxTurns");
+      expect(body).not.toContain("수동 확인이 필요합니다");
+    });
+
+    it("should show TIMEOUT insight when errorCategory is TIMEOUT", async () => {
+      mockRunCli.mockResolvedValue({
+        stdout: "Success",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await notifyFailure("owner/repo", 123, "Phase timed out", {
+        errorCategory: "TIMEOUT"
+      });
+
+      const [, , , , , , body] = mockRunCli.mock.calls[0][1] as string[];
+      expect(body).toContain("타임아웃");
+      expect(body).toContain("이슈 분할");
+      expect(body).not.toContain("수동 확인이 필요합니다");
+    });
+
+    it("should show default insight for other error categories", async () => {
+      mockRunCli.mockResolvedValue({
+        stdout: "Success",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await notifyFailure("owner/repo", 123, "Type error", {
+        errorCategory: "TS_ERROR"
+      });
+
+      const [, , , , , , body] = mockRunCli.mock.calls[0][1] as string[];
+      expect(body).toContain("수동 확인이 필요합니다");
+    });
+
+    it("should show default insight when no errorCategory provided", async () => {
+      mockRunCli.mockResolvedValue({
+        stdout: "Success",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await notifyFailure("owner/repo", 123, "Unknown error");
+
+      const [, , , , , , body] = mockRunCli.mock.calls[0][1] as string[];
+      expect(body).toContain("수동 확인이 필요합니다");
+    });
   });
 
   describe("notifyPlanRetryContext", () => {

--- a/tests/pipeline/error-classifier.test.ts
+++ b/tests/pipeline/error-classifier.test.ts
@@ -28,6 +28,24 @@ describe("classifyError", () => {
     });
   });
 
+  describe("MAX_TURNS_EXCEEDED", () => {
+    it("detects 'max turns exceeded'", () => {
+      expect(classifyError("max turns exceeded: limit reached")).toBe("MAX_TURNS_EXCEEDED");
+    });
+
+    it("detects 'maximum turns'", () => {
+      expect(classifyError("maximum turns reached for this session")).toBe("MAX_TURNS_EXCEEDED");
+    });
+
+    it("detects 'turn limit exceeded'", () => {
+      expect(classifyError("turn limit exceeded after 100 attempts")).toBe("MAX_TURNS_EXCEEDED");
+    });
+
+    it("is case-insensitive", () => {
+      expect(classifyError("MAX TURNS EXCEEDED")).toBe("MAX_TURNS_EXCEEDED");
+    });
+  });
+
   describe("TIMEOUT", () => {
     it("detects 'timeout'", () => {
       expect(classifyError("Operation timeout after 30s")).toBe("TIMEOUT");


### PR DESCRIPTION
## Summary

Resolves #702 — feat: 파이프라인 실패 코멘트에 카테고리별 권장 액션 인사이트 추가

파이프라인 실패 시 이슈 코멘트가 카테고리와 무관하게 "수동 확인이 필요합니다"만 출력하여, 사용자가 실패 원인과 대응 방법을 알 수 없음 (재현: #676 — maxTurns 초과 실패에도 동일 메시지). ErrorCategory에 MAX_TURNS_EXCEEDED가 없고, notifyFailure가 카테고리별 권장 액션을 분기하지 않음.

## Requirements

- ErrorCategory 타입에 MAX_TURNS_EXCEEDED 추가
- error-classifier에 'max turns exceeded' 패턴 → MAX_TURNS_EXCEEDED 매핑 추가
- notifyFailure에서 errorCategory별 권장 액션 인사이트 텍스트 분기 (MAX_TURNS_EXCEEDED, TIMEOUT, 기타는 기존 동작 유지)
- 카테고리별 인사이트가 실패 코멘트에 포함되는지 단위 테스트 추가

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 타입 & 분류기 확장 — SUCCESS (64eee540)
- Phase 1: 실패 코멘트에 카테고리별 인사이트 추가 — SUCCESS (8e4386da)

## Risks

- 기존 notifyFailure 테스트 중 '수동 확인이 필요합니다' 문자열을 exact match하는 케이스가 있어 카테고리 분기 후 깨질 수 있음 — 기본 케이스(카테고리 미지정)는 기존 메시지를 유지하므로 영향 없음 확인 완료

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.2242 (review: $0.1610)
- **Phases**: 3/3 completed
- **Branch**: `aq/702-feat` → `develop`
- **Tokens**: 64 input, 9875 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 타입 & 분류기 확장 | $0.2883 | 0 | $0.0000 |
| 실패 코멘트에 카테고리별 인사이트 추가 | $0.3566 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.6448 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #702