### PR TITLE
[AQ-#736] feat: 공통 EmptyState 컴포넌트 + Skip/Jobs/Projects variant 적용

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -861,6 +861,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 <script src="js/api.js"></script>
 <script src="js/state.js"></script>
 <script src="js/modal.js"></script>
+<script src="js/render-empty.js"></script>
 <script src="js/render-jobs.js"></script>
 <script src="js/render-settings.js"></script>
 <script src="js/render-repos.js"></script>

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -735,7 +735,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
         <span class="material-symbols-outlined text-sm">refresh</span> 새로고침
       </button>
     </div>
-    <div class="bg-surface-container rounded-xl ring-1 ring-outline-variant/10 overflow-hidden">
+    <div id="skip-events-table" class="bg-surface-container rounded-xl ring-1 ring-outline-variant/10 overflow-hidden">
       <table class="w-full text-left">
         <thead>
           <tr class="border-b border-outline-variant/20 bg-surface-container-high">
@@ -752,6 +752,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
         </tbody>
       </table>
     </div>
+    <div id="skip-events-empty" class="hidden"></div>
   </div>
 
   <div id="view-settings" class="view-panel">

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -728,7 +728,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     <div class="flex items-center justify-between mb-6">
       <h2 class="text-sm font-headline font-bold text-on-surface uppercase tracking-widest flex items-center gap-2">
         <span class="w-1 h-4 bg-primary-container rounded-full"></span>
-        <span>Skip Events</span>
+        <span>거부된 이슈</span>
         <span id="skip-events-total" class="text-xs font-mono text-outline ml-2">0</span>
       </h2>
       <button onclick="loadSkipEvents()" class="flex items-center gap-1.5 px-3 py-1.5 bg-surface-container-high text-outline text-xs font-bold rounded-lg ring-1 ring-outline-variant/20 hover:bg-surface-bright transition-colors">

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -1497,9 +1497,13 @@ function loadSkipEvents() {
         if (emptyEl) {
           emptyEl.classList.remove('hidden');
           emptyEl.innerHTML = renderEmptyState({
-            icon: 'block',
-            title: '스킵된 이벤트가 없습니다',
-            description: '이벤트가 스킵 없이 정상적으로 처리되고 있습니다.'
+            icon: 'filter_alt_off',
+            title: '거부된 이슈 없음',
+            description: '라벨/권한/안전장치로 거부된 이슈가 여기에 표시됩니다.',
+            secondaryLink: {
+              label: 'allowedLabels / instanceOwners 편집',
+              href: '#settings'
+            }
           });
         }
         return;

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -1490,10 +1490,22 @@ function loadSkipEvents() {
       var totalEl = document.getElementById('skip-events-total');
       if (totalEl) totalEl.textContent = String(total);
 
+      var tableEl = document.getElementById('skip-events-table');
+      var emptyEl = document.getElementById('skip-events-empty');
       if (events.length === 0) {
-        el.innerHTML = '<tr><td colspan="6" class="px-4 py-12 text-center text-outline text-sm">스킵된 이벤트가 없습니다.</td></tr>';
+        if (tableEl) tableEl.classList.add('hidden');
+        if (emptyEl) {
+          emptyEl.classList.remove('hidden');
+          emptyEl.innerHTML = renderEmptyState({
+            icon: 'block',
+            title: '스킵된 이벤트가 없습니다',
+            description: '이벤트가 스킵 없이 정상적으로 처리되고 있습니다.'
+          });
+        }
         return;
       }
+      if (tableEl) tableEl.classList.remove('hidden');
+      if (emptyEl) emptyEl.classList.add('hidden');
       el.innerHTML = events.map(renderSkipEventRow).join('');
     })
     .catch(function() {

--- a/src/server/public/js/render-empty.js
+++ b/src/server/public/js/render-empty.js
@@ -1,0 +1,76 @@
+// @ts-check
+'use strict';
+
+/* ══════════════════════════════════════════════════════════════
+   EmptyState Renderer — Kinetic Command Design System
+   ══════════════════════════════════════════════════════════════ */
+
+/**
+ * @typedef {Object} PrimaryAction
+ * @property {string} label - Button label
+ * @property {string} onclick - Inline onclick handler
+ */
+
+/**
+ * @typedef {Object} SecondaryLink
+ * @property {string} label - Link label
+ * @property {string} href - Link href
+ */
+
+/**
+ * @typedef {Object} EmptyStateOptions
+ * @property {string} icon - Material Symbol icon name
+ * @property {string} title - Main title text
+ * @property {string} description - Description text
+ * @property {PrimaryAction=} primaryAction - CTA button (optional)
+ * @property {SecondaryLink=} secondaryLink - Secondary link (optional)
+ */
+
+/**
+ * Renders a common EmptyState card following the Kinetic Command design system.
+ * - surface_container_high background card
+ * - primary 60% opacity 72px Material Symbol icon
+ * - primary gradient CTA button
+ *
+ * @param {EmptyStateOptions} opts
+ * @returns {string} HTML string
+ */
+function renderEmptyState(opts) {
+  var primaryBtn = '';
+  if (opts.primaryAction) {
+    primaryBtn =
+      '<button onclick="' + esc(opts.primaryAction.onclick) + '" ' +
+        'class="mt-5 inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-bold font-headline ' +
+        'bg-gradient-to-r from-primary to-primary-container text-on-primary ' +
+        'hover:opacity-90 active:scale-95 transition-all">' +
+        esc(opts.primaryAction.label) +
+      '</button>';
+  }
+
+  var secondaryLnk = '';
+  if (opts.secondaryLink) {
+    secondaryLnk =
+      '<a href="' + esc(opts.secondaryLink.href) + '" ' +
+        'class="mt-3 text-xs text-primary/70 hover:text-primary transition-colors underline underline-offset-2">' +
+        esc(opts.secondaryLink.label) +
+      '</a>';
+  }
+
+  return (
+    '<div class="flex flex-col items-center justify-center py-16 px-6 ' +
+      'bg-surface-container-high rounded-xl ring-1 ring-outline-variant/10">' +
+      '<span class="material-symbols-outlined text-[72px] leading-none text-primary/60 mb-4" ' +
+        'style="font-variation-settings: \'FILL\' 0, \'wght\' 300, \'GRAD\' 0, \'opsz\' 48;">' +
+        esc(opts.icon) +
+      '</span>' +
+      '<p class="text-base font-bold font-headline text-on-surface mb-2">' +
+        esc(opts.title) +
+      '</p>' +
+      '<p class="text-sm text-outline text-center max-w-xs leading-relaxed">' +
+        esc(opts.description) +
+      '</p>' +
+      primaryBtn +
+      secondaryLnk +
+    '</div>'
+  );
+}

--- a/src/server/public/js/render-jobs.js
+++ b/src/server/public/js/render-jobs.js
@@ -706,7 +706,14 @@ function renderFromState() {
 
   if (allJobs.length === 0) {
     if (listEl) listEl.classList.add('hidden');
-    if (emptyEl) { emptyEl.classList.remove('hidden'); emptyEl.classList.add('flex'); }
+    if (emptyEl) {
+      emptyEl.innerHTML = renderEmptyState({
+        icon: 'inbox',
+        title: '아직 작업이 없습니다',
+        description: 'GitHub 이슈에 /aq implement 명령을 남기면 자동으로 파이프라인이 시작됩니다.'
+      });
+      emptyEl.classList.remove('hidden');
+    }
     var detailEl0 = $id('job-detail');
     if (detailEl0) detailEl0.innerHTML = '<div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">' + t('noJobSelected') + '</div>';
     renderMobileActivityLog(null);

--- a/src/server/public/js/render-repos.js
+++ b/src/server/public/js/render-repos.js
@@ -197,9 +197,16 @@ function renderRepositoriesView(repos, storageData) {
   var repoList = Array.isArray(repos) ? repos : [];
   if (repoList.length === 0) {
     grid.insertAdjacentHTML('beforeend',
-      '<div class="repo-card-dynamic bg-surface-container rounded-xl p-6 flex flex-col items-center justify-center min-h-[200px] ring-1 ring-outline-variant/10">' +
-        '<span class="material-symbols-outlined text-4xl text-outline/20 mb-3">inventory_2</span>' +
-        '<p class="text-sm text-outline font-body">등록된 레포지토리가 없습니다.</p>' +
+      '<div class="repo-card-dynamic">' +
+        renderEmptyState({
+          icon: 'inventory_2',
+          title: '등록된 레포지토리가 없습니다',
+          description: '새 Git 레포지토리를 연결하여 AQM이 자동으로 이슈를 처리하도록 설정하세요.',
+          primaryAction: {
+            label: '레포지토리 추가',
+            onclick: 'showAddRepositoryDialog()'
+          }
+        }) +
       '</div>'
     );
   } else {

--- a/src/server/public/views/_layout-sidebar.html
+++ b/src/server/public/views/_layout-sidebar.html
@@ -37,7 +37,7 @@
     </a>
     <a class="flex items-center gap-3 text-slate-400 hover:bg-slate-800 hover:text-slate-200 px-4 py-3 my-1 rounded-md transition-all font-headline text-sm cursor-pointer" data-nav="skip-events">
       <span class="material-symbols-outlined">block</span>
-      <span>Skip Events</span>
+      <span>거부된 이슈</span>
     </a>
     <a class="flex items-center gap-3 text-slate-400 hover:bg-slate-800 hover:text-slate-200 px-4 py-3 my-1 rounded-md transition-all font-headline text-sm cursor-pointer" data-nav="settings">
       <span class="material-symbols-outlined">settings</span>

--- a/src/server/public/views/dashboard.html
+++ b/src/server/public/views/dashboard.html
@@ -69,12 +69,8 @@
         <div id="job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-350px)] pr-2 custom-scrollbar">
           <!-- Jobs rendered here dynamically -->
         </div>
-        <!-- Empty state -->
-        <div id="empty-state" class="hidden flex-col items-center justify-center py-16 text-center">
-          <span class="material-symbols-outlined text-5xl text-outline/30 mb-4">inbox</span>
-          <p class="text-sm font-bold text-on-surface mb-1">아직 작업이 없습니다</p>
-          <p class="text-xs text-outline">GitHub 이슈에 <code class="font-mono text-[10px] bg-surface-container px-1.5 py-0.5 rounded border border-outline-variant/20">/aq implement</code> 명령을 남기면 자동으로 파이프라인이 시작됩니다.</p>
-        </div>
+        <!-- Empty state — populated by renderEmptyState() in render-jobs.js -->
+        <div id="empty-state" class="hidden"></div>
         <!-- Filter empty -->
         <div id="filter-empty" class="hidden flex-col items-center justify-center py-12 text-center">
           <span class="material-symbols-outlined text-3xl text-outline/30 mb-2">filter_list_off</span>


### PR DESCRIPTION
## Summary

Resolves #736 — feat: 공통 EmptyState 컴포넌트 + Skip/Jobs/Projects variant 적용

현재 Skip Events, Jobs 목록(0건), Projects 미등록 세 곳에서 각각 다른 스타일의 "없습니다" 한 줄 텍스트로 빈 상태를 표시 중. Kinetic Command 디자인 시스템 기반의 공통 EmptyState 컴포넌트를 도입하여 일관된 UX(surface_container_high 카드, primary 60% opacity 72px Material Symbol 아이콘, primary gradient CTA)를 제공해야 함.\n\n현재 빈 상태 위치:\n- Skip Events: app.js:1494 — `<tr><td colspan=\"6\">스킵된 이벤트가 없습니다.</td></tr>`\n- Jobs 목록: dashboard.html:73-77 — inbox 아이콘 + \"아직 작업이 없습니다\"\n- Projects: render-repos.js:202 — \"등록된 레포지토리가 없습니다.\"\n\n⚠️ 디자인 파일 `docs/design/empty-state-stitch.html`이 아직 존재하지 않음 — CLAUDE.md 규칙에 따라 Stitch에서 먼저 받아와야 구현 가능.

## Requirements

- 공통 EmptyState 렌더러 (render-empty.js) 도입: { icon, title, description, primaryAction?, secondaryLink? } 시그니처
- Skip Events / Jobs 목록(0건) / Projects 미등록 세 곳에 EmptyState 적용
- 각 variant의 타이틀/설명/CTA 라벨은 디자인 파일 카피 그대로 사용
- Kinetic Command 디자인 시스템 준수: surface_container_high 카드, primary 60% opacity 72px Material Symbol 아이콘, primary gradient CTA
- npx tsc --noEmit + npx vitest run 통과 필수
- 디자인 파일(docs/design/empty-state-stitch.html) 존재 확인 후 구현 착수

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 디자인 파일 확인 및 카피 추출 — SUCCESS (06dd6463)
- Phase 1: 공통 EmptyState 렌더러 구현 — SUCCESS (57b4f937)
- Phase 2: Skip Events variant 적용 — SUCCESS (a12896c6)
- Phase 3: Jobs 목록 variant 적용 — SUCCESS (a12896c6)
- Phase 4: Projects 미등록 variant 적용 — SUCCESS (a12896c6)
- Phase 5: 빌드 검증 및 테스트 — SUCCESS (a12896c6)

## Risks

- 디자인 파일(docs/design/empty-state-stitch.html)이 아직 존재하지 않음 — Stitch에서 먼저 받아와야 Phase 0 통과 가능
- Skip Events가 테이블 구조 내부에 있어 EmptyState 카드 삽입 시 테이블 숨김/대체 로직 필요
- dashboard.html의 필터 빈 상태와 전체 빈 상태가 혼동되지 않도록 구분 필요
- Phase 2/3/4는 병렬 가능하나 같은 파일(app.js, index.html) 수정 시 충돌 주의

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $3.0730 (review: $0.1662)
- **Phases**: 7/7 completed
- **Branch**: `aq/736-feat-emptystate-skip-jobs-projects-variant` → `develop`
- **Tokens**: 168 input, 25554 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 디자인 파일 확인 및 카피 추출 | $0.1259 | 0 | $0.0000 |
| 공통 EmptyState 렌더러 구현 | $0.6344 | 0 | $0.0000 |
| Skip Events variant 적용 | $0.4473 | 0 | $0.0000 |
| Jobs 목록 variant 적용 | $0.4793 | 0 | $0.0000 |
| Projects 미등록 variant 적용 | $0.4144 | 0 | $0.0000 |
| 빌드 검증 및 테스트 | $0.1728 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $2.2740 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #736