### PR TITLE
[AQ-#719] feat: phase 모델 fallback 체인 — sonnet 한도 도달 시 자동으로 haiku/다른 모델로 우회

### DIFF
--- a/src/claude/model-router.ts
+++ b/src/claude/model-router.ts
@@ -100,6 +100,33 @@ export function resolveMaxTurnsForMode(
 }
 
 /**
+ * Resolves the fallback chain of models for QUOTA_EXHAUSTED scenarios.
+ *
+ * - If modelFallbackChain is explicitly configured, returns it as-is.
+ * - Otherwise, derives the chain from [models.phase, models.fallback] with deduplication.
+ *   EXECUTION_MODE_MODELS entries are intentionally not merged here — the phase-executor
+ *   resolves the initial model via resolveModelWithExecutionMode, so the remaining chain
+ *   should reflect the config-level fallbacks (models.phase → models.fallback).
+ */
+export function resolveFallbackChain(config: ClaudeCliConfig): string[] {
+  if (config.modelFallbackChain && config.modelFallbackChain.length > 0) {
+    return config.modelFallbackChain;
+  }
+
+  const chain: string[] = [];
+  const seen = new Set<string>();
+
+  for (const model of [config.models.phase, config.models.fallback]) {
+    if (model && !seen.has(model)) {
+      seen.add(model);
+      chain.push(model);
+    }
+  }
+
+  return chain;
+}
+
+/**
  * Creates a copy of ClaudeCliConfig with the model set for the given task type and execution mode.
  * Optionally includes disallowedTools based on worker role.
  */

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -61,6 +61,7 @@ export const DEFAULT_CONFIG: AQConfig = {
         review: CLAUDE_MODELS.HAIKU,
         fallback: CLAUDE_MODELS.SONNET,
       },
+      modelFallbackChain: [CLAUDE_MODELS.SONNET, CLAUDE_MODELS.HAIKU],
       maxTurns: 60,
       maxTurnsPerMode: {
         economy: 30,

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -267,6 +267,7 @@ const claudeCliConfigSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingSchema,
+  modelFallbackChain: z.array(z.string()).min(1).optional(),
   maxTurns: z.number().int().positive(),
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -27,23 +27,37 @@ export interface PrContext {
   instanceLabel?: string;
 }
 
-export function buildPhaseCostTable(breakdown?: CostBreakdown): string {
+export function buildPhaseCostTable(breakdown?: CostBreakdown, phaseResults?: PhaseResult[]): string {
   if (!breakdown) return '';
+  const usedModelMap = new Map<number, string>();
+  if (phaseResults) {
+    for (const r of phaseResults) {
+      if (r.usedModel) usedModelMap.set(r.phaseIndex, r.usedModel);
+    }
+  }
+  const hasModel = usedModelMap.size > 0;
   const rows: string[] = [];
   for (const p of breakdown.phaseCosts) {
-    rows.push(`| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |`);
+    const modelCell = hasModel ? ` ${usedModelMap.get(p.phaseIndex) ?? '-'} |` : '';
+    rows.push(`| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |${modelCell}`);
   }
   if (breakdown.setupCostUsd && breakdown.setupCostUsd > 0) {
-    rows.push(`| setup | $${breakdown.setupCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| setup | $${breakdown.setupCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (breakdown.publishCostUsd && breakdown.publishCostUsd > 0) {
-    rows.push(`| publish | $${breakdown.publishCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| publish | $${breakdown.publishCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (breakdown.overheadCostUsd && breakdown.overheadCostUsd > 0) {
-    rows.push(`| overhead | $${breakdown.overheadCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| overhead | $${breakdown.overheadCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (!rows.length) return '';
-  return `\n### Phase Cost Breakdown\n\n| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|\n${rows.join('\n')}\n`;
+  const header = hasModel
+    ? `| Phase | Cost | Retries | Retry Cost | Model |\n|-------|------|---------|------------|-------|`
+    : `| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|`;
+  return `\n### Phase Cost Breakdown\n\n${header}\n${rows.join('\n')}\n`;
 }
 
 export function buildModelSummary(breakdown?: CostBreakdown): string {
@@ -102,7 +116,7 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
-        phaseCostTable: buildPhaseCostTable(ctx.costBreakdown),
+        phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),
         reviewCostUsd: ctx.costBreakdown?.reviewCostUsd?.toFixed(4) || '0.0000',
       },

--- a/src/pipeline/execution/phase-executor.ts
+++ b/src/pipeline/execution/phase-executor.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { assemblePrompt, loadTemplate, buildBaseLayer, buildProjectLayer, buildIssueLayer, buildLearningLayer } from "../../prompt/template-renderer.js";
 import type { PromptLayers } from "../../prompt/layer-types.js";
 import { runClaude, type ClaudeRunResult } from "../../claude/claude-runner.js";
-import { configForTask } from "../../claude/model-router.js";
+import { configForTask, resolveFallbackChain } from "../../claude/model-router.js";
 import { runShell, runCli } from "../../utils/cli-runner.js";
 import { checkDuplicateExtension, checkFileScope } from "../../safety/scope-guard.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
@@ -53,6 +53,15 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
   const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
   let claudeResult: ClaudeRunResult | undefined;
+  const modelCostsAccumulated: ModelCostEntry[] = [];
+
+  const buildFinalModelCosts = (result: ClaudeRunResult | undefined): ModelCostEntry[] | undefined => {
+    const entries: ModelCostEntry[] = [...modelCostsAccumulated];
+    if (result?.model && result.usage) {
+      entries.push({ model: result.model, costUsd: result.costUsd ?? 0, usage: result.usage });
+    }
+    return entries.length > 0 ? entries : undefined;
+  };
 
   try {
     // 1. Load and render phase implementation template using cached layers if available
@@ -71,8 +80,11 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
 
     const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi, "&lt;/USER_INPUT&gt;")}\n</USER_INPUT>`;
 
-    const config = configForTask(ctx.claudeConfig, "phase");
-    const modelName = config.model || ctx.claudeConfig.model;
+    const fallbackChain = ctx.claudeConfig.models
+      ? resolveFallbackChain(ctx.claudeConfig)
+      : (ctx.claudeConfig.modelFallbackChain ?? []);
+    const baseConfig = configForTask(ctx.claudeConfig, "phase");
+    const modelName = baseConfig.model || ctx.claudeConfig.model;
 
     // Build PromptLayers for assemblePrompt
     const buildLayers = (summary: string): PromptLayers => ({
@@ -154,30 +166,55 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       }
     }
 
-    // 2. Run Claude to implement the phase
-    jl?.log(`Claude 구현 중: ${ctx.phase.name}`);
+    // 2. Run Claude to implement the phase (with QUOTA_EXHAUSTED fallback chain support)
     const phaseStartHash = await getHeadHash(ctx.gitPath, ctx.cwd);
     const totalPhases = ctx.plan.phases.length;
     const phaseIdx = ctx.phase.index;
-    claudeResult = await runClaude({
-      prompt: rendered,
-      cwd: ctx.cwd,
-      config,
-      enableAgents: true,
-      onStderr: jl ? (line: string) => {
-        const match = line.match(/\[HEARTBEAT\].*?\((\d+)%\)/);
-        if (match) {
-          const pct = parseInt(match[1], 10);
-          jl.setProgress(phaseProgress(phaseIdx, totalPhases, pct));
-          jl.log(line.trim());
-        } else if (line.includes("[HEARTBEAT]") || line.includes("[INFO]") || line.includes("[STEP]")) {
-          jl.log(line.trim());
-        }
-      } : undefined,
-    });
+    const onStderr = jl ? (line: string) => {
+      const match = line.match(/\[HEARTBEAT\].*?\((\d+)%\)/);
+      if (match) {
+        const pct = parseInt(match[1], 10);
+        jl.setProgress(phaseProgress(phaseIdx, totalPhases, pct));
+        jl.log(line.trim());
+      } else if (line.includes("[HEARTBEAT]") || line.includes("[INFO]") || line.includes("[STEP]")) {
+        jl.log(line.trim());
+      }
+    } : undefined;
 
-    if (!claudeResult.success) {
-      throw new PipelineError("PHASE_FAILED", `Phase implementation failed: ${claudeResult.output}`);
+    const configsToTry: ClaudeCliConfig[] = fallbackChain.length > 0
+      ? fallbackChain.map((m) => ({ ...baseConfig, model: m }))
+      : [baseConfig];
+
+    for (let fi = 0; fi < configsToTry.length; fi++) {
+      if (fi > 0) {
+        jl?.log(`QUOTA_EXHAUSTED (${fallbackChain[fi - 1]}), fallback 시도: ${fallbackChain[fi]}`);
+        logger.warn(`Phase ${ctx.phase.index}: QUOTA_EXHAUSTED on ${fallbackChain[fi - 1]}, trying fallback model ${fallbackChain[fi]}`);
+      }
+      jl?.log(`Claude 구현 중: ${ctx.phase.name}`);
+      claudeResult = await runClaude({
+        prompt: rendered,
+        cwd: ctx.cwd,
+        config: configsToTry[fi],
+        enableAgents: true,
+        onStderr,
+      });
+
+      if (claudeResult.success) break;
+
+      if (fi < configsToTry.length - 1) {
+        const failCategory = classifyError(claudeResult.output);
+        if (failCategory === 'QUOTA_EXHAUSTED') {
+          if (claudeResult.model && claudeResult.usage) {
+            modelCostsAccumulated.push({ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage });
+          }
+          continue;
+        }
+      }
+      break;
+    }
+
+    if (!claudeResult!.success) {
+      throw new PipelineError("PHASE_FAILED", `Phase implementation failed: ${claudeResult!.output}`);
     }
     jl?.log(`Claude 구현 완료: ${ctx.phase.name}`);
 
@@ -222,10 +259,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
           const warnings = vitestResult.failedTests.length > 0
             ? vitestResult.failedTests.map(t => `Test failed: ${t}`)
             : undefined;
-          const partialVitestModelCosts: ModelCostEntry[] | undefined =
-            claudeResult?.model && claudeResult.usage
-              ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-              : undefined;
           return {
             phaseIndex: ctx.phase.index,
             phaseName: ctx.phase.name,
@@ -239,7 +272,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
-            modelCosts: partialVitestModelCosts,
+            modelCosts: buildFinalModelCosts(claudeResult),
           };
         }
 
@@ -280,10 +313,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             `Phase ${ctx.phase.index}: ${tscRawResult.totalErrors} tsc error(s) all pre-existing — treating as success`
           );
           const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
-          const partialTscModelCosts: ModelCostEntry[] | undefined =
-            claudeResult?.model && claudeResult.usage
-              ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-              : undefined;
           return {
             phaseIndex: ctx.phase.index,
             phaseName: ctx.phase.name,
@@ -294,7 +323,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
-            modelCosts: partialTscModelCosts,
+            modelCosts: buildFinalModelCosts(claudeResult),
           };
         }
 
@@ -313,10 +342,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
     // 5. Get latest commit hash
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
-    const successModelCosts: ModelCostEntry[] | undefined =
-      claudeResult.model && claudeResult.usage
-        ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-        : undefined;
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
@@ -325,16 +350,12 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       durationMs: Date.now() - startTime,
       startedAt,
       completedAt: new Date().toISOString(),
-      costUsd: claudeResult.costUsd,
-      usage: claudeResult.usage,
-      modelCosts: successModelCosts,
+      costUsd: claudeResult!.costUsd,
+      usage: claudeResult!.usage,
+      modelCosts: buildFinalModelCosts(claudeResult),
     };
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
-    const errorModelCosts: ModelCostEntry[] | undefined =
-      claudeResult?.model && claudeResult.usage
-        ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-        : undefined;
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
@@ -347,7 +368,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       completedAt: new Date().toISOString(),
       costUsd: claudeResult?.costUsd,
       usage: claudeResult?.usage,
-      modelCosts: errorModelCosts,
+      modelCosts: buildFinalModelCosts(claudeResult),
     };
   }
 }

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -22,6 +22,7 @@ export interface PipelineReport {
     errorCategory?: ErrorCategory;
     costUsd?: number;
     retryCostUsd?: number;
+    usedModel?: string;
   }>;
   totalDurationMs: number;
   prUrl?: string;
@@ -74,6 +75,7 @@ export function formatResult(
       errorCategory: r.errorCategory,
       costUsd: r.costUsd,
       retryCostUsd: r.retryCostUsd,
+      usedModel: r.usedModel,
     })),
     totalDurationMs: Date.now() - startTime,
     prUrl,
@@ -99,7 +101,8 @@ export function printResult(report: PipelineReport): void {
     const commit = phase.commit ? ` [${phase.commit}]` : "";
     const cost = phase.costUsd !== undefined ? ` $${phase.costUsd.toFixed(4)}` : "";
     const retryCost = phase.retryCostUsd ? ` +retry $${phase.retryCostUsd.toFixed(4)}` : "";
-    console.log(`  ${status} ${phase.name}${commit} (${(phase.durationMs / 1000).toFixed(1)}s${cost}${retryCost})`);
+    const model = phase.usedModel ? ` [${phase.usedModel}]` : "";
+    console.log(`  ${status} ${phase.name}${commit} (${(phase.durationMs / 1000).toFixed(1)}s${cost}${retryCost}${model})`);
     if (!phase.success && phase.error) {
       console.log(`    → ${phase.error}`);
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -89,6 +89,7 @@ export interface ClaudeCliConfig {
   path: string;
   model: string;            // 글로벌 기본 모델 (routing 미설정 시 사용)
   models: ModelRouting;     // 태스크별 모델 라우팅
+  modelFallbackChain?: string[]; // QUOTA_EXHAUSTED 시 순서대로 시도할 모델 체인
   maxTurns: number;
   maxTurnsPerMode?: Record<ExecutionMode, number>; // 실행 모드별 maxTurns 제한
   timeout: number;

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -156,6 +156,8 @@ export interface PhaseResult {
   retryCostUsd?: number;
   retryCount?: number;
   modelCosts?: ModelCostEntry[];
+  /** fallback 체인으로 최종 성공한 모델 (기본 모델과 다를 때만 존재) */
+  usedModel?: string;
   /** 재시도가 필요한 실패 파일 목록 (partial=true일 때 유효) */
   failedFiles?: string[];
   /** 성공적으로 처리된 파일 목록 (partial=true일 때 유효) */

--- a/tests/claude/model-router.test.ts
+++ b/tests/claude/model-router.test.ts
@@ -5,6 +5,7 @@ import {
   resolveModelWithExecutionMode,
   resolveMaxTurnsForMode,
   configForTaskWithMode,
+  resolveFallbackChain,
 } from "../../src/claude/model-router.js";
 import { CLAUDE_MODELS } from "../../src/claude/model-constants.js";
 import type { ClaudeCliConfig } from "../../src/types/config.js";
@@ -176,5 +177,66 @@ describe("configForTaskWithMode", () => {
   it("should not set disallowedTools when workerRole is not provided", () => {
     const result = configForTaskWithMode(baseConfig, "plan", "economy");
     expect(result.disallowedTools).toBeUndefined();
+  });
+});
+
+describe("resolveFallbackChain", () => {
+  it("returns explicit modelFallbackChain as-is when set", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+      modelFallbackChain: ["claude-custom-model", CLAUDE_MODELS.HAIKU],
+    };
+    expect(resolveFallbackChain(config)).toEqual(["claude-custom-model", CLAUDE_MODELS.HAIKU]);
+  });
+
+  it("derives chain from models.phase and models.fallback when modelFallbackChain is not set", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain).toContain(CLAUDE_MODELS.SONNET);
+    expect(chain).toContain(CLAUDE_MODELS.HAIKU);
+  });
+
+  it("deduplicates when models.phase equals models.fallback", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.SONNET,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain).toEqual([CLAUDE_MODELS.SONNET]);
+  });
+
+  it("returns chain with phase first and fallback second when models differ", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain[0]).toBe(CLAUDE_MODELS.SONNET);
+    expect(chain[1]).toBe(CLAUDE_MODELS.HAIKU);
+    expect(chain).toHaveLength(2);
   });
 });

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -599,4 +599,40 @@ describe("validateConfig - command safety", () => {
     };
     expect(() => validateConfig(unsafe)).toThrow("위험한 shell 패턴");
   });
+
+  describe("modelFallbackChain validation", () => {
+    it("accepts config without modelFallbackChain (optional field)", () => {
+      expect(() => validateConfig(validConfig)).not.toThrow();
+    });
+
+    it("accepts valid non-empty string array for modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: ["claude-haiku-4-5-20251001"],
+        },
+      });
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it("accepts multiple models in modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: ["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"],
+        },
+      });
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it("rejects empty array for modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: [],
+        },
+      });
+      expect(() => validateConfig(config)).toThrow();
+    });
+  });
 });

--- a/tests/pipeline/execution/phase-executor.test.ts
+++ b/tests/pipeline/execution/phase-executor.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/claude/claude-runner.js", () => ({
+  runClaude: vi.fn(),
+}));
+vi.mock("../../../src/utils/cli-runner.js", () => ({
+  runCli: vi.fn(),
+  runShell: vi.fn(),
+}));
+vi.mock("../../../src/prompt/template-renderer.js", () => ({
+  assemblePrompt: vi.fn().mockReturnValue({ content: "rendered prompt", cacheHit: false, assemblyTimeMs: 0 }),
+  loadTemplate: vi.fn().mockReturnValue("template content"),
+  buildBaseLayer: vi.fn().mockReturnValue({ role: "시니어 개발자", rules: [], outputFormat: "", progressReporting: "", parallelWorkGuide: "" }),
+  buildProjectLayer: vi.fn().mockReturnValue({ conventions: "", structure: "", testCommand: "", lintCommand: "", safetyRules: [] }),
+  buildIssueLayer: vi.fn().mockImplementation((cfg: { number: number; title: string; body: string; labels: string[] }) => ({ ...cfg })),
+  buildLearningLayer: vi.fn().mockReturnValue({ pastFailures: [], errorPatterns: [], learnedPatterns: [], updatedAt: "" }),
+}));
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../../../src/review/token-estimator.js", () => ({
+  analyzeTokenUsage: vi.fn(),
+  summarizeForBudget: vi.fn(),
+}));
+
+import { executePhase } from "../../../src/pipeline/execution/phase-executor.js";
+import { runClaude } from "../../../src/claude/claude-runner.js";
+import { runCli } from "../../../src/utils/cli-runner.js";
+import type { PhaseExecutorContext } from "../../../src/pipeline/execution/phase-executor.js";
+import { analyzeTokenUsage } from "../../../src/review/token-estimator.js";
+
+const mockRunClaude = vi.mocked(runClaude);
+const mockRunCli = vi.mocked(runCli);
+const mockAnalyzeTokenUsage = vi.mocked(analyzeTokenUsage);
+
+function makeCtx(overrides: Partial<PhaseExecutorContext> = {}): PhaseExecutorContext {
+  return {
+    issue: { number: 42, title: "Fix bug", body: "Fix it", labels: [] },
+    plan: {
+      issueNumber: 42,
+      title: "Fix plan",
+      problemDefinition: "A bug",
+      requirements: [],
+      affectedFiles: [],
+      risks: [],
+      phases: [
+        {
+          index: 0,
+          name: "Phase One",
+          description: "Do something",
+          targetFiles: ["src/foo.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: [],
+          dependsOn: [],
+        },
+      ],
+      verificationPoints: [],
+      stopConditions: [],
+    },
+    phase: {
+      index: 0,
+      name: "Phase One",
+      description: "Do something",
+      targetFiles: ["src/foo.ts"],
+      commitStrategy: "atomic",
+      verificationCriteria: [],
+      dependsOn: [],
+    },
+    previousResults: [],
+    claudeConfig: {
+      path: "claude",
+      model: "model-primary",
+      models: {
+        plan: "model-primary",
+        phase: "model-primary",
+        review: "model-review",
+        fallback: "model-fallback",
+      },
+      maxTurns: 1,
+      timeout: 5000,
+      additionalArgs: [],
+    },
+    promptsDir: "/tmp/prompts",
+    cwd: "/tmp/project",
+    testCommand: "",
+    lintCommand: "",
+    gitPath: "git",
+    gitConfig: {
+      commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}",
+    },
+    ...overrides,
+  };
+}
+
+function mockSuccessRunCliSequence(): void {
+  mockRunCli
+    .mockResolvedValueOnce({ stdout: "startabc123", stderr: "", exitCode: 0 }) // getHeadHash (phaseStartHash)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // diff committed (scope guard)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // diff uncommitted (scope guard)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // git status --porcelain (autoCommit, clean)
+    .mockResolvedValueOnce({ stdout: "finaldef456", stderr: "", exitCode: 0 }); // getHeadHash (final)
+}
+
+describe("executePhase QUOTA_EXHAUSTED fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAnalyzeTokenUsage.mockReturnValue({
+      estimatedTokens: 1000,
+      modelLimit: 200000,
+      effectiveLimit: 160000,
+      exceedsLimit: false,
+      usagePercentage: 0.6,
+    });
+  });
+
+  it("falls back to second model when first model returns QUOTA_EXHAUSTED", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "You've hit your limit · resets Apr 15, 2pm" })
+      .mockResolvedValueOnce({ success: true, output: "done" });
+    mockSuccessRunCliSequence();
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+    expect(mockRunClaude.mock.calls[0][0].config.model).toBe("model-primary");
+    expect(mockRunClaude.mock.calls[1][0].config.model).toBe("model-fallback");
+  });
+
+  it("fails when all fallback models are exhausted or fail", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "You've hit your limit · resets Apr 15, 2pm" })
+      .mockResolvedValueOnce({ success: false, output: "Claude failed: unexpected error" });
+    mockRunCli.mockResolvedValue({ stdout: "startabc123", stderr: "", exitCode: 0 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fall back when failure is not QUOTA_EXHAUSTED", async () => {
+    mockRunClaude.mockResolvedValueOnce({ success: false, output: "TS2345: type error in file" });
+    mockRunCli.mockResolvedValue({ stdout: "startabc123", stderr: "", exitCode: 0 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(false);
+    // Should fail immediately without trying fallback model
+    expect(mockRunClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses explicit modelFallbackChain when provided", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "usage limit reached" })
+      .mockResolvedValueOnce({ success: true, output: "done" });
+    mockSuccessRunCliSequence();
+
+    const ctx = makeCtx({
+      claudeConfig: {
+        path: "claude",
+        model: "chain-model-a",
+        models: {
+          plan: "chain-model-a",
+          phase: "chain-model-a",
+          review: "chain-model-a",
+          fallback: "chain-model-a",
+        },
+        modelFallbackChain: ["chain-model-a", "chain-model-b"],
+        maxTurns: 1,
+        timeout: 5000,
+        additionalArgs: [],
+      },
+    });
+
+    const result = await executePhase(ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+    expect(mockRunClaude.mock.calls[1][0].config.model).toBe("chain-model-b");
+  });
+});

--- a/tests/pipeline/reporting/result-reporter.test.ts
+++ b/tests/pipeline/reporting/result-reporter.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { formatResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import type { Plan, PhaseResult } from "../../../src/types/pipeline.js";
+
+function makePlan(overrides: Partial<Plan> = {}): Plan {
+  return {
+    issueNumber: 42,
+    title: "Test Plan",
+    problemDefinition: "Fix a bug",
+    requirements: [],
+    affectedFiles: [],
+    risks: [],
+    phases: [
+      { index: 0, name: "Phase 1", description: "First", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+    ],
+    verificationPoints: [],
+    stopConditions: [],
+    ...overrides,
+  };
+}
+
+describe("formatResult usedModel field", () => {
+  it("includes usedModel in phase report when fallback model was used", () => {
+    const results: PhaseResult[] = [
+      {
+        phaseIndex: 0,
+        phaseName: "Phase 1",
+        success: true,
+        commitHash: "abc12345",
+        durationMs: 1000,
+        usedModel: "claude-haiku-4-5-20251001",
+      },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.phases[0].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("has undefined usedModel when not set in PhaseResult", () => {
+    const results: PhaseResult[] = [
+      {
+        phaseIndex: 0,
+        phaseName: "Phase 1",
+        success: true,
+        commitHash: "abc12345",
+        durationMs: 1000,
+      },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.phases[0].usedModel).toBeUndefined();
+  });
+
+  it("maps usedModel for each phase independently", () => {
+    const plan = makePlan({
+      phases: [
+        { index: 0, name: "Phase 1", description: "First", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+        { index: 1, name: "Phase 2", description: "Second", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+      ],
+    });
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+      { phaseIndex: 1, phaseName: "Phase 2", success: true, durationMs: 2000, usedModel: "claude-haiku-4-5-20251001" },
+    ];
+    const report = formatResult(42, "test/repo", plan, results, Date.now() - 3000);
+    expect(report.phases[0].usedModel).toBeUndefined();
+    expect(report.phases[1].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #719 — feat: phase 모델 fallback 체인 — sonnet 한도 도달 시 자동으로 haiku/다른 모델로 우회

sonnet 한도 도달 시 QUOTA_EXHAUSTED로 즉시 실패하며, haiku 한도 여유가 있어도 자동 우회 불가. 비개발자가 수동으로 config의 phase 모델을 변경해야 하는 UX 문제. #717에서 QUOTA_EXHAUSTED 카테고리가 이미 분리되었으므로, 이를 감지하여 fallback chain의 다음 모델로 자동 재시도하는 로직이 필요.

## Requirements

- config에 commands.claudeCli.modelFallbackChain 옵션 추가 (예: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"])
- phase 실행 시 첫 모델로 호출 → QUOTA_EXHAUSTED 카테고리 응답이면 다음 모델로 자동 재시도
- 모든 fallback 모델 소진 시 비로소 QUOTA_EXHAUSTED 최종 실패
- 잡 결과 리포트에 어떤 모델로 실행됐는지 표시 (Model Usage 테이블에 fallback 분기 표기)

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: Config 3중 동기화: modelFallbackChain 필드 추가 — SUCCESS (cbf1c115)
- Phase 1: Model Router에 fallback chain 해석 함수 추가 — SUCCESS (66741c62)
- Phase 2: Phase Executor에 QUOTA_EXHAUSTED fallback 로직 추가 — SUCCESS (0135c275)
- Phase 3: 리포트에 fallback 모델 사용 표기 추가 — SUCCESS (b3bfc5a0)
- Phase 4: 테스트 작성 — SUCCESS (2a2b2dc5)

## Risks

- phase-executor의 try-catch 구조 변경 시 기존 에러 핸들링 경로에 영향 가능 — QUOTA_EXHAUSTED만 분기하고 나머지는 기존 로직 유지 필수
- fallback 모델도 QUOTA_EXHAUSTED일 경우 무한 루프 방지 — chain 순회는 한 번만, 이미 시도한 모델은 스킵
- modelFallbackChain과 기존 models.fallback의 역할 혼동 — models.fallback은 코드 에러 retry용, modelFallbackChain은 quota 소진 시 모델 교체용으로 명확히 분리

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $4.9081 (review: $0.2224)
- **Phases**: 6/6 completed
- **Branch**: `aq/719-feat-phase-fallback-sonnet-haiku` → `develop`
- **Tokens**: 311 input, 70821 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| Config 3중 동기화: modelFallbackChain 필드 추가 | $0.5056 | 0 | $0.0000 |
| Model Router에 fallback chain 해석 함수 추가 | $0.2300 | 0 | $0.0000 |
| Phase Executor에 QUOTA_EXHAUSTED fallback 로직 추가 | $1.3670 | 0 | $0.0000 |
| 리포트에 fallback 모델 사용 표기 추가 | $0.6299 | 0 | $0.0000 |
| 테스트 작성 | $1.3417 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $4.0742 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #719