### PR TITLE
[AQ-#712] feat: 대시보드 설정 UI에 maxTurns / maxTurnsPerMode 편집 노출

### DIFF
--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -263,12 +263,19 @@ const retryConfigSchema = z.object({
   jitterFactor: z.number().min(0).max(1),
 });
 
+const maxTurnsPerModeSchema = z.object({
+  economy: z.number().int().min(1).max(500),
+  standard: z.number().int().min(1).max(500),
+  thorough: z.number().int().min(1).max(500),
+}).partial().optional();
+
 const claudeCliConfigSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingSchema,
   modelFallbackChain: z.array(z.string()).min(1).optional(),
-  maxTurns: z.number().int().positive(),
+  maxTurns: z.number().int().min(1).max(500),
+  maxTurnsPerMode: maxTurnsPerModeSchema,
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),
   retry: retryConfigSchema.optional(),

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -421,6 +421,29 @@ function collectFormData() {
     result[section] = sectionData;
   });
 
+  // commands.claudeCli 필드 수집 (maxTurns, maxTurnsPerMode)
+  var commandsCliData = /** @type {Record<string, *>} */ ({});
+
+  var maxTurnsEl = /** @type {HTMLInputElement|null} */ (document.getElementById('field-commands-claudeCli-maxTurns'));
+  if (maxTurnsEl && maxTurnsEl.value !== '') {
+    var maxTurnsVal = parseInt(maxTurnsEl.value, 10);
+    if (!isNaN(maxTurnsVal)) commandsCliData.maxTurns = maxTurnsVal;
+  }
+
+  var perModeData = /** @type {Record<string, number>} */ ({});
+  ['economy', 'standard', 'thorough'].forEach(function(mode) {
+    var el = /** @type {HTMLInputElement|null} */ (document.getElementById('field-commands-claudeCli-maxTurnsPerMode-' + mode));
+    if (el && el.value !== '') {
+      var val = parseInt(el.value, 10);
+      if (!isNaN(val)) perModeData[mode] = val;
+    }
+  });
+  if (Object.keys(perModeData).length > 0) commandsCliData.maxTurnsPerMode = perModeData;
+
+  if (Object.keys(commandsCliData).length > 0) {
+    result.commands = { claudeCli: commandsCliData };
+  }
+
   return result;
 }
 

--- a/src/server/public/js/render-settings.js
+++ b/src/server/public/js/render-settings.js
@@ -97,6 +97,9 @@ function renderSettingsView(config) {
   renderTabForm('safety', config.safety || null);
   renderTabForm('review', config.review || null);
 
+  // Claude CLI maxTurns / maxTurnsPerMode 필드 바인딩
+  bindCommandsCliFields(config);
+
   // 저장된 탭 선택 복원 또는 기본 탭 설정
   var savedTab = localStorage.getItem('aqm-selected-tab') || 'general';
   setSettingsTab(savedTab);
@@ -364,6 +367,30 @@ function renderArrayInput(fieldId, value, configPath, isReadonly) {
          esc(arrayText) +
          '</textarea>' +
          '<div class="text-[10px] text-outline/70 mt-1">JSON</div>';
+}
+
+/**
+ * config.commands.claudeCli 값을 maxTurns / maxTurnsPerMode 필드에 바인딩
+ * @param {AqmConfig} config
+ * @returns {void}
+ */
+function bindCommandsCliFields(config) {
+  var commands = /** @type {any} */ (config).commands;
+  var cli = commands && commands.claudeCli ? commands.claudeCli : null;
+  if (!cli) return;
+
+  var maxTurnsEl = document.getElementById('field-commands-claudeCli-maxTurns');
+  if (maxTurnsEl && typeof cli.maxTurns === 'number') {
+    /** @type {HTMLInputElement} */ (maxTurnsEl).value = String(cli.maxTurns);
+  }
+
+  var modes = ['economy', 'standard', 'thorough'];
+  modes.forEach(function(mode) {
+    var el = document.getElementById('field-commands-claudeCli-maxTurnsPerMode-' + mode);
+    if (el && cli.maxTurnsPerMode && typeof cli.maxTurnsPerMode[mode] === 'number') {
+      /** @type {HTMLInputElement} */ (el).value = String(cli.maxTurnsPerMode[mode]);
+    }
+  });
 }
 
 /**

--- a/src/server/public/views/settings.html
+++ b/src/server/public/views/settings.html
@@ -77,6 +77,56 @@
     <div class="settings-tab-content">
       <div id="settings-tab-general" class="settings-tab-panel bg-surface-container p-6 rounded-xl space-y-4">
         <div id="general-settings-form" class="grid grid-cols-1 sm:grid-cols-2 gap-6"></div>
+
+        <!-- Claude CLI Turn Limits Section -->
+        <div class="mt-6 pt-6 border-t border-outline-variant/30">
+          <div class="flex items-center gap-2 mb-4">
+            <span class="material-symbols-outlined text-primary text-sm">tune</span>
+            <span class="text-[10px] font-black uppercase text-primary tracking-widest">Claude CLI — Turn Limits</span>
+            <span class="ml-auto text-[10px] text-outline/60 flex items-center gap-1" title="설정 저장 시 즉시 반영됩니다 (hot reload)">
+              <span class="material-symbols-outlined text-[12px]">bolt</span>
+              hot reload
+            </span>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns</span>
+              <span class="text-[10px] text-outline block mb-2">Claude CLI 호출 1회당 기본 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurns"
+                     data-config-path="commands.claudeCli.maxTurns"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Economy</span>
+              <span class="text-[10px] text-outline block mb-2">economy 모드 최대 턴 수 (미설정 시 Max Turns 적용)</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-economy"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.economy"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Standard</span>
+              <span class="text-[10px] text-outline block mb-2">standard 모드 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-standard"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.standard"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Thorough</span>
+              <span class="text-[10px] text-outline block mb-2">thorough 모드 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-thorough"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.thorough"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+          </div>
+        </div>
       </div>
       <div id="settings-tab-safety" class="settings-tab-panel bg-surface-container p-6 rounded-xl space-y-4 hidden">
         <div id="safety-settings-form" class="grid grid-cols-1 sm:grid-cols-2 gap-6"></div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -73,11 +73,18 @@ const modelRoutingUpdateSchema = z.object({
   fallback: z.string(),
 }).partial();
 
+const maxTurnsPerModeUpdateSchema = z.object({
+  economy: z.number().int().min(1).max(500),
+  standard: z.number().int().min(1).max(500),
+  thorough: z.number().int().min(1).max(500),
+}).partial().optional();
+
 const claudeCliConfigUpdateSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingUpdateSchema,
-  maxTurns: z.number().int().positive(),
+  maxTurns: z.number().int().min(1).max(500),
+  maxTurnsPerMode: maxTurnsPerModeUpdateSchema,
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),
 }).partial();

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -340,6 +340,76 @@ describe("validateConfig", () => {
     expect(() => validateConfig(invalidConfig)).toThrow();
   });
 
+  it("maxTurnsPerMode 전체 모드 설정 시 유효", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { economy: 10, standard: 30, thorough: 80 },
+        },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toEqual({ economy: 10, standard: 30, thorough: 80 });
+  });
+
+  it("maxTurnsPerMode 일부 모드만 설정 시 유효 (partial)", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { standard: 50 },
+        },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toEqual({ standard: 50 });
+  });
+
+  it("maxTurnsPerMode 생략 시 유효 (optional)", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: { ...validConfig.commands.claudeCli, maxTurnsPerMode: undefined },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toBeUndefined();
+  });
+
+  it("maxTurnsPerMode.economy가 0이면 에러 (min 1)", () => {
+    const invalidConfig = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { economy: 0 },
+        },
+      },
+    };
+    expect(() => validateConfig(invalidConfig)).toThrow();
+  });
+
+  it("maxTurnsPerMode.standard가 501이면 에러 (max 500)", () => {
+    const invalidConfig = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { standard: 501 },
+        },
+      },
+    };
+    expect(() => validateConfig(invalidConfig)).toThrow();
+  });
+
   it("should throw error for maxRetries outside valid range (too small)", () => {
     const invalidConfig = updateNested(validConfig, "safety", {
       maxRetries: 0,


### PR DESCRIPTION
## Summary

Resolves #712 — feat: 대시보드 설정 UI에 maxTurns / maxTurnsPerMode 편집 노출

현재 사용자가 maxTurns / maxTurnsPerMode를 변경하려면 config.yml을 직접 편집해야 함. 타입/기본값/런타임 코드에는 maxTurnsPerMode가 정의되어 있지만, Zod 검증 스키마(validator.ts, api.ts)에 누락되어 API로 저장 불가하고, 대시보드 설정 UI에도 노출되지 않음. 비개발자 친화를 위해 대시보드에서 직접 편집할 수 있어야 한다.

## Requirements

- 대시보드 설정 페이지에 commands.claudeCli.maxTurns 숫자 입력 필드 추가
- maxTurnsPerMode 3개(economy/standard/thorough) 별도 숫자 입력 추가
- PUT /api/config로 저장 — claudeCliConfigUpdateSchema에 maxTurnsPerMode 필드 추가
- 입력 검증: 1~500 범위, 정수
- 변경 후 hot reload되어 다음 잡부터 적용됨을 사용자에게 안내(툴팁)
- Stitch 디자인 시스템 패턴 준수 (settings-page-stitch.html 참조)

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 백엔드 스키마 보강 — SUCCESS (7538de13)
- Phase 1: 설정 UI 렌더링 추가 — SUCCESS (01276793)
- Phase 2: 폼 저장 로직 연결 — SUCCESS (9a5dd7ca)
- Phase 3: 테스트 및 검증 — SUCCESS (37ea9b3a)

## Risks

- validator.ts의 claudeCliConfigSchema와 api.ts의 claudeCliConfigUpdateSchema 양쪽 동기화 누락 가능
- render-settings.js의 기존 폼 수집 로직이 중첩 객체(commands.claudeCli.maxTurnsPerMode)를 제대로 처리하지 못할 수 있음
- maxTurnsPerMode 키가 ExecutionMode enum과 정확히 일치해야 함 (economy/standard/thorough)

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $3.2188 (review: $0.1887)
- **Phases**: 5/5 completed
- **Branch**: `aq/712-feat-ui-maxturns-maxturnspermode` → `develop`
- **Tokens**: 127 input, 22216 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 백엔드 스키마 보강 | $0.4981 | 0 | $0.0000 |
| 설정 UI 렌더링 추가 | $0.5890 | 0 | $0.0000 |
| 폼 저장 로직 연결 | $0.3340 | 0 | $0.0000 |
| 테스트 및 검증 | $0.9515 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $2.3727 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #712