### PR TITLE
[AQ-#703] fix: 대시보드 잡/프로젝트 액션 실패 응답을 silently 삼키지 말고 사용자에게 표시

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -161,6 +161,50 @@ if (localStorage.getItem('aqm-theme') === 'light') {
         to { opacity: 1; transform: scale(1) translateY(0); }
     }
 
+    /* Toast notifications */
+    .aqm-toast {
+        max-width: 360px;
+        padding: 10px 16px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-family: Inter, sans-serif;
+        line-height: 1.4;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+        animation: aqm-toast-in 0.2s ease forwards;
+        cursor: pointer;
+    }
+    .aqm-toast-error {
+        background: #3d1a1c;
+        color: #ffa198;
+        border: 1px solid #f8514933;
+    }
+    .aqm-toast-success {
+        background: #12261e;
+        color: #56d364;
+        border: 1px solid #3fb95033;
+    }
+    .aqm-toast-out {
+        animation: aqm-toast-out 0.3s ease forwards;
+    }
+    @keyframes aqm-toast-in {
+        from { opacity: 0; transform: translateX(20px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes aqm-toast-out {
+        from { opacity: 1; transform: translateX(0); }
+        to { opacity: 0; transform: translateX(20px); }
+    }
+    html:not(.dark) .aqm-toast-error {
+        background: #fff0ee;
+        color: #cf2f24;
+        border-color: #f851491a;
+    }
+    html:not(.dark) .aqm-toast-success {
+        background: #edfbf0;
+        color: #1a7f37;
+        border-color: #3fb9501a;
+    }
+
     /* Responsive Sidebar — DISABLED: 태블릿 모드 디자인 미완성으로 비활성화 */
     /* @media (max-width: 1080px) { */
     @media (max-width: 0px) { /* effectively disabled */

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -375,8 +375,11 @@ function cancelJob(id) {
   showConfirm(t('cancelConfirm'), '').then(function(ok) {
     if (!ok) return;
     apiFetch('/api/jobs/' + encodeURIComponent(id) + '/cancel', { method: 'POST' })
-      .then(function() { return apiFetch(buildJobsUrl()).then(function(r) { return r.json(); }).then(handleData); })
-      .catch(function() {});
+      .then(function(r) {
+        if (!r.ok) return r.json().then(function(body) { throw new Error(body.error || '취소 실패'); });
+        return apiFetch(buildJobsUrl()).then(function(r2) { return r2.json(); }).then(handleData);
+      })
+      .catch(function(err) { handleMutationError(err, '취소 실패'); });
   });
 }
 

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -389,8 +389,11 @@ function cancelJob(id) {
  */
 function retryJob(id) {
   apiFetch('/api/jobs/' + encodeURIComponent(id) + '/retry', { method: 'POST' })
-    .then(function() { return apiFetch(buildJobsUrl()).then(function(r) { return r.json(); }).then(handleData); })
-    .catch(function() {});
+    .then(function(r) {
+      if (!r.ok) return r.json().then(function(body) { throw new Error(body.error || '재시도 실패'); });
+      return apiFetch(buildJobsUrl()).then(function(r2) { return r2.json(); }).then(handleData);
+    })
+    .catch(function(err) { handleMutationError(err, '재시도 실패'); });
 }
 
 /**
@@ -400,12 +403,11 @@ function retryJob(id) {
 function deleteJob(id) {
   apiFetch('/api/jobs/' + encodeURIComponent(id), { method: 'DELETE' })
     .then(function(r) {
-      if (r.ok) {
-        if (selectedJobId === id) selectedJobId = null;
-        apiFetch(buildJobsUrl()).then(function(r) { return r.json(); }).then(handleData).catch(function() {});
-      }
+      if (!r.ok) return r.json().then(function(body) { throw new Error(body.error || '삭제 실패'); });
+      if (selectedJobId === id) selectedJobId = null;
+      return apiFetch(buildJobsUrl()).then(function(r2) { return r2.json(); }).then(handleData);
     })
-    .catch(function() {});
+    .catch(function(err) { handleMutationError(err, '삭제 실패'); });
 }
 
 /** @returns {void} */
@@ -414,10 +416,14 @@ function clearAllJobs() {
     if (!ok) return;
     var deletable = currentJobs.filter(function(j) { return j.status === 'success' || j.status === 'failure' || j.status === 'cancelled' || j.status === 'archived'; });
     Promise.all(deletable.map(function(j) {
-      return apiFetch('/api/jobs/' + encodeURIComponent(j.id), { method: 'DELETE' }).catch(function() {});
+      return apiFetch('/api/jobs/' + encodeURIComponent(j.id), { method: 'DELETE' })
+        .then(function(r) {
+          if (!r.ok) return r.json().then(function(body) { throw new Error(body.error || '삭제 실패'); });
+        })
+        .catch(function(err) { handleMutationError(err, '삭제 실패'); });
     })).then(function() {
       selectedJobId = null;
-      apiFetch(buildJobsUrl()).then(function(r) { return r.json(); }).then(handleData).catch(function() {});
+      apiFetch(buildJobsUrl()).then(function(r) { return r.json(); }).then(handleData).catch(function(err) { handleMutationError(err, '목록 조회 실패'); });
     });
   });
 }
@@ -686,14 +692,13 @@ function deleteProject(id) {
     if (!ok) return;
     apiFetch('/api/projects/' + encodeURIComponent(id), { method: 'DELETE' })
       .then(function(r) {
-        if (r.ok) {
-          // Reload settings to refresh project list
-          if (currentView === 'settings') {
-            loadSettings();
-          }
+        if (!r.ok) return r.json().then(function(body) { throw new Error(body.error || '프로젝트 삭제 실패'); });
+        // Reload settings to refresh project list
+        if (currentView === 'settings') {
+          loadSettings();
         }
       })
-      .catch(function() {});
+      .catch(function(err) { handleMutationError(err, '프로젝트 삭제 실패'); });
   });
 }
 

--- a/src/server/public/js/render-repos.js
+++ b/src/server/public/js/render-repos.js
@@ -226,7 +226,7 @@ function cleanOldData() {
     if (!ok) return;
     apiFetch('/api/jobs?status=archived', { method: 'DELETE' })
       .then(function() { loadRepositories(); })
-      .catch(function() {});
+      .catch(function(err) { handleMutationError(err, '데이터 정리 실패'); });
   });
 }
 
@@ -240,8 +240,9 @@ function deleteRepo(repo) {
     apiFetch('/api/projects/' + encodeURIComponent(repo), { method: 'DELETE' })
       .then(function(r) {
         if (r.ok) loadRepositories();
+        else return r.json().then(function(body) { handleMutationError(new Error(body.error || '저장소 삭제 실패'), '저장소 삭제 실패'); });
       })
-      .catch(function() {});
+      .catch(function(err) { handleMutationError(err, '저장소 삭제 실패'); });
   });
 }
 

--- a/src/server/public/js/utils.js
+++ b/src/server/public/js/utils.js
@@ -199,6 +199,76 @@ function asForm(el) {
 }
 
 /* ══════════════════════════════════════════════════════════════
+   Toast Notifications
+   ══════════════════════════════════════════════════════════════ */
+/**
+ * Show a toast notification in the top-right corner.
+ * @param {string} message
+ * @param {'error' | 'success'} [type]
+ */
+function showToast(message, type) {
+  var container = $id('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    container.style.cssText = 'position:fixed;top:16px;right:16px;z-index:9999;display:flex;flex-direction:column;gap:8px;pointer-events:none;';
+    document.body.appendChild(container);
+  }
+
+  var toast = document.createElement('div');
+  toast.className = 'aqm-toast aqm-toast-' + (type || 'error');
+  toast.textContent = message;
+  toast.style.pointerEvents = 'auto';
+  container.appendChild(toast);
+
+  // Auto-dismiss after 5 seconds
+  var timer = setTimeout(function() { removeToast(toast); }, 5000);
+
+  toast.addEventListener('click', function() {
+    clearTimeout(timer);
+    removeToast(toast);
+  });
+}
+
+/**
+ * @param {HTMLElement} toast
+ */
+function removeToast(toast) {
+  toast.classList.add('aqm-toast-out');
+  setTimeout(function() {
+    if (toast.parentNode) toast.parentNode.removeChild(toast);
+  }, 300);
+}
+
+/**
+ * Extract error message from a fetch Response or Error and show a toast.
+ * @param {unknown} error
+ * @param {string} fallbackMessage
+ * @returns {Promise<void>}
+ */
+async function handleMutationError(error, fallbackMessage) {
+  if (error instanceof Response) {
+    var msg = fallbackMessage;
+    try {
+      /** @type {unknown} */
+      var body = await error.json();
+      if (body && typeof body === 'object' && 'error' in body && typeof (/** @type {{error:unknown}} */(body)).error === 'string') {
+        msg = (/** @type {{error:string}} */(body)).error + ' (' + error.status + ')';
+      } else {
+        msg = fallbackMessage + ' (' + error.status + ')';
+      }
+    } catch (_) {
+      msg = fallbackMessage + ' (' + error.status + ')';
+    }
+    showToast(msg, 'error');
+  } else if (error instanceof Error) {
+    showToast(error.message || fallbackMessage, 'error');
+  } else {
+    showToast(fallbackMessage, 'error');
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
    Log Colorizer
    ══════════════════════════════════════════════════════════════ */
 /**


### PR DESCRIPTION
## Summary

Resolves #703 — fix: 대시보드 잡/프로젝트 액션 실패 응답을 silently 삼키지 말고 사용자에게 표시

대시보드의 잡/프로젝트 액션(delete, cancel, retry, clear 등) mutation fetch에서 `.catch(function(){})` 패턴으로 서버 에러 응답을 silently 삼키고 있어, 사용자가 실패를 인지할 수 없음. 예: 403 응답 시 "삭제 버튼이 안 눌린다"로만 인지. 공통 에러 핸들러와 토스트 UI가 필요.

## Requirements

- mutation fetch의 silent .catch(function(){}) 제거 — 에러 시 사용자에게 토스트로 알림
- 공통 에러 핸들러 헬퍼 1개 도입: HTTP status + server message 추출 후 토스트 표시
- 최소 대상: cancelJob, retryJob, deleteJob, clearAllJobs, deleteProject (app.js) + cleanOldData, deleteRepo (render-repos.js)
- 토스트 UI: 자동 dismiss + 수동 닫기, error/success 구분, 기존 디자인 시스템(Material tokens) 준수
- read-only fetch (loadInstanceLabel, loadClaudeProfile, loadProjectList, initial fetch)는 현행 유지 — UI 초기화 실패를 토스트로 띄울 필요 없음

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 토스트 UI + 공통 에러 핸들러 추가 — SUCCESS (78b9b6fe)
- Phase 1: app.js mutation 에러 핸들링 적용 — SUCCESS (dbabfdcf)
- Phase 2: render-repos.js mutation 에러 핸들링 적용 — SUCCESS (3b01ab8f)
- Phase 3: 타입체크 + 테스트 검증 — SUCCESS (dbabfdcf)

## Risks

- utils.js에 이미 있는 함수와 이름 충돌 가능성 — 기존 함수 확인 필요
- index.html script 로드 순서: utils.js가 app.js/render-repos.js보다 먼저 로드되는지 확인 필요
- 토스트 z-index가 모달/드롭다운과 충돌할 수 있음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.0455 (review: $0.1810)
- **Phases**: 5/5 completed
- **Branch**: `aq/703-fix-silently` → `develop`
- **Tokens**: 122 input, 17987 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 토스트 UI + 공통 에러 핸들러 추가 | $0.2889 | 0 | $0.0000 |
| app.js mutation 에러 핸들링 적용 | $0.4620 | 0 | $0.0000 |
| render-repos.js mutation 에러 핸들링 적용 | $0.2452 | 0 | $0.0000 |
| 타입체크 + 테스트 검증 | $0.1351 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.1311 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #703