### PR TITLE
hotfix: CLAUDE_CONFIG_DIR env 누수 + QUOTA_EXHAUSTED 카테고리 분리

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -90,6 +90,7 @@ function buildClaudeEnv(): NodeJS.ProcessEnv {
     "XDG_CACHE_HOME",
     "ANTHROPIC_API_KEY",
     "CLAUDE_API_KEY",
+    "CLAUDE_CONFIG_DIR",
   ];
 
   const env: NodeJS.ProcessEnv = {};

--- a/src/notification/notifier.ts
+++ b/src/notification/notifier.ts
@@ -48,7 +48,13 @@ export async function notifySuccess(
 /**
  * errorCategory에 따라 권장 액션 인사이트 텍스트를 반환합니다.
  */
-function getActionInsight(errorCategory?: string): string {
+function getActionInsight(errorCategory?: string, errorMessage?: string): string {
+  if (errorCategory === "QUOTA_EXHAUSTED") {
+    // 메시지에 reset 시각이 포함되어 있으면 추출 (예: "resets Apr 15, 2pm (Asia/Seoul)")
+    const resetMatch = errorMessage?.match(/resets\s+([^.\n]+)/i);
+    const resetText = resetMatch ? ` 한도 해제 시각: **${resetMatch[1].trim()}**.` : "";
+    return `Claude 요금제 사용 한도에 도달했습니다.${resetText} 한도 해제 후 잡을 다시 큐잉해 주세요. 재시도는 자동으로 비활성화됩니다.`;
+  }
   if (errorCategory === "MAX_TURNS_EXCEEDED") {
     return "이슈가 너무 복잡합니다. **이슈 분할**을 권장하거나, config의 `maxTurns` 값을 높여 주세요.";
   }
@@ -73,7 +79,7 @@ export async function notifyFailure(
     ? `\n<details><summary>마지막 출력 (최대 50줄)</summary>\n\n\`\`\`\n${options.lastOutput.split("\n").slice(-50).join("\n")}\n\`\`\`\n</details>\n`
     : "";
   const rollback = options?.rollbackInfo ? `\n**롤백**: ${options.rollbackInfo}\n` : "";
-  const actionInsight = getActionInsight(options?.errorCategory);
+  const actionInsight = getActionInsight(options?.errorCategory, error);
   const message = `## AI Quartermaster${instancePrefix} - 파이프라인 실패\n\n자동 구현에 실패했습니다.\n\n${category}**에러**: ${error.slice(0, 500)}\n${rollback}${output}\n${actionInsight}`;
   await notifyIssue(repo, issueNumber, message, options);
 }

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -390,8 +390,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         baseline: ctx.baseline,
       });
 
-      // Retry on failure (skip for TIMEOUT and SAFETY_VIOLATION — not recoverable by retry)
-      if (!result.success && result.errorCategory !== "TIMEOUT" && result.errorCategory !== "SAFETY_VIOLATION") {
+      // Retry on failure (skip for TIMEOUT, SAFETY_VIOLATION, QUOTA_EXHAUSTED — not recoverable by retry)
+      if (!result.success && result.errorCategory !== "TIMEOUT" && result.errorCategory !== "SAFETY_VIOLATION" && result.errorCategory !== "QUOTA_EXHAUSTED") {
         let errorHistory = addErrorToHistory(phaseErrorHistories, phase.index, 0, result.errorCategory, result.error);
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {

--- a/src/pipeline/errors/error-classifier.ts
+++ b/src/pipeline/errors/error-classifier.ts
@@ -5,6 +5,10 @@ export function classifyError(error: string): ErrorCategory {
   if (lower.includes("ts2") || lower.includes("ts1") || lower.includes("type error") || lower.includes("cannot find name") || (lower.includes("property") && lower.includes("does not exist"))) {
     return "TS_ERROR";
   }
+  // Claude Max 요금제 quota 한도 — 짧은 retry로 회복 불가, 별도 카테고리로 분리
+  if (lower.includes("hit your limit") || lower.includes("usage limit reached") || lower.includes("quota exhausted")) {
+    return "QUOTA_EXHAUSTED";
+  }
   if (lower.includes("rate limit") || lower.includes("too many requests") || lower.includes("x-ratelimit") || lower.includes("429")) {
     return "RATE_LIMIT";
   }

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -91,6 +91,7 @@ export type ErrorCategory =
   | "RATE_LIMIT"
   | "PROMPT_TOO_LONG"
   | "MAX_TURNS_EXCEEDED"
+  | "QUOTA_EXHAUSTED"
   | "UNKNOWN";
 
 /**


### PR DESCRIPTION
## Summary

v0.7.0 후 발견된 두 가지 파이프라인 버그를 main에 hotfix.

## Fixes

### 1. CLAUDE_CONFIG_DIR env 누수 (P1) — `02e605f`
AQM 데몬은 `acc2` 프로필을 정상 인식하지만, spawn한 `claude` 자식 프로세스의 env 화이트리스트에 `CLAUDE_CONFIG_DIR`이 빠져 있어 자식이 default `~/.claude`로 fallback. 비어있거나 만료된 세션으로 인증 실패가 "You've hit your limit" 류 메시지로 잘못 표시됨.

- **재현:** #712/#714가 quota도 안 걸렸는데 즉시 한도 메시지로 실패
- **검증:** 실제 acc2 한도는 OMC HUD에서 정상 확인됨
- **영향:** multi-profile(`.claude-acc1/2/3`...) 사용자 전원에게 심각

### 2. QUOTA_EXHAUSTED 카테고리 분리 — `bc75933`
진짜 Claude quota 한도(`hit your limit · resets …`)가 `UNKNOWN`으로 분류되어 retry 루프가 5초 간격으로 3회 헛돌이를 반복하던 문제. 새 카테고리 추가 + retry skip + 코멘트 인사이트(reset 시각 추출).

- error-classifier에 `hit your limit`, `usage limit reached`, `quota exhausted` 패턴 추가
- core-loop retry skip 목록에 `QUOTA_EXHAUSTED` 포함
- notifier에 카테고리 분기 추가

## Test plan

- [ ] develop CI green
- [ ] aqm restart 후 #712/#714 재큐잉 → 정상 처리 또는 quota 한도 시 깔끔하게 1회만 실패