### PR TITLE
hotfix: bin/aqm AQM_HOME 미설정 시 $HOME/.ai-quartermaster 자동 폴백

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -18,6 +18,12 @@ if [ -z "$AQM_MODE" ] && [ -n "$AQM_HOME" ] && [ -d "$AQM_HOME" ]; then
   AQM_ROOT="$AQM_HOME"
 fi
 
+# git-clone 기본 위치 폴백: $HOME/.ai-quartermaster가 존재하면 자동으로 git 모드
+if [ -z "$AQM_MODE" ] && [ -d "$HOME/.ai-quartermaster" ] && [ -f "$HOME/.ai-quartermaster/package.json" ]; then
+  AQM_MODE="git"
+  AQM_ROOT="$HOME/.ai-quartermaster"
+fi
+
 if [ -z "$AQM_MODE" ]; then
   echo "AI Quartermaster가 설치되어 있지 않습니다."
   echo ""


### PR DESCRIPTION
## Summary

v0.7.0 (#686 npm 호환 재작성)에서 \`\${AQM_HOME:-\$HOME/.ai-quartermaster}\` 기본값을 제거하면서 git-clone 사용자가 \`AQM_HOME\` env를 export 안 해두면 \`aqm\` 모든 명령이 "설치 안 됨" 처리되는 회귀 발생.

npm 패키지가 publish되지 않은 상태라 npm 모드 분기는 사실상 dead code인데 working git-clone 흐름을 깬 셈.

## Fix

`bin/aqm` 설치 모드 감지에 폴백 추가:
- AQM_HOME env 없어도 `$HOME/.ai-quartermaster/package.json` 존재 시 자동으로 git 모드

## Test plan

- [ ] AQM_HOME unset 상태에서 `aqm version` 정상 동작
- [ ] AQM_HOME set 상태에서도 동작 유지