### PR TITLE
hotfix: v0.7.4 — bin/aqm config.yml 자동 주입 (임의 디렉토리 실행 복구)

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -64,20 +64,47 @@ resolve_claude_config_dir() {
 }
 resolve_claude_config_dir
 
+# --config는 반드시 서브커맨드 뒤에 삽입한다.
+# parseArgs()가 argv[0]을 command로 간주하므로 --config를 맨 앞에 두면
+# command 인식이 깨진다. 첫 인자(서브커맨드) 뒤에 끼워넣는다.
+# 사용자가 "$@"가 비어 있거나 첫 인자가 플래그인 경우는 주입하지 않는다.
+inject_default_config() {
+  INJECTED_ARGS=("$@")
+  if [ ! -f "$AQM_ROOT/config.yml" ]; then
+    return 0
+  fi
+  if [ $# -eq 0 ]; then
+    return 0
+  fi
+  case "$1" in
+    --*) return 0 ;;
+  esac
+  for arg in "$@"; do
+    case "$arg" in
+      --config|--config=*) return 0 ;;
+    esac
+  done
+  local subcmd="$1"
+  shift
+  INJECTED_ARGS=("$subcmd" --config "$AQM_ROOT/config.yml" "$@")
+}
+
 # CLI 실행 헬퍼
 run_cli() {
+  inject_default_config "$@"
   if [ "$AQM_MODE" = "npm" ]; then
-    node "$AQM_ROOT/dist/cli.js" "$@"
+    node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}"
   else
-    npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "$@"
+    npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}"
   fi
 }
 
 exec_cli() {
+  inject_default_config "$@"
   if [ "$AQM_MODE" = "npm" ]; then
-    exec node "$AQM_ROOT/dist/cli.js" "$@"
+    exec node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}"
   else
-    exec npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "$@"
+    exec npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}"
   fi
 }
 
@@ -271,11 +298,12 @@ case "${1:-}" in
 
       mkdir -p "$AQM_DATA_DIR/logs"
       echo "서버를 백그라운드에서 시작합니다..."
+      inject_default_config start "${ARGS[@]}"
       if [ "$AQM_MODE" = "npm" ]; then
-        nohup node "$AQM_ROOT/dist/cli.js" start "${ARGS[@]}" \
+        nohup node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" \
           >> "$AQM_LOG_FILE" 2>&1 &
       else
-        nohup npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" start "${ARGS[@]}" \
+        nohup npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" \
           >> "$AQM_LOG_FILE" 2>&1 &
       fi
       echo $! > "$AQM_PID_FILE"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- `bin/aqm` 래퍼가 cwd와 무관하게 설치 경로의 `config.yml`을 찾도록 `--config`를 서브커맨드 뒤에 자동 주입
- 기존에는 cwd가 AQM_ROOT인 경우에만 동작 → `/home/$USER` 등 임의 경로에서 `aqm start` 시 `CONFIG_NOT_FOUND`로 실패
- 사용자가 직접 `--config`를 지정했거나 첫 인자가 플래그/없음인 경우는 주입 스킵
- 버전 bump: 0.7.3 → 0.7.4 (hotfix only, Plan B UI 변경 미포함)

## 적용 범위
- `run_cli` / `exec_cli` / `start --daemon` nohup 경로 모두 커버

## Test plan
- [x] `bash -n bin/aqm` 문법 통과
- [x] `/home/$USER`에서 `aqm doctor` 정상 실행 확인
- [x] `/home/$USER`에서 `aqm version` 정상 출력 확인
- [x] 인자 없이 호출 시 기존 도움말 동작 유지 확인
- [x] `npx tsc --noEmit` 통과
- [ ] 머지 후 `aqm update`로 본인 환경 반영 확인