### PR TITLE
fix(ci): visual-baseline-regen config.yml seed 방식 수정

### DIFF
--- a/.github/workflows/visual-baseline-regen.yml
+++ b/.github/workflows/visual-baseline-regen.yml
@@ -14,7 +14,15 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - name: Seed test config.yml
-        run: cp config.reference.yml config.yml
+        run: |
+          cat > config.yml << EOF
+          projects:
+            - repo: "ai-quartermaster/visual-test"
+              path: "${GITHUB_WORKSPACE}"
+          general:
+            logLevel: "warn"
+            serverMode: "polling"
+          EOF
       - run: npx playwright test --update-snapshots --project=visual-desktop --project=visual-mobile
       - name: Create PR with updated snapshots
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
- visual-baseline-regen workflow가 `cp config.reference.yml config.yml`로 placeholder repo/path를 그대로 사용 → AQM webServer 시작 시 검증 실패로 baseline 재생성 불가
- ci.yml의 visual-regression job과 동일하게 heredoc 방식 dummy config로 변경

## Test plan
- [ ] PR 머지 후 workflow_dispatch로 visual-baseline-regen 트리거 → 정상 완료 확인