### PR TITLE
[AQ-#726] fix(AutomationDispatcher): draft PR 생성 시점에 'pr-merged' 이벤트가 잘못 발화

### DIFF
--- a/src/pipeline/automation/automation-dispatcher.ts
+++ b/src/pipeline/automation/automation-dispatcher.ts
@@ -1,6 +1,7 @@
 import type {
   PipelineEvent,
   PrMergedPayload,
+  DraftPrCreatedPayload,
   PhaseFailedPayload,
   PipelineCompletePayload,
   PipelineFailedPayload,
@@ -46,6 +47,13 @@ export async function dispatchPipelineEvent(event: PipelineEvent): Promise<void>
 
 async function processEvent(event: PipelineEvent): Promise<void> {
   switch (event.type) {
+    case "draft-pr-created": {
+      const p = event.payload as DraftPrCreatedPayload;
+      logger.info(
+        `[AutomationDispatcher] Draft PR 생성 — 이슈 #${p.issueNumber} PR #${p.prNumber} (${p.repo})`
+      );
+      break;
+    }
     case "pr-merged": {
       const p = event.payload as PrMergedPayload;
       logger.info(

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -693,13 +693,14 @@ export async function executePostProcessingPhases(
   const prUrl = publishResult.prUrl;
 
   await dispatchPipelineEvent({
-    type: "pr-merged",
+    type: "draft-pr-created",
     payload: {
       issueNumber,
       repo,
       prNumber: publishResult.prNumber ?? 0,
       prUrl: prUrl ?? "",
-      mergedAt: new Date().toISOString(),
+      branchName: runtime.branchName ?? "",
+      createdAt: new Date().toISOString(),
     },
     triggeredAt: new Date().toISOString(),
   });

--- a/src/server/public/js/automations.js
+++ b/src/server/public/js/automations.js
@@ -246,6 +246,7 @@ function openRuleModal(rule) {
         '<label class="' + labelCls + '">이벤트</label>' +
         '<select id="rule-trigger-event" class="' + fieldCls + '">' +
           '<option value="pr-merged"' + (triggerEvent === 'pr-merged' ? ' selected' : '') + '>PR Merged</option>' +
+          '<option value="draft-pr-created"' + (triggerEvent === 'draft-pr-created' ? ' selected' : '') + '>Draft PR 생성</option>' +
           '<option value="phase-failed"' + (triggerEvent === 'phase-failed' ? ' selected' : '') + '>Phase Failed</option>' +
         '</select>' +
       '</div>' +

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -388,6 +388,7 @@ export interface AssembledPrompt {
 
 export type PipelineEventType =
   | "pr-merged"
+  | "draft-pr-created"
   | "phase-failed"
   | "pipeline-complete"
   | "pipeline-failed";
@@ -398,6 +399,15 @@ export interface PrMergedPayload {
   prNumber: number;
   prUrl: string;
   mergedAt: string;
+}
+
+export interface DraftPrCreatedPayload {
+  issueNumber: number;
+  repo: string;
+  prNumber: number;
+  prUrl: string;
+  branchName: string;
+  createdAt: string;
 }
 
 export interface PhaseFailedPayload {
@@ -429,6 +439,7 @@ export interface PipelineFailedPayload {
 
 export type PipelineEventPayload =
   | PrMergedPayload
+  | DraftPrCreatedPayload
   | PhaseFailedPayload
   | PipelineCompletePayload
   | PipelineFailedPayload;
@@ -437,13 +448,15 @@ export interface PipelineEvent<T extends PipelineEventType = PipelineEventType> 
   type: T;
   payload: T extends "pr-merged"
     ? PrMergedPayload
-    : T extends "phase-failed"
-      ? PhaseFailedPayload
-      : T extends "pipeline-complete"
-        ? PipelineCompletePayload
-        : T extends "pipeline-failed"
-          ? PipelineFailedPayload
-          : never;
+    : T extends "draft-pr-created"
+      ? DraftPrCreatedPayload
+      : T extends "phase-failed"
+        ? PhaseFailedPayload
+        : T extends "pipeline-complete"
+          ? PipelineCompletePayload
+          : T extends "pipeline-failed"
+            ? PipelineFailedPayload
+            : never;
   triggeredAt: string;
 }
 

--- a/tests/pipeline/automation-dispatcher.test.ts
+++ b/tests/pipeline/automation-dispatcher.test.ts
@@ -16,6 +16,7 @@ import { AutomationScheduler } from "../../src/automation/scheduler.js";
 import type {
   PipelineEvent,
   PrMergedPayload,
+  DraftPrCreatedPayload,
   PhaseFailedPayload,
   PipelineCompletePayload,
   PipelineFailedPayload,
@@ -32,6 +33,21 @@ function makeScheduler(running: boolean): AutomationScheduler {
   const scheduler = new AutomationScheduler(DEFAULT_CONFIG, [], mockHandlers);
   if (running) scheduler.start();
   return scheduler;
+}
+
+function makeDraftPrCreatedEvent(): PipelineEvent<"draft-pr-created"> {
+  return {
+    type: "draft-pr-created",
+    payload: {
+      issueNumber: 42,
+      repo: "test/repo",
+      prNumber: 7,
+      prUrl: "https://github.com/test/repo/pull/7",
+      branchName: "aq/42-test-feature",
+      createdAt: "2026-04-10T11:00:00Z",
+    } satisfies DraftPrCreatedPayload,
+    triggeredAt: "2026-04-10T11:00:00Z",
+  };
 }
 
 function makePrMergedEvent(): PipelineEvent<"pr-merged"> {
@@ -194,6 +210,28 @@ describe("automation-dispatcher", () => {
         expect(mockLogger.info).toHaveBeenCalledWith(
           expect.stringContaining("PHASE_FAILED")
         );
+      });
+
+      it("draft-pr-created 이벤트를 처리한다", async () => {
+        const event = makeDraftPrCreatedEvent();
+        await dispatchPipelineEvent(event);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("Draft PR 생성")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("42")
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining("7")
+        );
+      });
+
+      it("draft PR 생성 시 pr-merged 이벤트가 발화되지 않는다 (회귀)", async () => {
+        const event = makeDraftPrCreatedEvent();
+        await dispatchPipelineEvent(event);
+        const infoCalls = mockLogger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+        const hasPrMerged = infoCalls.some((msg) => msg.includes("PR 병합"));
+        expect(hasPrMerged).toBe(false);
       });
     });
 


### PR DESCRIPTION
## Summary

Resolves #726 — fix(AutomationDispatcher): draft PR 생성 시점에 'pr-merged' 이벤트가 잘못 발화

pipeline-phases.ts L695-704에서 draft PR 생성 직후 dispatchPipelineEvent({ type: "pr-merged" })를 호출하여, 실제 PR이 머지되지 않았음에도 AutomationDispatcher가 "PR 병합" 이벤트를 수신함. 이로 인해 이슈가 잘못 close되고 파이프라인이 완료로 마킹되는 위양성 발생. pr-merged 이벤트는 실제 GitHub webhook(pull_request.closed + merged: true)에서만 트리거되어야 하며, draft PR 생성 시점에는 별도 이벤트(draft-pr-created)를 발화해야 함.

## Requirements

- PipelineEventType union에 'draft-pr-created' 추가 및 DraftPrCreatedPayload 인터페이스 정의
- pipeline-phases.ts L695-704의 pr-merged dispatch를 draft-pr-created로 변경
- automation-dispatcher.ts의 processEvent switch에 draft-pr-created case 추가
- PipelineEvent 제네릭 conditional type에 draft-pr-created 분기 추가
- PipelineEventPayload union에 DraftPrCreatedPayload 추가
- automations.js UI의 이벤트 select 옵션에 'Draft PR Created' 추가
- 기존 automation-dispatcher 테스트에 draft-pr-created 이벤트 처리 테스트 추가
- 회귀 테스트: draft PR 생성 시 pr-merged가 발화되지 않는지 검증

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 타입 정의 확장 — SUCCESS (66e78784)
- Phase 3: UI 이벤트 옵션 추가 — SUCCESS (66e78784)
- Phase 1: pipeline-phases 이벤트 분리 — SUCCESS (1a21cc62)
- Phase 2: automation-dispatcher 핸들러 추가 — SUCCESS (1a21cc62)
- Phase 4: 테스트 추가 및 회귀 검증 — SUCCESS (3aed7b0e)

## Risks

- 기존 사용자 정의 automation 규칙이 pr-merged 트리거를 사용 중일 수 있음 — draft-pr-created로 마이그레이션 필요
- PipelineEvent 제네릭 conditional type 분기 추가 시 타입 호환성 깨질 수 있음
- automations.js의 select 옵션 변경이 기존 저장된 규칙의 event 값과 불일치할 수 있음

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.6704 (review: $0.2024)
- **Phases**: 6/6 completed
- **Branch**: `aq/726-fix-automationdispatcher-draft-pr-pr-merged` → `develop`
- **Tokens**: 206 input, 23136 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 타입 정의 확장 | $0.4905 | 0 | $0.0000 |
| UI 이벤트 옵션 추가 | $0.2095 | 0 | $0.0000 |
| pipeline-phases 이벤트 분리 | $0.5000 | 0 | $0.0000 |
| automation-dispatcher 핸들러 추가 | $0.3197 | 0 | $0.0000 |
| 테스트 추가 및 회귀 검증 | $0.3885 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.9082 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #726