### PR TITLE
[AQ-#765] feat: AQM 병렬 파이프라인 depends 게이트 — stale base 충돌 방지

### DIFF
--- a/src/server/event-dispatcher.ts
+++ b/src/server/event-dispatcher.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "../utils/logger.js";
 import { listConfiguredRepos } from "../config/project-resolver.js";
 import type { AQConfig } from "../types/config.js";
-import { parseDependencies, checkCircularDependency } from "../queue/dependency-resolver.js";
+import { parseDependencies, checkCircularDependency, checkDependencyPRsMerged } from "../queue/dependency-resolver.js";
 import type { JobStore } from "../queue/job-store.js";
 import { isAllowedOwner, hasInstanceOwnersConfigured } from "../safety/label-filter.js";
 
@@ -36,13 +36,13 @@ export interface DispatchResult {
  * Evaluates a GitHub webhook event and determines if it should trigger a pipeline.
  * Only processes "issues" events with "labeled" action containing the trigger label.
  */
-export function dispatchEvent(
+export async function dispatchEvent(
   eventType: string,
   payload: GitHubIssueEvent,
   triggerLabels: string[],
   config?: AQConfig,
   store?: JobStore
-): DispatchResult {
+): Promise<DispatchResult> {
   // Defensive validation: ensure required fields are present
   if (!payload?.issue?.number || !Array.isArray(payload?.issue?.labels) || !payload?.repository?.full_name) {
     return { shouldProcess: false, reasonCode: "invalid_payload", reason: "Malformed payload: missing required fields" };
@@ -119,6 +119,24 @@ export function dispatchEvent(
         shouldProcess: false,
         reasonCode: "circular_dependency",
         reason: `Circular dependency detected for issue #${payload.issue.number}`,
+      };
+    }
+  }
+
+  // Check if dependency PRs are merged on GitHub (only when dependencies exist and config is available)
+  if (dependencies.length > 0 && config) {
+    const ghPath = config.commands.ghCli.path ?? "gh";
+    const prCheck = await checkDependencyPRsMerged(dependencies, repo, ghPath);
+    if (prCheck.unmerged.length > 0) {
+      const unmergedList = prCheck.unmerged.map(n => `#${n}`).join(", ");
+      logger.warn(
+        `Dependency PRs not merged for issue #${payload.issue.number} in ${repo}: ${unmergedList} — deferring`
+      );
+      return {
+        shouldProcess: false,
+        reasonCode: "dependency_pr_not_merged",
+        reason: `의존 PR 미머지: ${unmergedList}`,
+        dependencies,
       };
     }
   }

--- a/src/server/webhook-server.ts
+++ b/src/server/webhook-server.ts
@@ -46,7 +46,7 @@ export function createWebhookApp(options: WebhookServerOptions): Hono {
       options.config.general.instanceLabel,
       options.config.safety.allowedLabels
     );
-    const result = dispatchEvent(
+    const result = await dispatchEvent(
       eventType,
       payload,
       triggerLabels,

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { dispatchEvent } from "../../src/server/event-dispatcher.js";
 import type { AQConfig } from "../../src/types/config.js";
 import type { JobStore } from "../../src/queue/job-store.js";
 import type { Job } from "../../src/types/pipeline.js";
+import { checkDependencyPRsMerged } from "../../src/queue/dependency-resolver.js";
+
+vi.mock("../../src/queue/dependency-resolver.js", async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    checkDependencyPRsMerged: vi.fn(),
+  };
+});
 
 const makePayload = (action: string, labels: string[], author = "user") => ({
   action,

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -124,4 +124,63 @@ describe("dispatchEvent", () => {
       expect(result.shouldProcess).toBe(true);
     });
   });
+
+  describe("dependency PR merge gate", () => {
+    const makeDepsConfig = (): AQConfig => ({
+      general: { instanceOwners: ["user"] },
+      git: { allowedRepos: ["test/repo"] },
+      commands: { ghCli: { path: "gh" } },
+      projects: [],
+    } as unknown as AQConfig);
+
+    const makePayloadWithDeps = (depNumbers: number[]) => ({
+      action: "labeled",
+      issue: {
+        number: 42,
+        title: "Test",
+        body: `depends: ${depNumbers.map(n => `#${n}`).join(", ")}`,
+        labels: [{ name: "aqm" }],
+        user: { login: "user" },
+      },
+      repository: {
+        full_name: "test/repo",
+        default_branch: "main",
+      },
+    });
+
+    it("의존 PR 미머지 → shouldProcess: false, reasonCode: dependency_pr_not_merged", async () => {
+      vi.mocked(checkDependencyPRsMerged).mockResolvedValueOnce({
+        merged: false,
+        unmerged: [100],
+        notFound: [],
+      });
+
+      const result = await dispatchEvent(
+        "issues",
+        makePayloadWithDeps([100]),
+        ["aqm"],
+        makeDepsConfig()
+      );
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reasonCode).toBe("dependency_pr_not_merged");
+    });
+
+    it("의존 PR 머지됨 → shouldProcess: true", async () => {
+      vi.mocked(checkDependencyPRsMerged).mockResolvedValueOnce({
+        merged: true,
+        unmerged: [],
+        notFound: [],
+      });
+
+      const result = await dispatchEvent(
+        "issues",
+        makePayloadWithDeps([100]),
+        ["aqm"],
+        makeDepsConfig()
+      );
+
+      expect(result.shouldProcess).toBe(true);
+    });
+  });
 });

--- a/tests/server/event-dispatcher.test.ts
+++ b/tests/server/event-dispatcher.test.ts
@@ -26,59 +26,59 @@ const makeConfig = (instanceOwners: string[]): AQConfig => ({
 } as unknown as AQConfig);
 
 describe("dispatchEvent", () => {
-  it("should process issues.labeled with matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"]);
+  it("should process issues.labeled with matching label", async () => {
+    const result = await dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(true);
     expect(result.issueNumber).toBe(42);
     expect(result.repo).toBe("test/repo");
   });
 
-  it("should ignore non-issues events", () => {
-    const result = dispatchEvent("push", makePayload("labeled", ["aqm"]), ["aqm"]);
+  it("should ignore non-issues events", async () => {
+    const result = await dispatchEvent("push", makePayload("labeled", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
-  it("should ignore non-labeled actions", () => {
-    const result = dispatchEvent("issues", makePayload("opened", ["aqm"]), ["aqm"]);
+  it("should ignore non-labeled actions", async () => {
+    const result = await dispatchEvent("issues", makePayload("opened", ["aqm"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
-  it("should ignore when no matching label", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["bug"]), ["aqm"]);
+  it("should ignore when no matching label", async () => {
+    const result = await dispatchEvent("issues", makePayload("labeled", ["bug"]), ["aqm"]);
     expect(result.shouldProcess).toBe(false);
   });
 
-  it("should process when triggerLabels is empty (allow all)", () => {
-    const result = dispatchEvent("issues", makePayload("labeled", ["anything"]), []);
+  it("should process when triggerLabels is empty (allow all)", async () => {
+    const result = await dispatchEvent("issues", makePayload("labeled", ["anything"]), []);
     expect(result.shouldProcess).toBe(true);
   });
 
   describe("owner filtering", () => {
-    it("should block when instanceOwners is empty (not configured)", () => {
+    it("should block when instanceOwners is empty (not configured)", async () => {
       const config = makeConfig([]);
-      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "anyone"), ["ai-quartermaster"], config);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "anyone"), ["ai-quartermaster"], config);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toMatch(/instanceOwners/);
     });
 
-    it("should process when author is in instanceOwners", () => {
+    it("should process when author is in instanceOwners", async () => {
       const config = makeConfig(["alice", "bob"]);
-      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "alice"), ["ai-quartermaster"], config);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "alice"), ["ai-quartermaster"], config);
       expect(result.shouldProcess).toBe(true);
     });
 
-    it("should reject when author is not in instanceOwners", () => {
+    it("should reject when author is not in instanceOwners", async () => {
       const config = makeConfig(["alice", "bob"]);
-      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toContain("charlie");
       expect(result.reason).toContain("instanceOwners");
     });
 
-    it("should reject before repo check when owner is not allowed", () => {
+    it("should reject before repo check when owner is not allowed", async () => {
       const config = makeConfig(["alice"]);
       // charlie is not in instanceOwners — should fail on owner check
-      const result = dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["ai-quartermaster"], "charlie"), ["ai-quartermaster"], config);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toMatch(/instanceOwners/);
     });
@@ -89,29 +89,29 @@ describe("dispatchEvent", () => {
       findAnyByIssue: () => job as Job | undefined,
     });
 
-    it("should block dispatch when queued job already exists", () => {
+    it("should block dispatch when queued job already exists", async () => {
       const store = makeStore({ id: "aq-42-1", status: "queued", issueNumber: 42, repo: "test/repo" });
-      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toMatch(/queued/);
     });
 
-    it("should block dispatch when running job already exists", () => {
+    it("should block dispatch when running job already exists", async () => {
       const store = makeStore({ id: "aq-42-2", status: "running", issueNumber: 42, repo: "test/repo" });
-      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
       expect(result.shouldProcess).toBe(false);
       expect(result.reason).toMatch(/running/);
     });
 
-    it("should allow dispatch when only a success job exists", () => {
+    it("should allow dispatch when only a success job exists", async () => {
       const store = makeStore({ id: "aq-42-3", status: "success", issueNumber: 42, repo: "test/repo" });
-      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
       expect(result.shouldProcess).toBe(true);
     });
 
-    it("should allow dispatch when no existing job", () => {
+    it("should allow dispatch when no existing job", async () => {
       const store = makeStore(undefined);
-      const result = dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
+      const result = await dispatchEvent("issues", makePayload("labeled", ["aqm"]), ["aqm"], undefined, store as unknown as JobStore);
       expect(result.shouldProcess).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

Resolves #765 — feat: AQM 병렬 파이프라인 depends 게이트 — stale base 충돌 방지

동일 레이어 이슈를 동시에 큐잉하면 후발 PR이 구 API 기반으로 생성되어 stale base 충돌 발생. 이슈 본문의 `depends: #N` 메타가 텍스트로만 존재하고, 큐 스케줄러가 이를 읽지 않아 의존 PR 머지 전에 파이프라인이 시작됨. dispatchEvent에서 의존 PR 머지 여부를 확인하는 게이트를 추가하여, 미머지 시 보류하고 다음 폴링 사이클에서 재시도하도록 한다.

## Requirements

- 의존 이슈의 PR이 미머지 상태이면 dispatchEvent에서 shouldProcess: false 반환 (reasonCode: 'dependency_pr_not_merged')
- 보류된 이슈는 다음 폴링 사이클(general.pollingIntervalMs)에서 자연 재시도 — 별도 내부 큐 불필요
- 기존 parseDependencies/checkDependencyPRsMerged (src/queue/dependency-resolver.ts) 재사용 — 중복 파서 신규 생성 금지
- dispatchEvent를 sync→async 전환하고, 호출부(webhook-server.ts) 업데이트
- 기존 pr-merged 이벤트 흐름 및 기존 테스트 깨뜨리지 않을 것
- npx tsc --noEmit + npx vitest run 통과 필수

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: dispatchEvent async 전환 + 머지 게이트 추가 — SUCCESS (b25d01a6)
- Phase 1: webhook-server.ts 호출부 await 적용 — SUCCESS (99596dcb)
- Phase 2: 게이트 시나리오 테스트 추가 — SUCCESS (fe0a708b)
- Phase 3: 빌드 + 전체 테스트 검증 — SUCCESS (fe0a708b)

## Risks

- dispatchEvent sync→async 전환 시 기존 테스트가 await 없이 호출하면 Promise truthy로 항상 통과하는 위양성 발생 가능 — 기존 테스트 전부 await 추가 필수
- checkDependencyPRsMerged가 gh API 호출하므로 네트워크 지연 시 webhook 응답 느려질 수 있음 — 현재 구조에서는 허용 범위, 추후 필요 시 캐시 검토
- notFound(PR 없는 의존)를 통과 처리하면 아직 PR 미생성 이슈에 대한 게이트가 작동 안 함 — 현재 요구사항은 '머지 여부'만 체크이므로 의도된 동작

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.4961 (review: $0.1739)
- **Phases**: 5/5 completed
- **Branch**: `aq/765-feat-aqm-depends-stale-base` → `develop`
- **Tokens**: 139 input, 23271 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| dispatchEvent async 전환 + 머지 게이트 추가 | $0.7976 | 0 | $0.0000 |
| webhook-server.ts 호출부 await 적용 | $0.2113 | 0 | $0.0000 |
| 게이트 시나리오 테스트 추가 | $0.4003 | 0 | $0.0000 |
| 빌드 + 전체 테스트 검증 | $0.3970 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.8061 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #765