### PR TITLE
[AQ-#741] feat: Doctor 10개 Check 구현 (claude/gh/git/Node/sqlite/권한/ping)

### DIFF
--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -1,0 +1,483 @@
+import { accessSync, constants, existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { runCli } from '../utils/cli-runner.js';
+import { getErrorMessage } from '../utils/error-utils.js';
+import { DoctorCheck, DoctorCheckOptions, DoctorCheckResult } from './types.js';
+
+const MIN_CLAUDE_VERSION = '1.0.0';
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(n => parseInt(n, 10) || 0);
+  const pb = b.split('.').map(n => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** Check 1: claude CLI 설치 여부 + 버전 확인 */
+export const checkClaudeCli: DoctorCheck = async (_opts?: DoctorCheckOptions): Promise<DoctorCheckResult> => {
+  const result = await runCli('claude', ['--version'], { timeout: 5000 });
+  const output = (result.stdout + result.stderr).trim();
+
+  if (result.exitCode !== 0 || output === '') {
+    return {
+      id: 'claude-cli',
+      label: 'Claude CLI 설치',
+      severity: 'error',
+      status: 'fail',
+      detail: "claude CLI를 찾을 수 없습니다. PATH에 설치되어 있는지 확인하세요.",
+      fixSteps: ['npm install -g @anthropic-ai/claude-code'],
+      docsUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+    };
+  }
+
+  const match = output.match(/(\d+\.\d+\.\d+)/);
+  if (!match) {
+    return {
+      id: 'claude-cli',
+      label: 'Claude CLI 설치',
+      severity: 'error',
+      status: 'pass',
+      detail: `claude CLI 설치됨 (버전 파싱 불가: ${output.slice(0, 40)})`,
+      fixSteps: [],
+    };
+  }
+
+  const version = match[1];
+  if (compareSemver(version, MIN_CLAUDE_VERSION) < 0) {
+    return {
+      id: 'claude-cli',
+      label: 'Claude CLI 설치',
+      severity: 'warning',
+      status: 'warn',
+      detail: `claude CLI v${version} 설치됨 — 최소 권장 버전은 v${MIN_CLAUDE_VERSION}입니다`,
+      fixSteps: ['npm install -g @anthropic-ai/claude-code', 'claude update'],
+      docsUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+    };
+  }
+
+  return {
+    id: 'claude-cli',
+    label: 'Claude CLI 설치',
+    severity: 'error',
+    status: 'pass',
+    detail: `claude CLI v${version}`,
+    fixSteps: [],
+  };
+};
+
+/** Check 2: claude 로그인 상태 확인 */
+export const checkClaudeLogin: DoctorCheck = async (_opts?: DoctorCheckOptions): Promise<DoctorCheckResult> => {
+  const result = await runCli('claude', ['auth', 'status'], { timeout: 10000 });
+  const output = (result.stdout + result.stderr).trim();
+
+  const notLoggedIn =
+    result.exitCode !== 0 ||
+    output.toLowerCase().includes('not logged in') ||
+    output.toLowerCase().includes('not authenticated') ||
+    output === '';
+
+  if (notLoggedIn) {
+    return {
+      id: 'claude-login',
+      label: 'Claude 로그인',
+      severity: 'error',
+      status: 'fail',
+      detail: 'claude에 로그인되어 있지 않습니다',
+      fixSteps: ['claude login'],
+      docsUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+    };
+  }
+
+  return {
+    id: 'claude-login',
+    label: 'Claude 로그인',
+    severity: 'error',
+    status: 'pass',
+    detail: 'claude 인증 확인됨',
+    fixSteps: [],
+  };
+};
+
+/** Check 3: gh CLI 설치 여부 확인 */
+export const checkGhCli: DoctorCheck = async (_opts?: DoctorCheckOptions): Promise<DoctorCheckResult> => {
+  const result = await runCli('gh', ['--version'], { timeout: 5000 });
+  const output = (result.stdout + result.stderr).trim();
+
+  if (result.exitCode !== 0 || output === '') {
+    return {
+      id: 'gh-cli',
+      label: 'GitHub CLI (gh) 설치',
+      severity: 'error',
+      status: 'fail',
+      detail: "gh CLI를 찾을 수 없습니다. PATH에 설치되어 있는지 확인하세요.",
+      fixSteps: [
+        'brew install gh  # macOS',
+        '# 또는 https://cli.github.com/ 에서 설치',
+      ],
+      docsUrl: 'https://cli.github.com/',
+    };
+  }
+
+  const match = output.match(/gh version (\S+)/);
+  const version = match ? match[1] : output.split('\n')[0].trim();
+
+  return {
+    id: 'gh-cli',
+    label: 'GitHub CLI (gh) 설치',
+    severity: 'error',
+    status: 'pass',
+    detail: `gh CLI 설치됨 (${version})`,
+    fixSteps: [],
+  };
+};
+
+/** Check 4: gh 인증 + scope (repo, workflow) 확인 */
+export const checkGhAuth: DoctorCheck = async (_opts?: DoctorCheckOptions): Promise<DoctorCheckResult> => {
+  const result = await runCli('gh', ['auth', 'status'], { timeout: 10000 });
+  const output = result.stdout + result.stderr;
+
+  const notLoggedIn =
+    result.exitCode !== 0 &&
+    (output.toLowerCase().includes('not logged in') ||
+      output.toLowerCase().includes('no credentials found') ||
+      output.trim() === '');
+
+  if (notLoggedIn) {
+    return {
+      id: 'gh-auth',
+      label: 'GitHub CLI 인증',
+      severity: 'error',
+      status: 'fail',
+      detail: 'gh에 로그인되어 있지 않습니다',
+      fixSteps: ['gh auth login'],
+      docsUrl: 'https://cli.github.com/manual/gh_auth_login',
+    };
+  }
+
+  // scope 파싱: "Token scopes: 'repo', 'workflow'" 형태
+  const scopeMatch = output.match(/[Tt]oken scopes?:\s*(.+)/);
+  const scopeLine = scopeMatch ? scopeMatch[1] : '';
+  const scopes = scopeLine.match(/'([^']+)'/g)?.map(s => s.replace(/'/g, '')) ?? [];
+
+  const missingScopes: string[] = [];
+  if (!scopes.includes('repo')) missingScopes.push('repo');
+  if (!scopes.includes('workflow')) missingScopes.push('workflow');
+
+  if (missingScopes.length > 0) {
+    return {
+      id: 'gh-auth',
+      label: 'GitHub CLI 인증',
+      severity: 'warning',
+      status: 'warn',
+      detail: `gh 인증됨, 누락된 scope: ${missingScopes.join(', ')}`,
+      fixSteps: [`gh auth refresh -s ${missingScopes.join(',')}`],
+      docsUrl: 'https://cli.github.com/manual/gh_auth_refresh',
+    };
+  }
+
+  return {
+    id: 'gh-auth',
+    label: 'GitHub CLI 인증',
+    severity: 'error',
+    status: 'pass',
+    detail: `gh 인증됨, scope: ${scopes.join(', ') || '확인됨'}`,
+    fixSteps: [],
+  };
+};
+
+/** Check 5: git user.name + user.email 설정 확인 */
+export const checkGitIdentity: DoctorCheck = async (_opts?: DoctorCheckOptions): Promise<DoctorCheckResult> => {
+  const [nameResult, emailResult] = await Promise.all([
+    runCli('git', ['config', 'user.name'], { timeout: 5000 }),
+    runCli('git', ['config', 'user.email'], { timeout: 5000 }),
+  ]);
+
+  const name = nameResult.stdout.trim();
+  const email = emailResult.stdout.trim();
+
+  const missing: string[] = [];
+  if (!name) missing.push('user.name');
+  if (!email) missing.push('user.email');
+
+  if (missing.length > 0) {
+    const fixSteps = missing.map(field =>
+      field === 'user.name'
+        ? 'git config --global user.name "Your Name"'
+        : 'git config --global user.email "you@example.com"',
+    );
+    return {
+      id: 'git-identity',
+      label: 'Git 사용자 정보',
+      severity: 'error',
+      status: 'fail',
+      detail: `git 사용자 정보 누락: ${missing.join(', ')}`,
+      fixSteps,
+    };
+  }
+
+  return {
+    id: 'git-identity',
+    label: 'Git 사용자 정보',
+    severity: 'error',
+    status: 'pass',
+    detail: `git identity 설정됨 (${name} <${email}>)`,
+    fixSteps: [],
+  };
+};
+
+// ── helpers (checks 6-10) ─────────────────────────────────────────────────────
+
+function isWsl(): boolean {
+  if (process.env['WSL_DISTRO_NAME'] || process.env['WSL_INTEROP']) return true;
+  try {
+    const release = readFileSync('/proc/sys/kernel/osrelease', 'utf-8').toLowerCase();
+    return release.includes('microsoft') || release.includes('wsl');
+  } catch {
+    return false;
+  }
+}
+
+function parseSemverMajor(version: string): number | null {
+  const m = version.trim().replace(/^v/, '').match(/^(\d+)\./);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/** Check 6: Node.js 버전 >= 20 확인 */
+export const checkNodeVersion: DoctorCheck = async (
+  _opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult> => {
+  const id = 'node-version';
+  const label = 'Node.js >= 20';
+
+  try {
+    const result = await runCli('node', ['--version'], { timeout: 5000 });
+    if (result.exitCode !== 0) {
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'fail',
+        detail: `node 실행 실패: ${result.stderr.trim() || 'not found'}`,
+        fixSteps: ['nvm install 20', 'nvm use 20'],
+      };
+    }
+
+    const versionStr = result.stdout.trim();
+    const major = parseSemverMajor(versionStr);
+
+    if (major === null) {
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'fail',
+        detail: `버전 파싱 실패: ${versionStr}`,
+        fixSteps: ['nvm install 20', 'nvm use 20'],
+      };
+    }
+
+    const wslSuffix = isWsl() ? ' (WSL 환경)' : '';
+
+    if (major < 20) {
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'fail',
+        detail: `현재 버전: ${versionStr} — Node.js 20 이상 필요${wslSuffix}`,
+        fixSteps: ['nvm install 20', 'nvm use 20'],
+      };
+    }
+
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'pass',
+      detail: `${versionStr}${wslSuffix}`,
+      fixSteps: [],
+    };
+  } catch (err: unknown) {
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'fail',
+      detail: getErrorMessage(err),
+      fixSteps: ['nvm install 20', 'nvm use 20'],
+    };
+  }
+};
+
+/** Check 7: better-sqlite3 native 바이너리 로드 가능 여부 */
+export const checkSqliteNative: DoctorCheck = async (
+  _opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult> => {
+  const id = 'sqlite-native';
+  const label = 'better-sqlite3 native 바이너리';
+
+  try {
+    await import('better-sqlite3');
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'pass',
+      detail: 'better-sqlite3 로드 성공',
+      fixSteps: [],
+    };
+  } catch (err: unknown) {
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'fail',
+      detail: `native 바이너리 로드 실패: ${getErrorMessage(err)}`,
+      fixSteps: ['npm rebuild better-sqlite3', 'npm install'],
+    };
+  }
+};
+
+/** Check 8: ~/.aqm (또는 AQM_HOME) 디렉토리 쓰기 권한 */
+export const checkAqmWritable: DoctorCheck = async (
+  _opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult> => {
+  const id = 'aqm-writable';
+  const label = '~/.aqm 쓰기 권한';
+
+  const aqmHome = process.env['AQM_HOME'] ?? join(homedir(), '.aqm');
+
+  try {
+    if (existsSync(aqmHome)) {
+      accessSync(aqmHome, constants.W_OK);
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'pass',
+        detail: `${aqmHome} 쓰기 가능`,
+        fixSteps: [],
+      };
+    }
+
+    // 디렉토리 미존재 시 부모 디렉토리 쓰기 가능 여부 확인
+    const parent = dirname(aqmHome);
+    accessSync(parent, constants.W_OK);
+    return {
+      id,
+      label,
+      severity: 'warning',
+      status: 'warn',
+      detail: `${aqmHome} 미존재 — 부모 디렉토리(${parent}) 쓰기 가능`,
+      fixSteps: ['mkdir -p ~/.aqm && chmod 755 ~/.aqm'],
+    };
+  } catch (err: unknown) {
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'fail',
+      detail: `${aqmHome} 쓰기 불가: ${getErrorMessage(err)}`,
+      fixSteps: ['mkdir -p ~/.aqm && chmod 755 ~/.aqm'],
+    };
+  }
+};
+
+/** Check 9: gh api /rate_limit으로 GitHub API 연결 확인 */
+export const checkGithubPing: DoctorCheck = async (
+  _opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult> => {
+  const id = 'github-ping';
+  const label = 'GitHub API 연결';
+
+  try {
+    const result = await runCli('gh', ['api', '/rate_limit'], { timeout: 10000 });
+    if (result.exitCode !== 0) {
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'fail',
+        detail: `gh api /rate_limit 실패: ${result.stderr.trim() || result.stdout.trim()}`,
+        fixSteps: ['네트워크 연결 확인', 'gh auth login'],
+      };
+    }
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'pass',
+      detail: 'GitHub API 응답 정상',
+      fixSteps: [],
+    };
+  } catch (err: unknown) {
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'fail',
+      detail: getErrorMessage(err),
+      fixSteps: ['네트워크 연결 확인', 'gh auth login'],
+    };
+  }
+};
+
+/** Check 10: Claude CLI 1토큰 ping (기본 skip — enableClaudePing=true 시 활성화) */
+export const checkClaudePing: DoctorCheck = async (
+  opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult> => {
+  const id = 'claude-ping';
+  const label = 'Claude CLI ping';
+
+  if (!opts?.enableClaudePing) {
+    return {
+      id,
+      label,
+      severity: 'info',
+      status: 'skip',
+      detail: '비용 회피를 위해 기본 skip (enableClaudePing=true로 활성화)',
+      fixSteps: [],
+    };
+  }
+
+  try {
+    const result = await runCli(
+      'claude',
+      ['--model', 'claude-haiku-4-5', '--max-turns', '1', '-p', 'hi'],
+      { timeout: 30000 },
+    );
+
+    if (result.exitCode !== 0) {
+      return {
+        id,
+        label,
+        severity: 'error',
+        status: 'fail',
+        detail: `Claude CLI 응답 실패: ${result.stderr.trim() || result.stdout.trim()}`,
+        fixSteps: ['claude login', 'API 키 확인'],
+      };
+    }
+
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'pass',
+      detail: 'Claude CLI 응답 정상',
+      fixSteps: [],
+    };
+  } catch (err: unknown) {
+    return {
+      id,
+      label,
+      severity: 'error',
+      status: 'fail',
+      detail: getErrorMessage(err),
+      fixSteps: ['claude login', 'API 키 확인'],
+    };
+  }
+};

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,15 @@
+import { DoctorCheck, DoctorCheckOptions, DoctorCheckResult } from './types.js';
+
+export { DoctorCheckResult, DoctorCheckOptions, DoctorCheck } from './types.js';
+
+export async function runAllChecks(
+  checks: DoctorCheck[],
+  opts?: DoctorCheckOptions,
+): Promise<DoctorCheckResult[]> {
+  const results: DoctorCheckResult[] = [];
+  for (const check of checks) {
+    const result = await check(opts);
+    results.push(result);
+  }
+  return results;
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,6 +1,18 @@
 import { DoctorCheck, DoctorCheckOptions, DoctorCheckResult } from './types.js';
 
 export { DoctorCheckResult, DoctorCheckOptions, DoctorCheck } from './types.js';
+export {
+  checkClaudeCli,
+  checkClaudeLogin,
+  checkGhCli,
+  checkGhAuth,
+  checkGitIdentity,
+  checkNodeVersion,
+  checkSqliteNative,
+  checkAqmWritable,
+  checkGithubPing,
+  checkClaudePing,
+} from './checks.js';
 
 export async function runAllChecks(
   checks: DoctorCheck[],

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -1,0 +1,17 @@
+export interface DoctorCheckResult {
+  id: string;
+  label: string;
+  severity: 'error' | 'warning' | 'info';
+  status: 'pass' | 'fail' | 'warn' | 'skip';
+  detail: string;
+  fixSteps: string[];
+  autoFixCommand?: string;
+  docsUrl?: string;
+}
+
+export interface DoctorCheckOptions {
+  /** claudePing check 활성화 여부 (기본: false) */
+  enableClaudePing?: boolean;
+}
+
+export type DoctorCheck = (opts?: DoctorCheckOptions) => Promise<DoctorCheckResult>;

--- a/tests/doctor-checks.test.ts
+++ b/tests/doctor-checks.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/utils/cli-runner.js', () => ({
+  runCli: vi.fn(),
+}));
+
+vi.mock('better-sqlite3', () => ({
+  default: class Database {},
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn(() => 'linux'),
+  };
+});
+
+import { runCli } from '../src/utils/cli-runner.js';
+import * as fsModule from 'fs';
+import {
+  checkClaudeCli,
+  checkClaudeLogin,
+  checkGhCli,
+  checkGhAuth,
+  checkGitIdentity,
+  checkNodeVersion,
+  checkSqliteNative,
+  checkAqmWritable,
+  checkGithubPing,
+  checkClaudePing,
+} from '../src/doctor/checks.js';
+import type { DoctorCheckResult } from '../src/doctor/types.js';
+
+const mockRunCli = vi.mocked(runCli);
+
+function cliOk(stdout = '', stderr = '') {
+  return { exitCode: 0, stdout, stderr };
+}
+
+function cliFail(stderr = '', stdout = '') {
+  return { exitCode: 1, stdout, stderr };
+}
+
+function assertSchema(result: DoctorCheckResult) {
+  expect(typeof result.id).toBe('string');
+  expect(result.id.length).toBeGreaterThan(0);
+  expect(typeof result.label).toBe('string');
+  expect(result.label.length).toBeGreaterThan(0);
+  expect(['error', 'warning', 'info']).toContain(result.severity);
+  expect(['pass', 'fail', 'warn', 'skip']).toContain(result.status);
+  expect(typeof result.detail).toBe('string');
+  expect(Array.isArray(result.fixSteps)).toBe(true);
+}
+
+describe('DoctorCheckResult 스키마 검증', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fsModule.accessSync).mockImplementation(() => undefined);
+    vi.mocked(fsModule.existsSync).mockReturnValue(true);
+    vi.mocked(fsModule.readFileSync).mockReturnValue('linux');
+  });
+
+  it('checkClaudeCli — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('claude 1.5.0'));
+    const result = await checkClaudeCli();
+    assertSchema(result);
+    expect(result.id).toBe('claude-cli');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkClaudeLogin — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('Logged in as user@example.com'));
+    const result = await checkClaudeLogin();
+    assertSchema(result);
+    expect(result.id).toBe('claude-login');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkGhCli — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('gh version 2.40.0 (2024-01-15)'));
+    const result = await checkGhCli();
+    assertSchema(result);
+    expect(result.id).toBe('gh-cli');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkGhAuth — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(
+      cliOk("Logged in to github.com\nToken scopes: 'repo', 'workflow'"),
+    );
+    const result = await checkGhAuth();
+    assertSchema(result);
+    expect(result.id).toBe('gh-auth');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkGitIdentity — 필수 필드 포함', async () => {
+    mockRunCli
+      .mockResolvedValueOnce(cliOk('Test User'))
+      .mockResolvedValueOnce(cliOk('test@example.com'));
+    const result = await checkGitIdentity();
+    assertSchema(result);
+    expect(result.id).toBe('git-identity');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkNodeVersion — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('v20.11.0'));
+    const result = await checkNodeVersion();
+    assertSchema(result);
+    expect(result.id).toBe('node-version');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkSqliteNative — 필수 필드 포함', async () => {
+    const result = await checkSqliteNative();
+    assertSchema(result);
+    expect(result.id).toBe('sqlite-native');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkAqmWritable — 필수 필드 포함', async () => {
+    const result = await checkAqmWritable();
+    assertSchema(result);
+    expect(result.id).toBe('aqm-writable');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkGithubPing — 필수 필드 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('{"rate":{"limit":5000,"remaining":4999}}'));
+    const result = await checkGithubPing();
+    assertSchema(result);
+    expect(result.id).toBe('github-ping');
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkClaudePing — 기본 skip 스키마 반환', async () => {
+    const result = await checkClaudePing();
+    assertSchema(result);
+    expect(result.id).toBe('claude-ping');
+    expect(result.status).toBe('skip');
+  });
+});
+
+describe('fail 시나리오', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fsModule.readFileSync).mockReturnValue('linux');
+  });
+
+  it('checkClaudeCli: exitCode 1 → status=fail, fixSteps>0, docsUrl 존재', async () => {
+    mockRunCli.mockResolvedValue(cliFail('command not found: claude'));
+    const result = await checkClaudeCli();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+    expect(result.docsUrl).toBeTruthy();
+  });
+
+  it('checkClaudeCli: 버전 < 최소(1.0.0) → status=warn, fixSteps>0', async () => {
+    mockRunCli.mockResolvedValue(cliOk('0.9.0'));
+    const result = await checkClaudeCli();
+    expect(result.status).toBe('warn');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkClaudeLogin: not logged in → status=fail, fixSteps>0', async () => {
+    mockRunCli.mockResolvedValue(cliFail('not logged in'));
+    const result = await checkClaudeLogin();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+    expect(result.docsUrl).toBeTruthy();
+  });
+
+  it('checkGhAuth: 미로그인 → status=fail, fixSteps gh auth login 포함', async () => {
+    mockRunCli.mockResolvedValue(cliFail('no credentials found'));
+    const result = await checkGhAuth();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps).toContain('gh auth login');
+  });
+
+  it('checkGhAuth: scope 누락(repo, workflow 없음) → status=warn, detail에 누락 scope 포함', async () => {
+    mockRunCli.mockResolvedValue(
+      cliOk("Logged in to github.com\nToken scopes: 'read:org'"),
+    );
+    const result = await checkGhAuth();
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('repo');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkNodeVersion: v18 → status=fail, detail에 버전 포함', async () => {
+    mockRunCli.mockResolvedValue(cliOk('v18.17.0'));
+    const result = await checkNodeVersion();
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('18');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkNodeVersion: node 없음(exitCode 1) → status=fail', async () => {
+    mockRunCli.mockResolvedValue(cliFail('not found'));
+    const result = await checkNodeVersion();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkGitIdentity: user.name 누락 → status=fail, detail에 user.name 포함', async () => {
+    mockRunCli
+      .mockResolvedValueOnce(cliOk(''))
+      .mockResolvedValueOnce(cliOk('test@example.com'));
+    const result = await checkGitIdentity();
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('user.name');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkGithubPing: exitCode 1 → status=fail', async () => {
+    mockRunCli.mockResolvedValue(cliFail('Could not resolve host'));
+    const result = await checkGithubPing();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkClaudePing: enableClaudePing=true, exitCode 1 → status=fail', async () => {
+    mockRunCli.mockResolvedValue(cliFail('API key invalid'));
+    const result = await checkClaudePing({ enableClaudePing: true });
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkClaudePing: enableClaudePing=true, 성공 → status=pass', async () => {
+    mockRunCli.mockResolvedValue(cliOk('Hello!'));
+    const result = await checkClaudePing({ enableClaudePing: true });
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkAqmWritable: 디렉토리 미존재 + 부모 쓰기 가능 → status=warn', async () => {
+    vi.mocked(fsModule.existsSync).mockReturnValue(false);
+    vi.mocked(fsModule.accessSync).mockImplementation(() => undefined);
+    const result = await checkAqmWritable();
+    expect(result.status).toBe('warn');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+
+  it('checkAqmWritable: accessSync 예외 → status=fail', async () => {
+    vi.mocked(fsModule.existsSync).mockReturnValue(true);
+    vi.mocked(fsModule.accessSync).mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+    const result = await checkAqmWritable();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+  });
+});
+
+describe('checkSqliteNative fail 시나리오', () => {
+  it('better-sqlite3 로드 실패 → status=fail, fixSteps>0, detail에 native 포함', async () => {
+    vi.resetModules();
+    vi.doMock('better-sqlite3', () => {
+      throw new Error('node_modules not found');
+    });
+    const { checkSqliteNative: check } = await import('../src/doctor/checks.js');
+    const result = await check();
+    expect(result.status).toBe('fail');
+    expect(result.fixSteps.length).toBeGreaterThan(0);
+    expect(result.detail.toLowerCase()).toContain('native');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #741 — feat: Doctor 10개 Check 구현 (claude/gh/git/Node/sqlite/권한/ping)

기존 `src/setup/doctor.ts`는 console.log 기반 monolithic 구조로, 구조화된 Check 스키마(`{ id, label, severity, status, detail, fixSteps[], autoFixCommand?, docsUrl }`)를 따르지 않는다. 이슈 #741은 `src/doctor/checks.ts`에 10개 Check를 구조화된 인터페이스로 구현하고, runner를 만들고, 스키마 검증 + fail 시나리오 mock 테스트를 작성하는 것이다. depends: #735 (Doctor 스켈레톤 + Check API)가 `src/setup/doctor.ts`에 이미 존재하므로, 새로운 `src/doctor/` 모듈로 구조화된 Check 시스템을 구축한다.

## Requirements

- 10개 Check 각각 `{ id, label, severity, status, detail, fixSteps[], autoFixCommand?, docsUrl }` 스키마 준수
- fail/warn 시 fixSteps·docsUrl 필수 반환
- Check 목록: (1) claude CLI 존재+버전 (2) claude 로그인 상태 (3) gh CLI 존재 (4) gh auth status + scope(repo, workflow) (5) git identity(name/email) (6) Node ≥ 20 (WSL 감지 포함) (7) better-sqlite3 native build 로드 (8) ~/.aqm 쓰기 권한 (9) GitHub API ping (10) Claude 모델 1토큰 ping(기본 off)
- src/doctor/index.ts에 Check runner 구현
- tests/doctor-checks.test.ts — 10개 Check 모두 결과 스키마 검증 + 최소 한 개 fail 시나리오 mock 테스트
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: Check 타입 정의 + Runner — SUCCESS (8b103282)
- Phase 1: Check 1-5 구현 (CLI + Auth + Git Identity) — SUCCESS (30ac6164)
- Phase 2: Check 6-10 구현 (Node/sqlite/권한/ping) — SUCCESS (30ac6164)
- Phase 3: 테스트 작성 — SUCCESS (9cc18553)
- Phase 4: 통합 검증 — SUCCESS (48674b5c)

## Risks

- better-sqlite3 native import를 테스트에서 mock하기 까다로울 수 있음 — createRequire 또는 dynamic import mock 필요
- claude 로그인 상태 확인 CLI 명령이 버전에 따라 다를 수 있음 — claude auth status 대신 claude --version 후 auth 체크 필요
- WSL 감지 시 /proc/version이 존재하지 않는 환경(macOS) 대응 필요
- 기존 src/setup/doctor.ts와의 관계 정리 — 이번 이슈에서는 새 모듈만 작성하고, 기존 doctor.ts 교체는 별도 이슈

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $4.1293 (review: $0.2434)
- **Phases**: 6/6 completed
- **Branch**: `aq/741-feat-doctor-10-check-claude-gh-git-node-sqlite-pin` → `develop`
- **Tokens**: 243 input, 57145 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| Check 타입 정의 + Runner | $0.3567 | 0 | $0.0000 |
| Check 1-5 구현 (CLI + Auth + Git Identity) | $0.8482 | 0 | $0.0000 |
| Check 6-10 구현 (Node/sqlite/권한/ping) | $0.9015 | 0 | $0.0000 |
| 테스트 작성 | $0.6438 | 0 | $0.0000 |
| 통합 검증 | $0.3545 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $3.1047 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #741