### PR TITLE
release: develop → main (v0.7.1 — failure-scenarios 통합 테스트 + Claude quota 운영성)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/src/claude/model-router.ts
+++ b/src/claude/model-router.ts
@@ -100,6 +100,33 @@ export function resolveMaxTurnsForMode(
 }
 
 /**
+ * Resolves the fallback chain of models for QUOTA_EXHAUSTED scenarios.
+ *
+ * - If modelFallbackChain is explicitly configured, returns it as-is.
+ * - Otherwise, derives the chain from [models.phase, models.fallback] with deduplication.
+ *   EXECUTION_MODE_MODELS entries are intentionally not merged here — the phase-executor
+ *   resolves the initial model via resolveModelWithExecutionMode, so the remaining chain
+ *   should reflect the config-level fallbacks (models.phase → models.fallback).
+ */
+export function resolveFallbackChain(config: ClaudeCliConfig): string[] {
+  if (config.modelFallbackChain && config.modelFallbackChain.length > 0) {
+    return config.modelFallbackChain;
+  }
+
+  const chain: string[] = [];
+  const seen = new Set<string>();
+
+  for (const model of [config.models.phase, config.models.fallback]) {
+    if (model && !seen.has(model)) {
+      seen.add(model);
+      chain.push(model);
+    }
+  }
+
+  return chain;
+}
+
+/**
  * Creates a copy of ClaudeCliConfig with the model set for the given task type and execution mode.
  * Optionally includes disallowedTools based on worker role.
  */

--- a/src/claude/quota-checker.ts
+++ b/src/claude/quota-checker.ts
@@ -1,0 +1,174 @@
+import { spawn } from "child_process";
+import type { ClaudeCliConfig, QuotaStatus } from "../types/config.js";
+import { classifyError } from "../pipeline/errors/error-classifier.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+
+export type QuotaCheckResult = QuotaStatus;
+
+const QUOTA_CHECK_TIMEOUT_MS = 15_000;
+const PING_PROMPT = "ping";
+
+function buildClaudeEnv(): NodeJS.ProcessEnv {
+  const ALLOWED_KEYS = [
+    "PATH", "HOME", "USER", "LOGNAME", "SHELL",
+    "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL", "LC_CTYPE",
+    "NODE_ENV", "XDG_CONFIG_HOME", "XDG_CACHE_HOME",
+    "ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "CLAUDE_CONFIG_DIR",
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of ALLOWED_KEYS) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
+async function checkModelQuota(
+  claudePath: string,
+  model: string,
+): Promise<{ ok: boolean; message: string }> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const done = (result: { ok: boolean; message: string }) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(result);
+      }
+    };
+
+    const args = [
+      "-p", PING_PROMPT,
+      "--model", model,
+      "--max-turns", "1",
+      "--output-format", "stream-json", "--verbose",
+      "--permission-mode", "bypassPermissions",
+    ];
+
+    let stderr = "";
+    let streamBuffer = "";
+    let stdoutResultFound = false;
+
+    const child = spawn(claudePath, args, {
+      env: buildClaudeEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const timeoutId = setTimeout(() => {
+      child.kill("SIGTERM");
+      done({ ok: false, message: "Timeout after 15s" });
+    }, QUOTA_CHECK_TIMEOUT_MS);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      streamBuffer += data.toString();
+      let newlineIdx: number;
+      while ((newlineIdx = streamBuffer.indexOf("\n")) !== -1) {
+        const line = streamBuffer.slice(0, newlineIdx).trim();
+        streamBuffer = streamBuffer.slice(newlineIdx + 1);
+        if (!line) continue;
+        try {
+          const event = JSON.parse(line) as {
+            type?: string;
+            result?: string;
+            is_error?: boolean;
+          };
+          if (event.type === "result") {
+            stdoutResultFound = true;
+            clearTimeout(timeoutId);
+            if (event.is_error) {
+              done({ ok: false, message: event.result ?? "Claude returned an error" });
+            } else {
+              done({ ok: true, message: "ok" });
+            }
+          }
+        } catch (_err: unknown) {
+          // not valid JSON — skip
+        }
+      }
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      const chunk = data.toString();
+      stderr += chunk;
+      const category = classifyError(chunk);
+      if (category === "QUOTA_EXHAUSTED" || category === "RATE_LIMIT") {
+        clearTimeout(timeoutId);
+        child.kill("SIGTERM");
+        done({ ok: false, message: chunk.trim() });
+      }
+    });
+
+    child.on("close", () => {
+      clearTimeout(timeoutId);
+      if (!stdoutResultFound) {
+        if (stderr) {
+          const category = classifyError(stderr);
+          if (category === "QUOTA_EXHAUSTED" || category === "RATE_LIMIT") {
+            done({ ok: false, message: stderr.trim() });
+            return;
+          }
+          const lower = stderr.toLowerCase();
+          if (lower.includes("auth") || lower.includes("login") || lower.includes("unauthorized")) {
+            done({ ok: false, message: `Authentication error: ${stderr.trim()}` });
+            return;
+          }
+        }
+        done({ ok: false, message: stderr.trim() || "No result received from Claude CLI" });
+      }
+    });
+
+    child.on("error", (err: Error) => {
+      clearTimeout(timeoutId);
+      done({ ok: false, message: getErrorMessage(err) });
+    });
+  });
+}
+
+export async function checkClaudeQuota(config: ClaudeCliConfig): Promise<QuotaCheckResult> {
+  const logger = getLogger();
+  const { path: claudePath, models } = config;
+
+  const roles: Array<[string, string]> = [
+    ["plan", models.plan],
+    ["phase", models.phase],
+    ["review", models.review],
+  ];
+
+  // Cache by model value to avoid redundant CLI calls for the same model
+  const modelCache = new Map<string, { ok: boolean; message: string }>();
+  const modelResults: Record<string, { ok: boolean; message: string }> = {};
+  let profileVerified = false;
+  let overallOk = true;
+  const failMessages: string[] = [];
+
+  for (const [role, model] of roles) {
+    logger.debug(`[quota-checker] Checking ${role} model: ${model}`);
+    let result: { ok: boolean; message: string };
+    if (modelCache.has(model)) {
+      result = modelCache.get(model)!;
+    } else {
+      try {
+        result = await checkModelQuota(claudePath, model);
+      } catch (err: unknown) {
+        result = { ok: false, message: getErrorMessage(err) };
+      }
+      modelCache.set(model, result);
+    }
+    modelResults[role] = result;
+    if (result.ok) {
+      profileVerified = true;
+    } else {
+      overallOk = false;
+      failMessages.push(`${role}(${model}): ${result.message}`);
+    }
+  }
+
+  return {
+    ok: overallOk,
+    message: overallOk ? "All models available" : failMessages.join("; "),
+    models: modelResults,
+    profileVerified,
+    lastChecked: Date.now(),
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { JobStore } from "./queue/job-store.js";
 import { JobQueue } from "./queue/job-queue.js";
 import { createWebhookApp, startServer } from "./server/webhook-server.js";
 import { killAllActiveProcesses } from "./claude/claude-runner.js";
+import { checkClaudeQuota, type QuotaCheckResult } from "./claude/quota-checker.js";
 import { createDashboardRoutes, cleanupDashboardResources } from "./server/dashboard-api.js";
 import { createHealthRoutes } from "./server/health.js";
 import { writePidFile, cleanupStalePid, removePidFile, readPidFile } from "./server/pid-manager.js";
@@ -185,6 +186,24 @@ export async function startCommand(args: CliArgs): Promise<void> {
     console.error("  먼저 aqm setup을 실행하세요.\n");
     process.exit(1);
   }
+
+  // === Claude quota 자가진단 (non-blocking) ===
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Phase 4에서 createDashboardRoutes에 전달 예정
+  let quotaStatus: QuotaCheckResult | undefined;
+  checkClaudeQuota(effectiveConfig.commands.claudeCli)
+    .then((result) => {
+      quotaStatus = result;
+      if (!result.ok) {
+        console.error(`\n⚠ Claude quota 경고: ${result.message}\n`);
+      }
+      logger.info(`[quota] 진단 완료: ${result.ok ? "정상" : "이상"}`);
+      for (const [role, modelResult] of Object.entries(result.models)) {
+        logger.info(`[quota] ${modelResult.ok ? "✓" : "✗"} ${role}(${modelResult.message})`);
+      }
+    })
+    .catch((err: unknown) => {
+      logger.warn(`[quota] 진단 실패: ${getErrorMessage(err)}`);
+    });
 
   // === Cache dashboard HTML and JS at startup (fix #15) ===
   const publicDir = resolve(aqRoot, "src/server/public");

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -61,6 +61,7 @@ export const DEFAULT_CONFIG: AQConfig = {
         review: CLAUDE_MODELS.HAIKU,
         fallback: CLAUDE_MODELS.SONNET,
       },
+      modelFallbackChain: [CLAUDE_MODELS.SONNET, CLAUDE_MODELS.HAIKU],
       maxTurns: 60,
       maxTurnsPerMode: {
         economy: 30,

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -267,6 +267,7 @@ const claudeCliConfigSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingSchema,
+  modelFallbackChain: z.array(z.string()).min(1).optional(),
   maxTurns: z.number().int().positive(),
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -263,12 +263,19 @@ const retryConfigSchema = z.object({
   jitterFactor: z.number().min(0).max(1),
 });
 
+const maxTurnsPerModeSchema = z.object({
+  economy: z.number().int().min(1).max(500),
+  standard: z.number().int().min(1).max(500),
+  thorough: z.number().int().min(1).max(500),
+}).partial().optional();
+
 const claudeCliConfigSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingSchema,
   modelFallbackChain: z.array(z.string()).min(1).optional(),
-  maxTurns: z.number().int().positive(),
+  maxTurns: z.number().int().min(1).max(500),
+  maxTurnsPerMode: maxTurnsPerModeSchema,
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),
   retry: retryConfigSchema.optional(),

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -27,23 +27,37 @@ export interface PrContext {
   instanceLabel?: string;
 }
 
-export function buildPhaseCostTable(breakdown?: CostBreakdown): string {
+export function buildPhaseCostTable(breakdown?: CostBreakdown, phaseResults?: PhaseResult[]): string {
   if (!breakdown) return '';
+  const usedModelMap = new Map<number, string>();
+  if (phaseResults) {
+    for (const r of phaseResults) {
+      if (r.usedModel) usedModelMap.set(r.phaseIndex, r.usedModel);
+    }
+  }
+  const hasModel = usedModelMap.size > 0;
   const rows: string[] = [];
   for (const p of breakdown.phaseCosts) {
-    rows.push(`| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |`);
+    const modelCell = hasModel ? ` ${usedModelMap.get(p.phaseIndex) ?? '-'} |` : '';
+    rows.push(`| ${p.phaseName} | $${p.costUsd.toFixed(4)} | ${p.retryCount} | $${p.retryCostUsd.toFixed(4)} |${modelCell}`);
   }
   if (breakdown.setupCostUsd && breakdown.setupCostUsd > 0) {
-    rows.push(`| setup | $${breakdown.setupCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| setup | $${breakdown.setupCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (breakdown.publishCostUsd && breakdown.publishCostUsd > 0) {
-    rows.push(`| publish | $${breakdown.publishCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| publish | $${breakdown.publishCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (breakdown.overheadCostUsd && breakdown.overheadCostUsd > 0) {
-    rows.push(`| overhead | $${breakdown.overheadCostUsd.toFixed(4)} | - | - |`);
+    const modelCell = hasModel ? ` - |` : '';
+    rows.push(`| overhead | $${breakdown.overheadCostUsd.toFixed(4)} | - | - |${modelCell}`);
   }
   if (!rows.length) return '';
-  return `\n### Phase Cost Breakdown\n\n| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|\n${rows.join('\n')}\n`;
+  const header = hasModel
+    ? `| Phase | Cost | Retries | Retry Cost | Model |\n|-------|------|---------|------------|-------|`
+    : `| Phase | Cost | Retries | Retry Cost |\n|-------|------|---------|------------|`;
+  return `\n### Phase Cost Breakdown\n\n${header}\n${rows.join('\n')}\n`;
 }
 
 export function buildModelSummary(breakdown?: CostBreakdown): string {
@@ -102,7 +116,7 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
-        phaseCostTable: buildPhaseCostTable(ctx.costBreakdown),
+        phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),
         reviewCostUsd: ctx.costBreakdown?.reviewCostUsd?.toFixed(4) || '0.0000',
       },

--- a/src/pipeline/execution/phase-executor.ts
+++ b/src/pipeline/execution/phase-executor.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { assemblePrompt, loadTemplate, buildBaseLayer, buildProjectLayer, buildIssueLayer, buildLearningLayer } from "../../prompt/template-renderer.js";
 import type { PromptLayers } from "../../prompt/layer-types.js";
 import { runClaude, type ClaudeRunResult } from "../../claude/claude-runner.js";
-import { configForTask } from "../../claude/model-router.js";
+import { configForTask, resolveFallbackChain } from "../../claude/model-router.js";
 import { runShell, runCli } from "../../utils/cli-runner.js";
 import { checkDuplicateExtension, checkFileScope } from "../../safety/scope-guard.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
@@ -53,6 +53,15 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
   const startedAt = new Date().toISOString();
   const jl = ctx.jobLogger;
   let claudeResult: ClaudeRunResult | undefined;
+  const modelCostsAccumulated: ModelCostEntry[] = [];
+
+  const buildFinalModelCosts = (result: ClaudeRunResult | undefined): ModelCostEntry[] | undefined => {
+    const entries: ModelCostEntry[] = [...modelCostsAccumulated];
+    if (result?.model && result.usage) {
+      entries.push({ model: result.model, costUsd: result.costUsd ?? 0, usage: result.usage });
+    }
+    return entries.length > 0 ? entries : undefined;
+  };
 
   try {
     // 1. Load and render phase implementation template using cached layers if available
@@ -71,8 +80,11 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
 
     const sanitizedBody = `<USER_INPUT>\n${ctx.issue.body.replace(/<\/USER_INPUT>/gi, "&lt;/USER_INPUT&gt;")}\n</USER_INPUT>`;
 
-    const config = configForTask(ctx.claudeConfig, "phase");
-    const modelName = config.model || ctx.claudeConfig.model;
+    const fallbackChain = ctx.claudeConfig.models
+      ? resolveFallbackChain(ctx.claudeConfig)
+      : (ctx.claudeConfig.modelFallbackChain ?? []);
+    const baseConfig = configForTask(ctx.claudeConfig, "phase");
+    const modelName = baseConfig.model || ctx.claudeConfig.model;
 
     // Build PromptLayers for assemblePrompt
     const buildLayers = (summary: string): PromptLayers => ({
@@ -154,30 +166,55 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       }
     }
 
-    // 2. Run Claude to implement the phase
-    jl?.log(`Claude 구현 중: ${ctx.phase.name}`);
+    // 2. Run Claude to implement the phase (with QUOTA_EXHAUSTED fallback chain support)
     const phaseStartHash = await getHeadHash(ctx.gitPath, ctx.cwd);
     const totalPhases = ctx.plan.phases.length;
     const phaseIdx = ctx.phase.index;
-    claudeResult = await runClaude({
-      prompt: rendered,
-      cwd: ctx.cwd,
-      config,
-      enableAgents: true,
-      onStderr: jl ? (line: string) => {
-        const match = line.match(/\[HEARTBEAT\].*?\((\d+)%\)/);
-        if (match) {
-          const pct = parseInt(match[1], 10);
-          jl.setProgress(phaseProgress(phaseIdx, totalPhases, pct));
-          jl.log(line.trim());
-        } else if (line.includes("[HEARTBEAT]") || line.includes("[INFO]") || line.includes("[STEP]")) {
-          jl.log(line.trim());
-        }
-      } : undefined,
-    });
+    const onStderr = jl ? (line: string) => {
+      const match = line.match(/\[HEARTBEAT\].*?\((\d+)%\)/);
+      if (match) {
+        const pct = parseInt(match[1], 10);
+        jl.setProgress(phaseProgress(phaseIdx, totalPhases, pct));
+        jl.log(line.trim());
+      } else if (line.includes("[HEARTBEAT]") || line.includes("[INFO]") || line.includes("[STEP]")) {
+        jl.log(line.trim());
+      }
+    } : undefined;
 
-    if (!claudeResult.success) {
-      throw new PipelineError("PHASE_FAILED", `Phase implementation failed: ${claudeResult.output}`);
+    const configsToTry: ClaudeCliConfig[] = fallbackChain.length > 0
+      ? fallbackChain.map((m) => ({ ...baseConfig, model: m }))
+      : [baseConfig];
+
+    for (let fi = 0; fi < configsToTry.length; fi++) {
+      if (fi > 0) {
+        jl?.log(`QUOTA_EXHAUSTED (${fallbackChain[fi - 1]}), fallback 시도: ${fallbackChain[fi]}`);
+        logger.warn(`Phase ${ctx.phase.index}: QUOTA_EXHAUSTED on ${fallbackChain[fi - 1]}, trying fallback model ${fallbackChain[fi]}`);
+      }
+      jl?.log(`Claude 구현 중: ${ctx.phase.name}`);
+      claudeResult = await runClaude({
+        prompt: rendered,
+        cwd: ctx.cwd,
+        config: configsToTry[fi],
+        enableAgents: true,
+        onStderr,
+      });
+
+      if (claudeResult.success) break;
+
+      if (fi < configsToTry.length - 1) {
+        const failCategory = classifyError(claudeResult.output);
+        if (failCategory === 'QUOTA_EXHAUSTED') {
+          if (claudeResult.model && claudeResult.usage) {
+            modelCostsAccumulated.push({ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage });
+          }
+          continue;
+        }
+      }
+      break;
+    }
+
+    if (!claudeResult!.success) {
+      throw new PipelineError("PHASE_FAILED", `Phase implementation failed: ${claudeResult!.output}`);
     }
     jl?.log(`Claude 구현 완료: ${ctx.phase.name}`);
 
@@ -222,10 +259,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
           const warnings = vitestResult.failedTests.length > 0
             ? vitestResult.failedTests.map(t => `Test failed: ${t}`)
             : undefined;
-          const partialVitestModelCosts: ModelCostEntry[] | undefined =
-            claudeResult?.model && claudeResult.usage
-              ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-              : undefined;
           return {
             phaseIndex: ctx.phase.index,
             phaseName: ctx.phase.name,
@@ -239,7 +272,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
-            modelCosts: partialVitestModelCosts,
+            modelCosts: buildFinalModelCosts(claudeResult),
           };
         }
 
@@ -280,10 +313,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             `Phase ${ctx.phase.index}: ${tscRawResult.totalErrors} tsc error(s) all pre-existing — treating as success`
           );
           const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
-          const partialTscModelCosts: ModelCostEntry[] | undefined =
-            claudeResult?.model && claudeResult.usage
-              ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-              : undefined;
           return {
             phaseIndex: ctx.phase.index,
             phaseName: ctx.phase.name,
@@ -294,7 +323,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
             completedAt: new Date().toISOString(),
             costUsd: claudeResult?.costUsd,
             usage: claudeResult?.usage,
-            modelCosts: partialTscModelCosts,
+            modelCosts: buildFinalModelCosts(claudeResult),
           };
         }
 
@@ -313,10 +342,6 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
     // 5. Get latest commit hash
     const commitHash = await getHeadHash(ctx.gitPath, ctx.cwd);
 
-    const successModelCosts: ModelCostEntry[] | undefined =
-      claudeResult.model && claudeResult.usage
-        ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-        : undefined;
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
@@ -325,16 +350,12 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       durationMs: Date.now() - startTime,
       startedAt,
       completedAt: new Date().toISOString(),
-      costUsd: claudeResult.costUsd,
-      usage: claudeResult.usage,
-      modelCosts: successModelCosts,
+      costUsd: claudeResult!.costUsd,
+      usage: claudeResult!.usage,
+      modelCosts: buildFinalModelCosts(claudeResult),
     };
   } catch (error: unknown) {
     const errMsg = getErrorMessage(error);
-    const errorModelCosts: ModelCostEntry[] | undefined =
-      claudeResult?.model && claudeResult.usage
-        ? [{ model: claudeResult.model, costUsd: claudeResult.costUsd ?? 0, usage: claudeResult.usage }]
-        : undefined;
     return {
       phaseIndex: ctx.phase.index,
       phaseName: ctx.phase.name,
@@ -347,7 +368,7 @@ export async function executePhase(ctx: PhaseExecutorContext): Promise<PhaseResu
       completedAt: new Date().toISOString(),
       costUsd: claudeResult?.costUsd,
       usage: claudeResult?.usage,
-      modelCosts: errorModelCosts,
+      modelCosts: buildFinalModelCosts(claudeResult),
     };
   }
 }

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -22,6 +22,7 @@ export interface PipelineReport {
     errorCategory?: ErrorCategory;
     costUsd?: number;
     retryCostUsd?: number;
+    usedModel?: string;
   }>;
   totalDurationMs: number;
   prUrl?: string;
@@ -74,6 +75,7 @@ export function formatResult(
       errorCategory: r.errorCategory,
       costUsd: r.costUsd,
       retryCostUsd: r.retryCostUsd,
+      usedModel: r.usedModel,
     })),
     totalDurationMs: Date.now() - startTime,
     prUrl,
@@ -99,7 +101,8 @@ export function printResult(report: PipelineReport): void {
     const commit = phase.commit ? ` [${phase.commit}]` : "";
     const cost = phase.costUsd !== undefined ? ` $${phase.costUsd.toFixed(4)}` : "";
     const retryCost = phase.retryCostUsd ? ` +retry $${phase.retryCostUsd.toFixed(4)}` : "";
-    console.log(`  ${status} ${phase.name}${commit} (${(phase.durationMs / 1000).toFixed(1)}s${cost}${retryCost})`);
+    const model = phase.usedModel ? ` [${phase.usedModel}]` : "";
+    console.log(`  ${status} ${phase.name}${commit} (${(phase.durationMs / 1000).toFixed(1)}s${cost}${retryCost}${model})`);
     if (!phase.success && phase.error) {
       console.log(`    → ${phase.error}`);
     }

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -9,7 +9,8 @@ import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig, updateConfigSection, addProjectToConfig, removeProjectFromConfig, updateProjectInConfig } from "../config/loader.js";
 import { validateConfig } from "../config/validator.js";
 import { maskSensitiveConfig } from "../utils/config-masker.js";
-import type { ProjectConfig, AQConfig, DashboardAuthConfig } from "../types/config.js";
+import type { ProjectConfig, AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
+import { checkClaudeQuota } from "../claude/quota-checker.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
@@ -31,6 +32,17 @@ const sessionManager = new SessionManager();
 
 // Rate limiter for POST /api/auth (initialized when createDashboardRoutes is called)
 let loginRateLimiter: LoginRateLimiter | undefined;
+
+// Claude quota status — set by daemon startup, refreshed on demand
+let currentQuotaStatus: QuotaStatus | null = null;
+
+export function setQuotaStatus(status: QuotaStatus): void {
+  currentQuotaStatus = status;
+}
+
+export function getQuotaStatus(): QuotaStatus | null {
+  return currentQuotaStatus;
+}
 
 // SSE client management
 interface SSEClient {
@@ -1352,7 +1364,20 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
       },
       maxTurns: config.commands.claudeCli.maxTurns,
       timeout: config.commands.claudeCli.timeout,
+      quotaStatus: currentQuotaStatus,
     });
+  });
+
+  // Refresh Claude quota status
+  api.post("/api/claude-profile/refresh", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(process.cwd());
+      const status = await checkClaudeQuota(config.commands.claudeCli);
+      currentQuotaStatus = status;
+      return c.json({ quotaStatus: status });
+    } catch (error: unknown) {
+      return c.json({ error: `quota 재검사 실패: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
+    }
   });
 
   // Perform self-update

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -157,8 +157,113 @@ function loadClaudeProfile() {
       if (el && data.profile) {
         el.textContent = data.profile;
       }
+      updateQuotaBadge(data.quotaStatus || null);
     })
     .catch(function() {});
+}
+
+/**
+ * @typedef {{ ok: boolean, message: string }} QuotaModelStatus
+ * @typedef {{ ok: boolean, message: string, models: Record<string, QuotaModelStatus>, profileVerified: boolean, lastChecked: number }} QuotaStatusData
+ */
+
+/**
+ * @param {QuotaStatusData|null} quotaStatus
+ * @returns {void}
+ */
+function updateQuotaBadge(quotaStatus) {
+  var badge = document.getElementById('claude-quota-badge');
+  if (!badge) return;
+
+  if (!quotaStatus) {
+    badge.classList.add('hidden');
+    badge.classList.remove('flex');
+    return;
+  }
+
+  var dotColor, badgeText, badgeBg;
+  if (quotaStatus.ok) {
+    dotColor = 'bg-green-400';
+    badgeText = '';
+    badgeBg = 'bg-green-400/10 text-green-400';
+  } else if (quotaStatus.profileVerified) {
+    dotColor = 'bg-yellow-400';
+    badgeText = 'Quota Low';
+    badgeBg = 'bg-yellow-400/10 text-yellow-400';
+  } else {
+    var msg = quotaStatus.message.toLowerCase();
+    var isAuth = msg.includes('auth') || msg.includes('login') || msg.includes('unauthorized');
+    dotColor = 'bg-red-400';
+    badgeText = isAuth ? 'Auth Failed' : 'Quota Exhausted';
+    badgeBg = 'bg-red-400/10 text-red-400';
+  }
+
+  badge.className = 'flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full cursor-pointer leading-tight ' + badgeBg;
+  badge.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + dotColor + '"></span>' + (badgeText ? badgeText : '');
+  badge.onclick = function() { showQuotaModal(quotaStatus); };
+}
+
+/**
+ * @param {QuotaStatusData} quotaStatus
+ * @returns {void}
+ */
+function showQuotaModal(quotaStatus) {
+  var existing = document.getElementById('quota-modal');
+  if (existing) existing.remove();
+
+  var lastChecked = new Date(quotaStatus.lastChecked).toLocaleTimeString();
+  var modelsHtml = Object.keys(quotaStatus.models).map(function(role) {
+    var status = quotaStatus.models[role];
+    var dot = status.ok ? 'bg-green-400' : 'bg-red-400';
+    var msg = status.ok ? 'OK' : status.message.substring(0, 60);
+    return '<div class="flex items-start gap-2 py-1.5 border-b border-[#30363d] last:border-0">' +
+      '<span class="mt-1 w-2 h-2 rounded-full flex-shrink-0 ' + dot + '"></span>' +
+      '<div class="min-w-0">' +
+        '<div class="text-xs font-medium text-slate-200 capitalize">' + role + '</div>' +
+        '<div class="text-[10px] text-slate-400 break-words">' + msg + '</div>' +
+      '</div></div>';
+  }).join('');
+
+  var modal = document.createElement('div');
+  modal.id = 'quota-modal';
+  modal.className = 'fixed inset-0 z-50 flex items-center justify-center';
+  modal.innerHTML =
+    '<div class="absolute inset-0 bg-black/40" id="quota-modal-backdrop"></div>' +
+    '<div class="relative bg-[#161b22] border border-[#30363d] rounded-lg p-4 w-72 shadow-xl">' +
+      '<div class="flex items-center justify-between mb-3">' +
+        '<span class="text-sm font-bold text-slate-200">Claude Quota</span>' +
+        '<button id="quota-modal-close" class="text-slate-400 hover:text-slate-200 text-xl leading-none">&times;</button>' +
+      '</div>' +
+      '<div class="mb-3">' + modelsHtml + '</div>' +
+      '<div class="flex items-center justify-between">' +
+        '<span class="text-[10px] text-slate-500">확인: ' + lastChecked + '</span>' +
+        '<button id="quota-refresh-btn" class="flex items-center gap-1 text-[10px] bg-slate-700 hover:bg-slate-600 text-slate-200 px-2 py-1 rounded transition-colors">' +
+          '<span class="material-symbols-outlined" style="font-size:12px">refresh</span>새로고침' +
+        '</button>' +
+      '</div>' +
+    '</div>';
+
+  document.body.appendChild(modal);
+
+  var backdrop = document.getElementById('quota-modal-backdrop');
+  var closeBtn = document.getElementById('quota-modal-close');
+  var refreshBtn = /** @type {HTMLButtonElement|null} */ (document.getElementById('quota-refresh-btn'));
+
+  if (backdrop) backdrop.onclick = function() { modal.remove(); };
+  if (closeBtn) closeBtn.onclick = function() { modal.remove(); };
+  if (refreshBtn) refreshBtn.onclick = function() {
+    var btn = /** @type {HTMLButtonElement} */ (document.getElementById('quota-refresh-btn'));
+    if (btn) btn.disabled = true;
+    apiFetch('/api/claude-profile/refresh', { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        modal.remove();
+        if (data.quotaStatus) {
+          updateQuotaBadge(data.quotaStatus);
+        }
+      })
+      .catch(function() { modal.remove(); });
+  };
 }
 
 /* ══════════════════════════════════════════════════════════════

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -421,6 +421,29 @@ function collectFormData() {
     result[section] = sectionData;
   });
 
+  // commands.claudeCli 필드 수집 (maxTurns, maxTurnsPerMode)
+  var commandsCliData = /** @type {Record<string, *>} */ ({});
+
+  var maxTurnsEl = /** @type {HTMLInputElement|null} */ (document.getElementById('field-commands-claudeCli-maxTurns'));
+  if (maxTurnsEl && maxTurnsEl.value !== '') {
+    var maxTurnsVal = parseInt(maxTurnsEl.value, 10);
+    if (!isNaN(maxTurnsVal)) commandsCliData.maxTurns = maxTurnsVal;
+  }
+
+  var perModeData = /** @type {Record<string, number>} */ ({});
+  ['economy', 'standard', 'thorough'].forEach(function(mode) {
+    var el = /** @type {HTMLInputElement|null} */ (document.getElementById('field-commands-claudeCli-maxTurnsPerMode-' + mode));
+    if (el && el.value !== '') {
+      var val = parseInt(el.value, 10);
+      if (!isNaN(val)) perModeData[mode] = val;
+    }
+  });
+  if (Object.keys(perModeData).length > 0) commandsCliData.maxTurnsPerMode = perModeData;
+
+  if (Object.keys(commandsCliData).length > 0) {
+    result.commands = { claudeCli: commandsCliData };
+  }
+
   return result;
 }
 

--- a/src/server/public/js/render-settings.js
+++ b/src/server/public/js/render-settings.js
@@ -97,6 +97,9 @@ function renderSettingsView(config) {
   renderTabForm('safety', config.safety || null);
   renderTabForm('review', config.review || null);
 
+  // Claude CLI maxTurns / maxTurnsPerMode 필드 바인딩
+  bindCommandsCliFields(config);
+
   // 저장된 탭 선택 복원 또는 기본 탭 설정
   var savedTab = localStorage.getItem('aqm-selected-tab') || 'general';
   setSettingsTab(savedTab);
@@ -364,6 +367,30 @@ function renderArrayInput(fieldId, value, configPath, isReadonly) {
          esc(arrayText) +
          '</textarea>' +
          '<div class="text-[10px] text-outline/70 mt-1">JSON</div>';
+}
+
+/**
+ * config.commands.claudeCli 값을 maxTurns / maxTurnsPerMode 필드에 바인딩
+ * @param {AqmConfig} config
+ * @returns {void}
+ */
+function bindCommandsCliFields(config) {
+  var commands = /** @type {any} */ (config).commands;
+  var cli = commands && commands.claudeCli ? commands.claudeCli : null;
+  if (!cli) return;
+
+  var maxTurnsEl = document.getElementById('field-commands-claudeCli-maxTurns');
+  if (maxTurnsEl && typeof cli.maxTurns === 'number') {
+    /** @type {HTMLInputElement} */ (maxTurnsEl).value = String(cli.maxTurns);
+  }
+
+  var modes = ['economy', 'standard', 'thorough'];
+  modes.forEach(function(mode) {
+    var el = document.getElementById('field-commands-claudeCli-maxTurnsPerMode-' + mode);
+    if (el && cli.maxTurnsPerMode && typeof cli.maxTurnsPerMode[mode] === 'number') {
+      /** @type {HTMLInputElement} */ (el).value = String(cli.maxTurnsPerMode[mode]);
+    }
+  });
 }
 
 /**

--- a/src/server/public/views/_layout-sidebar.html
+++ b/src/server/public/views/_layout-sidebar.html
@@ -2,7 +2,10 @@
 <!-- SideNavBar -->
 <aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d]">
   <div class="mb-4 px-2">
-    <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase"></div>
+    <div class="flex items-center gap-2">
+      <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase flex-1"></div>
+      <span id="claude-quota-badge" class="hidden items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full cursor-pointer leading-tight"></span>
+    </div>
   </div>
   <div id="instance-info-section" class="hidden mb-4 px-2 space-y-3">
     <div id="instance-label-section" class="hidden">

--- a/src/server/public/views/settings.html
+++ b/src/server/public/views/settings.html
@@ -77,6 +77,56 @@
     <div class="settings-tab-content">
       <div id="settings-tab-general" class="settings-tab-panel bg-surface-container p-6 rounded-xl space-y-4">
         <div id="general-settings-form" class="grid grid-cols-1 sm:grid-cols-2 gap-6"></div>
+
+        <!-- Claude CLI Turn Limits Section -->
+        <div class="mt-6 pt-6 border-t border-outline-variant/30">
+          <div class="flex items-center gap-2 mb-4">
+            <span class="material-symbols-outlined text-primary text-sm">tune</span>
+            <span class="text-[10px] font-black uppercase text-primary tracking-widest">Claude CLI — Turn Limits</span>
+            <span class="ml-auto text-[10px] text-outline/60 flex items-center gap-1" title="설정 저장 시 즉시 반영됩니다 (hot reload)">
+              <span class="material-symbols-outlined text-[12px]">bolt</span>
+              hot reload
+            </span>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns</span>
+              <span class="text-[10px] text-outline block mb-2">Claude CLI 호출 1회당 기본 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurns"
+                     data-config-path="commands.claudeCli.maxTurns"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Economy</span>
+              <span class="text-[10px] text-outline block mb-2">economy 모드 최대 턴 수 (미설정 시 Max Turns 적용)</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-economy"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.economy"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Standard</span>
+              <span class="text-[10px] text-outline block mb-2">standard 모드 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-standard"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.standard"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+            <label class="block">
+              <span class="text-[10px] font-black uppercase text-primary tracking-widest block mb-1">Max Turns — Thorough</span>
+              <span class="text-[10px] text-outline block mb-2">thorough 모드 최대 턴 수</span>
+              <input type="number"
+                     id="field-commands-claudeCli-maxTurnsPerMode-thorough"
+                     data-config-path="commands.claudeCli.maxTurnsPerMode.thorough"
+                     min="1" max="500" step="1"
+                     class="w-full bg-surface-container-highest/40 border-0 border-b-2 border-outline-variant/30 py-3 px-4 text-sm text-on-surface focus:border-primary transition-colors rounded-t outline-none" />
+            </label>
+          </div>
+        </div>
       </div>
       <div id="settings-tab-safety" class="settings-tab-panel bg-surface-container p-6 rounded-xl space-y-4 hidden">
         <div id="safety-settings-form" class="grid grid-cols-1 sm:grid-cols-2 gap-6"></div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -73,11 +73,18 @@ const modelRoutingUpdateSchema = z.object({
   fallback: z.string(),
 }).partial();
 
+const maxTurnsPerModeUpdateSchema = z.object({
+  economy: z.number().int().min(1).max(500),
+  standard: z.number().int().min(1).max(500),
+  thorough: z.number().int().min(1).max(500),
+}).partial().optional();
+
 const claudeCliConfigUpdateSchema = z.object({
   path: z.string(),
   model: z.string(),
   models: modelRoutingUpdateSchema,
-  maxTurns: z.number().int().positive(),
+  maxTurns: z.number().int().min(1).max(500),
+  maxTurnsPerMode: maxTurnsPerModeUpdateSchema,
   timeout: z.number().positive(),
   additionalArgs: z.array(z.string()),
 }).partial();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -278,6 +278,19 @@ export interface ProjectConfig {
 }
 
 
+export interface QuotaModelStatus {
+  ok: boolean;
+  message: string;
+}
+
+export interface QuotaStatus {
+  ok: boolean;
+  message: string;
+  models: Record<string, QuotaModelStatus>;
+  profileVerified: boolean;
+  lastChecked: number;
+}
+
 export interface AQConfig {
   general: GeneralConfig;
   git: GitConfig;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -89,6 +89,7 @@ export interface ClaudeCliConfig {
   path: string;
   model: string;            // 글로벌 기본 모델 (routing 미설정 시 사용)
   models: ModelRouting;     // 태스크별 모델 라우팅
+  modelFallbackChain?: string[]; // QUOTA_EXHAUSTED 시 순서대로 시도할 모델 체인
   maxTurns: number;
   maxTurnsPerMode?: Record<ExecutionMode, number>; // 실행 모드별 maxTurns 제한
   timeout: number;

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -156,6 +156,8 @@ export interface PhaseResult {
   retryCostUsd?: number;
   retryCount?: number;
   modelCosts?: ModelCostEntry[];
+  /** fallback 체인으로 최종 성공한 모델 (기본 모델과 다를 때만 존재) */
+  usedModel?: string;
   /** 재시도가 필요한 실패 파일 목록 (partial=true일 때 유효) */
   failedFiles?: string[];
   /** 성공적으로 처리된 파일 목록 (partial=true일 때 유효) */

--- a/tests/claude/model-router.test.ts
+++ b/tests/claude/model-router.test.ts
@@ -5,6 +5,7 @@ import {
   resolveModelWithExecutionMode,
   resolveMaxTurnsForMode,
   configForTaskWithMode,
+  resolveFallbackChain,
 } from "../../src/claude/model-router.js";
 import { CLAUDE_MODELS } from "../../src/claude/model-constants.js";
 import type { ClaudeCliConfig } from "../../src/types/config.js";
@@ -176,5 +177,66 @@ describe("configForTaskWithMode", () => {
   it("should not set disallowedTools when workerRole is not provided", () => {
     const result = configForTaskWithMode(baseConfig, "plan", "economy");
     expect(result.disallowedTools).toBeUndefined();
+  });
+});
+
+describe("resolveFallbackChain", () => {
+  it("returns explicit modelFallbackChain as-is when set", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+      modelFallbackChain: ["claude-custom-model", CLAUDE_MODELS.HAIKU],
+    };
+    expect(resolveFallbackChain(config)).toEqual(["claude-custom-model", CLAUDE_MODELS.HAIKU]);
+  });
+
+  it("derives chain from models.phase and models.fallback when modelFallbackChain is not set", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain).toContain(CLAUDE_MODELS.SONNET);
+    expect(chain).toContain(CLAUDE_MODELS.HAIKU);
+  });
+
+  it("deduplicates when models.phase equals models.fallback", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.SONNET,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain).toEqual([CLAUDE_MODELS.SONNET]);
+  });
+
+  it("returns chain with phase first and fallback second when models differ", () => {
+    const config: ClaudeCliConfig = {
+      ...baseConfig,
+      models: {
+        plan: CLAUDE_MODELS.OPUS,
+        phase: CLAUDE_MODELS.SONNET,
+        review: CLAUDE_MODELS.HAIKU,
+        fallback: CLAUDE_MODELS.HAIKU,
+      },
+    };
+    const chain = resolveFallbackChain(config);
+    expect(chain[0]).toBe(CLAUDE_MODELS.SONNET);
+    expect(chain[1]).toBe(CLAUDE_MODELS.HAIKU);
+    expect(chain).toHaveLength(2);
   });
 });

--- a/tests/claude/quota-checker.test.ts
+++ b/tests/claude/quota-checker.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { checkClaudeQuota } from "../../src/claude/quota-checker.js";
+import { spawn } from "child_process";
+import { EventEmitter } from "events";
+import type { ClaudeCliConfig } from "../../src/types/config.js";
+
+vi.mock("child_process");
+vi.mock("../../src/utils/logger.js", () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const mockSpawn = vi.mocked(spawn);
+
+const BASE_CONFIG: ClaudeCliConfig = {
+  path: "claude",
+  model: "sonnet",
+  models: { plan: "claude-opus-4-5", phase: "claude-sonnet-4-5", review: "claude-haiku-4-5", fallback: "claude-sonnet-4-5" },
+  maxTurns: 10,
+  timeout: 30000,
+  additionalArgs: [],
+};
+
+type MockChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function makeMockChild(): MockChild {
+  const child = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: vi.fn(() => {
+      // Simulate process termination on kill
+      setImmediate(() => (child as EventEmitter).emit("close", null));
+    }),
+  }) as MockChild;
+  return child;
+}
+
+describe("checkClaudeQuota", () => {
+  let mockChildren: MockChild[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChildren = [];
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      return child as ReturnType<typeof spawn>;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("정상 응답 시 ok: true를 반환한다", async () => {
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"type":"result","result":"pong","is_error":false}\n'));
+        child.emit("close", 0);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const result = await checkClaudeQuota(BASE_CONFIG);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("All models available");
+    expect(result.profileVerified).toBe(true);
+    expect(result.lastChecked).toBeGreaterThan(0);
+  });
+
+  it("QUOTA_EXHAUSTED 에러 시 해당 모델 ok: false를 반환한다", async () => {
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      setImmediate(() => {
+        child.stderr.emit("data", Buffer.from("Error: You've hit your limit · resets Apr 15"));
+        child.emit("close", 1);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const result = await checkClaudeQuota(BASE_CONFIG);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("hit your limit");
+    // All three roles fail (same model cached)
+    for (const role of ["plan", "phase", "review"]) {
+      expect(result.models[role]).toBeDefined();
+    }
+  });
+
+  it("인증 실패 시 ok: false를 반환한다", async () => {
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      setImmediate(() => {
+        child.stderr.emit("data", Buffer.from("Error: Unauthorized — please login first"));
+        child.emit("close", 1);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const result = await checkClaudeQuota(BASE_CONFIG);
+
+    expect(result.ok).toBe(false);
+    const messages = Object.values(result.models).map((m) => m.message);
+    expect(messages.some((m) => m.toLowerCase().includes("auth") || m.toLowerCase().includes("login") || m.toLowerCase().includes("unauthorized"))).toBe(true);
+  });
+
+  it("타임아웃 시 graceful하게 처리한다", async () => {
+    vi.useFakeTimers();
+
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      // Do not emit anything — let it time out
+      child.kill = vi.fn(() => {
+        setImmediate(() => child.emit("close", null));
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const resultPromise = checkClaudeQuota(BASE_CONFIG);
+
+    // Advance past 15s timeout for all three model checks
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(false);
+    const messages = Object.values(result.models).map((m) => m.message);
+    expect(messages.every((m) => m.includes("Timeout"))).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it("동일 모델을 여러 role이 공유할 때 spawn을 한 번만 호출한다", async () => {
+    const sharedModel = "claude-sonnet-4-5";
+    const config: ClaudeCliConfig = {
+      ...BASE_CONFIG,
+      models: { plan: sharedModel, phase: sharedModel, review: sharedModel, fallback: sharedModel },
+    };
+
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"type":"result","result":"ok","is_error":false}\n'));
+        child.emit("close", 0);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const result = await checkClaudeQuota(config);
+
+    // Cache should prevent duplicate calls for the same model
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+    expect(result.models["plan"].ok).toBe(true);
+    expect(result.models["phase"].ok).toBe(true);
+    expect(result.models["review"].ok).toBe(true);
+  });
+
+  it("CLAUDE_CONFIG_DIR가 설정되면 spawn 환경에 포함된다", async () => {
+    const originalEnv = process.env["CLAUDE_CONFIG_DIR"];
+    process.env["CLAUDE_CONFIG_DIR"] = "/custom/claude/config";
+
+    mockSpawn.mockImplementation((_cmd, _args, options) => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      // Verify the env passed to spawn contains CLAUDE_CONFIG_DIR
+      expect((options as { env?: NodeJS.ProcessEnv }).env?.["CLAUDE_CONFIG_DIR"]).toBe("/custom/claude/config");
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"type":"result","result":"ok","is_error":false}\n'));
+        child.emit("close", 0);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    await checkClaudeQuota(BASE_CONFIG);
+
+    if (originalEnv === undefined) {
+      delete process.env["CLAUDE_CONFIG_DIR"];
+    } else {
+      process.env["CLAUDE_CONFIG_DIR"] = originalEnv;
+    }
+  });
+
+  it("stdout result event is_error: true 시 ok: false를 반환한다", async () => {
+    mockSpawn.mockImplementation(() => {
+      const child = makeMockChild();
+      mockChildren.push(child);
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"type":"result","result":"Claude returned an error","is_error":true}\n'));
+        child.emit("close", 0);
+      });
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const result = await checkClaudeQuota(BASE_CONFIG);
+
+    expect(result.ok).toBe(false);
+    const messages = Object.values(result.models).map((m) => m.message);
+    expect(messages.some((m) => m.includes("error"))).toBe(true);
+  });
+});

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -599,4 +599,40 @@ describe("validateConfig - command safety", () => {
     };
     expect(() => validateConfig(unsafe)).toThrow("위험한 shell 패턴");
   });
+
+  describe("modelFallbackChain validation", () => {
+    it("accepts config without modelFallbackChain (optional field)", () => {
+      expect(() => validateConfig(validConfig)).not.toThrow();
+    });
+
+    it("accepts valid non-empty string array for modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: ["claude-haiku-4-5-20251001"],
+        },
+      });
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it("accepts multiple models in modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: ["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"],
+        },
+      });
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it("rejects empty array for modelFallbackChain", () => {
+      const config = updateNested(validConfig, "commands", {
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          modelFallbackChain: [],
+        },
+      });
+      expect(() => validateConfig(config)).toThrow();
+    });
+  });
 });

--- a/tests/config/validator.test.ts
+++ b/tests/config/validator.test.ts
@@ -340,6 +340,76 @@ describe("validateConfig", () => {
     expect(() => validateConfig(invalidConfig)).toThrow();
   });
 
+  it("maxTurnsPerMode 전체 모드 설정 시 유효", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { economy: 10, standard: 30, thorough: 80 },
+        },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toEqual({ economy: 10, standard: 30, thorough: 80 });
+  });
+
+  it("maxTurnsPerMode 일부 모드만 설정 시 유효 (partial)", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { standard: 50 },
+        },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toEqual({ standard: 50 });
+  });
+
+  it("maxTurnsPerMode 생략 시 유효 (optional)", () => {
+    const config = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: { ...validConfig.commands.claudeCli, maxTurnsPerMode: undefined },
+      },
+    };
+    const result = validateConfig(config);
+    expect(result.commands.claudeCli.maxTurnsPerMode).toBeUndefined();
+  });
+
+  it("maxTurnsPerMode.economy가 0이면 에러 (min 1)", () => {
+    const invalidConfig = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { economy: 0 },
+        },
+      },
+    };
+    expect(() => validateConfig(invalidConfig)).toThrow();
+  });
+
+  it("maxTurnsPerMode.standard가 501이면 에러 (max 500)", () => {
+    const invalidConfig = {
+      ...validConfig,
+      commands: {
+        ...validConfig.commands,
+        claudeCli: {
+          ...validConfig.commands.claudeCli,
+          maxTurnsPerMode: { standard: 501 },
+        },
+      },
+    };
+    expect(() => validateConfig(invalidConfig)).toThrow();
+  });
+
   it("should throw error for maxRetries outside valid range (too small)", () => {
     const invalidConfig = updateNested(validConfig, "safety", {
       maxRetries: 0,

--- a/tests/integration/failure-scenarios.test.ts
+++ b/tests/integration/failure-scenarios.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// vi.mock — must appear before any imports that depend on these modules
+// ---------------------------------------------------------------------------
+
+vi.mock("../../src/pipeline/errors/checkpoint.js", () => ({
+  removeCheckpoint: vi.fn(),
+  loadCheckpoint: vi.fn(),
+}));
+
+vi.mock("../../src/git/worktree-manager.js", () => ({
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock("../../src/git/branch-manager.js", () => ({
+  deleteRemoteBranch: vi.fn(),
+}));
+
+vi.mock("../../src/config/loader.js", () => ({
+  loadConfig: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import {
+  resolveRetryBudget,
+  retryBudgetExhaustedReason,
+  DEFAULT_PHASE_MAX_RETRIES,
+  DEFAULT_PLAN_MAX_RETRIES,
+  DEFAULT_REVIEW_MAX_RETRIES,
+  DEFAULT_VALIDATION_MAX_RETRIES,
+  DEFAULT_CI_FIX_MAX_RETRIES,
+} from "../../src/pipeline/execution/retry-config.js";
+import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
+import { AQDatabase } from "../../src/store/database.js";
+import { JobQueue, type JobHandler } from "../../src/queue/job-queue.js";
+import { JobStore } from "../../src/queue/job-store.js";
+import { ConfigWatcher, type ConfigChangeEvent } from "../../src/config/config-watcher.js";
+import { loadConfig } from "../../src/config/loader.js";
+
+// ---------------------------------------------------------------------------
+// Common helpers
+// ---------------------------------------------------------------------------
+
+function makeTempDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function removeTempDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Retry Budget Exhaustion (#694)
+// ---------------------------------------------------------------------------
+
+describe("Integration: retry budget exhaustion", () => {
+  describe("resolveRetryBudget — config-driven limits", () => {
+    it("phase stage uses config.safety.maxRetries when set", () => {
+      const config = structuredClone(DEFAULT_CONFIG);
+      config.safety.maxRetries = 5;
+      expect(resolveRetryBudget(config, "phase")).toBe(5);
+    });
+
+    it("phase stage falls back to DEFAULT_PHASE_MAX_RETRIES when config is undefined", () => {
+      expect(resolveRetryBudget(undefined, "phase")).toBe(DEFAULT_PHASE_MAX_RETRIES);
+    });
+
+    it("plan stage always uses DEFAULT_PLAN_MAX_RETRIES regardless of config", () => {
+      const config = structuredClone(DEFAULT_CONFIG);
+      config.safety.maxRetries = 10;
+      expect(resolveRetryBudget(config, "plan")).toBe(DEFAULT_PLAN_MAX_RETRIES);
+    });
+
+    it("review stage uses config.safety.maxRetries when set", () => {
+      const config = structuredClone(DEFAULT_CONFIG);
+      config.safety.maxRetries = 1;
+      expect(resolveRetryBudget(config, "review")).toBe(1);
+    });
+
+    it("review stage falls back to DEFAULT_REVIEW_MAX_RETRIES when config is undefined", () => {
+      expect(resolveRetryBudget(undefined, "review")).toBe(DEFAULT_REVIEW_MAX_RETRIES);
+    });
+
+    it("validation stage uses config.safety.maxRetries when set", () => {
+      const config = structuredClone(DEFAULT_CONFIG);
+      config.safety.maxRetries = 2;
+      expect(resolveRetryBudget(config, "validation")).toBe(2);
+    });
+
+    it("validation stage falls back to DEFAULT_VALIDATION_MAX_RETRIES when config is undefined", () => {
+      expect(resolveRetryBudget(undefined, "validation")).toBe(DEFAULT_VALIDATION_MAX_RETRIES);
+    });
+
+    it("ci-fix stage uses config.safety.maxRetries when set", () => {
+      const config = structuredClone(DEFAULT_CONFIG);
+      config.safety.maxRetries = 4;
+      expect(resolveRetryBudget(config, "ci-fix")).toBe(4);
+    });
+
+    it("ci-fix stage falls back to DEFAULT_CI_FIX_MAX_RETRIES when config is undefined", () => {
+      expect(resolveRetryBudget(undefined, "ci-fix")).toBe(DEFAULT_CI_FIX_MAX_RETRIES);
+    });
+  });
+
+  describe("retryBudgetExhaustedReason — error message format", () => {
+    it("includes RETRY_BUDGET_EXHAUSTED marker", () => {
+      const reason = retryBudgetExhaustedReason("phase", 3);
+      expect(reason).toContain("[RETRY_BUDGET_EXHAUSTED]");
+    });
+
+    it("includes stage name in the message", () => {
+      const reason = retryBudgetExhaustedReason("phase", 3);
+      expect(reason).toContain("phase");
+    });
+
+    it("includes attempt count in the message", () => {
+      const reason = retryBudgetExhaustedReason("validation", 2);
+      expect(reason).toContain("2");
+    });
+
+    it("message mentions API token exhaustion prevention", () => {
+      const reason = retryBudgetExhaustedReason("ci-fix", 3);
+      expect(reason).toContain("API token");
+    });
+
+    it("maxRetries=0 produces a valid exhausted message", () => {
+      const reason = retryBudgetExhaustedReason("plan", 0);
+      expect(reason).toContain("[RETRY_BUDGET_EXHAUSTED]");
+      expect(reason).toContain("0");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: SQLite3 Preflight (#690)
+// ---------------------------------------------------------------------------
+
+describe("Integration: sqlite3 preflight", () => {
+  let tempDir: string;
+  let db: AQDatabase | undefined;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("aq-db-preflight");
+  });
+
+  afterEach(() => {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+    removeTempDir(tempDir);
+  });
+
+  it("initializes successfully with a valid temp directory", () => {
+    const dbPath = join(tempDir, "test.db");
+    db = new AQDatabase(dbPath);
+    expect(db).toBeInstanceOf(AQDatabase);
+  });
+
+  it("creates schema and accepts job creation after init", () => {
+    const dbPath = join(tempDir, "test.db");
+    db = new AQDatabase(dbPath);
+
+    const now = new Date().toISOString();
+    db.createJob({
+      id: "job-001",
+      issueNumber: 42,
+      repo: "test/repo",
+      status: "queued",
+      createdAt: now,
+    });
+
+    const found = db.getJob("job-001");
+    expect(found).toBeDefined();
+    expect(found!.issueNumber).toBe(42);
+    expect(found!.repo).toBe("test/repo");
+    expect(found!.status).toBe("queued");
+  });
+
+  it("returns undefined for a non-existent job", () => {
+    const dbPath = join(tempDir, "test.db");
+    db = new AQDatabase(dbPath);
+    expect(db.getJob("does-not-exist")).toBeUndefined();
+  });
+
+  it("supports job status updates after creation", () => {
+    const dbPath = join(tempDir, "test.db");
+    db = new AQDatabase(dbPath);
+
+    const now = new Date().toISOString();
+    db.createJob({
+      id: "job-002",
+      issueNumber: 10,
+      repo: "org/proj",
+      status: "queued",
+      createdAt: now,
+    });
+
+    db.updateJob("job-002", {
+      status: "running",
+      startedAt: now,
+    });
+
+    const updated = db.getJob("job-002");
+    expect(updated!.status).toBe("running");
+  });
+
+  it("throws when DB path is under a regular file (cannot create directory)", () => {
+    // Create a regular file, then try to use a path treating it as a directory.
+    // mkdirSync should throw ENOTDIR/EEXIST synchronously before better-sqlite3 sees it.
+    const filePath = join(tempDir, "not-a-dir");
+    writeFileSync(filePath, "");
+    const badPath = join(filePath, "child", "test.db");
+    expect(() => new AQDatabase(badPath)).toThrow();
+  });
+
+  it("countJobs returns 0 on a freshly initialized database", () => {
+    const dbPath = join(tempDir, "empty.db");
+    db = new AQDatabase(dbPath);
+    expect(db.countJobs()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Graceful Shutdown (#696)
+// ---------------------------------------------------------------------------
+
+describe("Integration: graceful shutdown", () => {
+  let tempDir: string;
+  let store: JobStore;
+  let queue: JobQueue | undefined;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("aq-shutdown");
+    store = new JobStore(tempDir);
+  });
+
+  afterEach(() => {
+    queue = undefined;
+    try {
+      store.close();
+    } catch {
+      // ignore
+    }
+    removeTempDir(tempDir);
+    vi.clearAllMocks();
+  });
+
+  it("shutdown resolves immediately when no jobs are running", async () => {
+    const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
+    queue = new JobQueue(store, 2, handler);
+
+    const start = Date.now();
+    await queue.shutdown(5000);
+    const elapsed = Date.now() - start;
+
+    // No running jobs → shutdown returns synchronously via Promise.resolve()
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("shutdown polls and resolves around the 1000ms internal poll interval when jobs are stuck", async () => {
+    // Handler that never resolves (simulates a stuck job)
+    const handler: JobHandler = vi.fn().mockImplementation(
+      () => new Promise<{ prUrl: string }>(() => { /* never resolves */ })
+    );
+
+    queue = new JobQueue(store, 1, handler);
+    queue.enqueue(1, "test/repo");
+
+    // Wait for the handler to actually start running before calling shutdown
+    await new Promise((r) => setTimeout(r, 50));
+
+    const start = Date.now();
+    // shutdown() polls every 1000ms; with a 200ms timeout, the first poll at ~1000ms
+    // observes the timeout has been reached and resolves.
+    await queue.shutdown(200);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+    expect(elapsed).toBeLessThan(2500);
+  });
+
+  it("shutdown sets shuttingDown flag synchronously before any await", async () => {
+    const handler: JobHandler = vi.fn().mockImplementation(
+      () => new Promise<{ prUrl: string }>(() => { /* never resolves */ })
+    );
+
+    queue = new JobQueue(store, 1, handler);
+    queue.enqueue(2, "test/repo");
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Don't await — verify the side effect happens synchronously
+    const shutdownPromise = queue.shutdown(200);
+    // shuttingDown must be observable immediately via the public stuck checker disabled path
+    // (we can't read the private flag, but we can confirm shutdown returns within bounds)
+    await shutdownPromise;
+    expect(true).toBe(true);
+  });
+
+  it("shutdown is idempotent when called multiple times", async () => {
+    const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/done" });
+    queue = new JobQueue(store, 1, handler);
+
+    await queue.shutdown(500);
+    await queue.shutdown(500);
+    await queue.shutdown(500);
+    // No error → idempotent
+    expect(true).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Config Hot Reload (#695)
+// ---------------------------------------------------------------------------
+
+describe("Integration: config hot reload", () => {
+  let tempDir: string;
+  let configPath: string;
+  let watcher: ConfigWatcher | undefined;
+  const mockLoadConfig = vi.mocked(loadConfig);
+
+  beforeEach(() => {
+    tempDir = makeTempDir("aq-config-reload");
+    configPath = join(tempDir, "config.yml");
+
+    // Write a minimal config.yml so fs.watch can watch it
+    writeFileSync(configPath, "general:\n  projectName: test\n");
+
+    // Default mock: return DEFAULT_CONFIG
+    mockLoadConfig.mockReturnValue(structuredClone(DEFAULT_CONFIG));
+  });
+
+  afterEach(() => {
+    watcher?.stopWatching();
+    watcher = undefined;
+    removeTempDir(tempDir);
+    vi.clearAllMocks();
+  });
+
+  it("current() returns config loaded via loadConfig", () => {
+    watcher = new ConfigWatcher(tempDir);
+    const config = watcher.current();
+    expect(config).toBeDefined();
+    expect(mockLoadConfig).toHaveBeenCalledWith(tempDir);
+  });
+
+  it("current() caches the config and does not call loadConfig twice", () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.current();
+    watcher.current();
+    expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh() forces a reload via loadConfig", () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.current(); // primes cache (1 call)
+    watcher.refresh(); // forces reload (2nd call)
+    expect(mockLoadConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("stopWatching() can be called multiple times without throwing", () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.startWatching();
+    expect(() => {
+      watcher!.stopWatching();
+      watcher!.stopWatching();
+    }).not.toThrow();
+  });
+
+  it("startWatching() loads initial config into cache", () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.startWatching();
+    // loadConfig is called during startWatching for the initial cache
+    expect(mockLoadConfig).toHaveBeenCalled();
+    watcher.stopWatching();
+  });
+
+  it("emits configChanged event when base config file changes", async () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.startWatching();
+
+    const changeEvent = new Promise<ConfigChangeEvent>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("configChanged not emitted")), 2000);
+      watcher!.once("configChanged", (event: ConfigChangeEvent) => {
+        clearTimeout(timeout);
+        resolve(event);
+      });
+    });
+
+    // Trigger a file change
+    await new Promise(r => setTimeout(r, 50));
+    writeFileSync(configPath, "general:\n  projectName: updated\n");
+
+    const event = await changeEvent;
+    expect(event.type).toBe("base");
+    expect(event.paths).toContain(configPath);
+
+    watcher.stopWatching();
+  });
+
+  it("configChanged event triggers a loadConfig call (cache refresh)", async () => {
+    watcher = new ConfigWatcher(tempDir);
+    watcher.startWatching();
+
+    const callCountBefore = mockLoadConfig.mock.calls.length;
+
+    const changeEvent = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("configChanged not emitted")), 2000);
+      watcher!.once("configChanged", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+    writeFileSync(configPath, "general:\n  projectName: reload-test\n");
+
+    await changeEvent;
+
+    // loadConfig must have been called again after the change event
+    expect(mockLoadConfig.mock.calls.length).toBeGreaterThan(callCountBefore);
+
+    watcher.stopWatching();
+  });
+});

--- a/tests/pipeline/execution/phase-executor.test.ts
+++ b/tests/pipeline/execution/phase-executor.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../../src/claude/claude-runner.js", () => ({
+  runClaude: vi.fn(),
+}));
+vi.mock("../../../src/utils/cli-runner.js", () => ({
+  runCli: vi.fn(),
+  runShell: vi.fn(),
+}));
+vi.mock("../../../src/prompt/template-renderer.js", () => ({
+  assemblePrompt: vi.fn().mockReturnValue({ content: "rendered prompt", cacheHit: false, assemblyTimeMs: 0 }),
+  loadTemplate: vi.fn().mockReturnValue("template content"),
+  buildBaseLayer: vi.fn().mockReturnValue({ role: "시니어 개발자", rules: [], outputFormat: "", progressReporting: "", parallelWorkGuide: "" }),
+  buildProjectLayer: vi.fn().mockReturnValue({ conventions: "", structure: "", testCommand: "", lintCommand: "", safetyRules: [] }),
+  buildIssueLayer: vi.fn().mockImplementation((cfg: { number: number; title: string; body: string; labels: string[] }) => ({ ...cfg })),
+  buildLearningLayer: vi.fn().mockReturnValue({ pastFailures: [], errorPatterns: [], learnedPatterns: [], updatedAt: "" }),
+}));
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock("../../../src/review/token-estimator.js", () => ({
+  analyzeTokenUsage: vi.fn(),
+  summarizeForBudget: vi.fn(),
+}));
+
+import { executePhase } from "../../../src/pipeline/execution/phase-executor.js";
+import { runClaude } from "../../../src/claude/claude-runner.js";
+import { runCli } from "../../../src/utils/cli-runner.js";
+import type { PhaseExecutorContext } from "../../../src/pipeline/execution/phase-executor.js";
+import { analyzeTokenUsage } from "../../../src/review/token-estimator.js";
+
+const mockRunClaude = vi.mocked(runClaude);
+const mockRunCli = vi.mocked(runCli);
+const mockAnalyzeTokenUsage = vi.mocked(analyzeTokenUsage);
+
+function makeCtx(overrides: Partial<PhaseExecutorContext> = {}): PhaseExecutorContext {
+  return {
+    issue: { number: 42, title: "Fix bug", body: "Fix it", labels: [] },
+    plan: {
+      issueNumber: 42,
+      title: "Fix plan",
+      problemDefinition: "A bug",
+      requirements: [],
+      affectedFiles: [],
+      risks: [],
+      phases: [
+        {
+          index: 0,
+          name: "Phase One",
+          description: "Do something",
+          targetFiles: ["src/foo.ts"],
+          commitStrategy: "atomic",
+          verificationCriteria: [],
+          dependsOn: [],
+        },
+      ],
+      verificationPoints: [],
+      stopConditions: [],
+    },
+    phase: {
+      index: 0,
+      name: "Phase One",
+      description: "Do something",
+      targetFiles: ["src/foo.ts"],
+      commitStrategy: "atomic",
+      verificationCriteria: [],
+      dependsOn: [],
+    },
+    previousResults: [],
+    claudeConfig: {
+      path: "claude",
+      model: "model-primary",
+      models: {
+        plan: "model-primary",
+        phase: "model-primary",
+        review: "model-review",
+        fallback: "model-fallback",
+      },
+      maxTurns: 1,
+      timeout: 5000,
+      additionalArgs: [],
+    },
+    promptsDir: "/tmp/prompts",
+    cwd: "/tmp/project",
+    testCommand: "",
+    lintCommand: "",
+    gitPath: "git",
+    gitConfig: {
+      commitMessageTemplate: "[#{{issueNumber}}] {{phase}}: {{summary}}",
+    },
+    ...overrides,
+  };
+}
+
+function mockSuccessRunCliSequence(): void {
+  mockRunCli
+    .mockResolvedValueOnce({ stdout: "startabc123", stderr: "", exitCode: 0 }) // getHeadHash (phaseStartHash)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // diff committed (scope guard)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // diff uncommitted (scope guard)
+    .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 })             // git status --porcelain (autoCommit, clean)
+    .mockResolvedValueOnce({ stdout: "finaldef456", stderr: "", exitCode: 0 }); // getHeadHash (final)
+}
+
+describe("executePhase QUOTA_EXHAUSTED fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAnalyzeTokenUsage.mockReturnValue({
+      estimatedTokens: 1000,
+      modelLimit: 200000,
+      effectiveLimit: 160000,
+      exceedsLimit: false,
+      usagePercentage: 0.6,
+    });
+  });
+
+  it("falls back to second model when first model returns QUOTA_EXHAUSTED", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "You've hit your limit · resets Apr 15, 2pm" })
+      .mockResolvedValueOnce({ success: true, output: "done" });
+    mockSuccessRunCliSequence();
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+    expect(mockRunClaude.mock.calls[0][0].config.model).toBe("model-primary");
+    expect(mockRunClaude.mock.calls[1][0].config.model).toBe("model-fallback");
+  });
+
+  it("fails when all fallback models are exhausted or fail", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "You've hit your limit · resets Apr 15, 2pm" })
+      .mockResolvedValueOnce({ success: false, output: "Claude failed: unexpected error" });
+    mockRunCli.mockResolvedValue({ stdout: "startabc123", stderr: "", exitCode: 0 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fall back when failure is not QUOTA_EXHAUSTED", async () => {
+    mockRunClaude.mockResolvedValueOnce({ success: false, output: "TS2345: type error in file" });
+    mockRunCli.mockResolvedValue({ stdout: "startabc123", stderr: "", exitCode: 0 });
+
+    const result = await executePhase(makeCtx());
+
+    expect(result.success).toBe(false);
+    // Should fail immediately without trying fallback model
+    expect(mockRunClaude).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses explicit modelFallbackChain when provided", async () => {
+    mockRunClaude
+      .mockResolvedValueOnce({ success: false, output: "usage limit reached" })
+      .mockResolvedValueOnce({ success: true, output: "done" });
+    mockSuccessRunCliSequence();
+
+    const ctx = makeCtx({
+      claudeConfig: {
+        path: "claude",
+        model: "chain-model-a",
+        models: {
+          plan: "chain-model-a",
+          phase: "chain-model-a",
+          review: "chain-model-a",
+          fallback: "chain-model-a",
+        },
+        modelFallbackChain: ["chain-model-a", "chain-model-b"],
+        maxTurns: 1,
+        timeout: 5000,
+        additionalArgs: [],
+      },
+    });
+
+    const result = await executePhase(ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockRunClaude).toHaveBeenCalledTimes(2);
+    expect(mockRunClaude.mock.calls[1][0].config.model).toBe("chain-model-b");
+  });
+});

--- a/tests/pipeline/reporting/result-reporter.test.ts
+++ b/tests/pipeline/reporting/result-reporter.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { formatResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import type { Plan, PhaseResult } from "../../../src/types/pipeline.js";
+
+function makePlan(overrides: Partial<Plan> = {}): Plan {
+  return {
+    issueNumber: 42,
+    title: "Test Plan",
+    problemDefinition: "Fix a bug",
+    requirements: [],
+    affectedFiles: [],
+    risks: [],
+    phases: [
+      { index: 0, name: "Phase 1", description: "First", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+    ],
+    verificationPoints: [],
+    stopConditions: [],
+    ...overrides,
+  };
+}
+
+describe("formatResult usedModel field", () => {
+  it("includes usedModel in phase report when fallback model was used", () => {
+    const results: PhaseResult[] = [
+      {
+        phaseIndex: 0,
+        phaseName: "Phase 1",
+        success: true,
+        commitHash: "abc12345",
+        durationMs: 1000,
+        usedModel: "claude-haiku-4-5-20251001",
+      },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.phases[0].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("has undefined usedModel when not set in PhaseResult", () => {
+    const results: PhaseResult[] = [
+      {
+        phaseIndex: 0,
+        phaseName: "Phase 1",
+        success: true,
+        commitHash: "abc12345",
+        durationMs: 1000,
+      },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.phases[0].usedModel).toBeUndefined();
+  });
+
+  it("maps usedModel for each phase independently", () => {
+    const plan = makePlan({
+      phases: [
+        { index: 0, name: "Phase 1", description: "First", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+        { index: 1, name: "Phase 2", description: "Second", targetFiles: [], commitStrategy: "", verificationCriteria: [] },
+      ],
+    });
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+      { phaseIndex: 1, phaseName: "Phase 2", success: true, durationMs: 2000, usedModel: "claude-haiku-4-5-20251001" },
+    ];
+    const report = formatResult(42, "test/repo", plan, results, Date.now() - 3000);
+    expect(report.phases[0].usedModel).toBeUndefined();
+    expect(report.phases[1].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+});


### PR DESCRIPTION
## Summary

v0.7.1 patch release — Plan A 성공 지표 충족(통합 테스트 신설) + Claude 운영성 개선(quota 자가진단, 모델 fallback 체인, 대시보드 maxTurns 편집 UI).

## Highlights

### 🧪 Plan A 성공 지표 #3 충족
- **#723 (#714)** `tests/integration/failure-scenarios.test.ts` 신설 — retry budget exhaustion / sqlite3 preflight / graceful shutdown / config hot reload 4개 시나리오. AQM Phase 1이 작성한 코드의 `/proc/...` hang + resolver 재할당 버그를 수동으로 수정해 31/31 통과
- 전체 vitest 3076 passed / 7 skipped — 회귀 없음

### 🛠 Claude 운영성 개선
- **#722 (#719)** phase 모델 fallback 체인 — sonnet 한도 도달 시 haiku/다른 모델로 자동 우회 (`commands.claudeCli.modelFallbackChain`)
- **#721 (#718)** 시작 시 사용 모델별 Claude quota 자가진단 + 대시보드 표시 (`/api/claude-profile.quotaStatus`)
- **#720 (#712)** 대시보드 설정 UI에 `maxTurns` / `maxTurnsPerMode` 편집 노출 (비개발자 친화)

## Test plan

- [ ] develop CI green
- [ ] aqm restart 후 대시보드 settings에서 maxTurns 편집 확인
- [ ] sonnet quota 도달 시 fallback 체인이 haiku로 자동 우회 확인