### PR TITLE
[AQ-#778] feat: 설치 원클릭화 — curl 1줄 스크립트 + Node/WSL 자동 감지 (Plan B B4)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,45 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+AQM_INSTALL_MODE="${AQM_INSTALL_MODE:-npm}"
 AQM_HOME="${AQM_HOME:-$HOME/.ai-quartermaster}"
 BIN_DIR="${HOME}/.local/bin"
 REPO_URL="https://github.com/happytalkrz/AI-Quartermaster.git"
+
+# ── OS / WSL 감지 ──────────────────────────────────────────────────────
+detect_os() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin)
+      echo "macos"
+      ;;
+    Linux)
+      # WSL_DISTRO_NAME / WSL_INTEROP 환경변수 체크 (detect-wsl.ts 동일 로직)
+      if [ -n "${WSL_DISTRO_NAME:-}" ] || [ -n "${WSL_INTEROP:-}" ]; then
+        echo "wsl"
+        return
+      fi
+      # /proc/sys/kernel/osrelease 파일 체크 (detect-wsl.ts 동일 로직)
+      if [ -f /proc/sys/kernel/osrelease ]; then
+        local release
+        release=$(cat /proc/sys/kernel/osrelease 2>/dev/null | tr '[:upper:]' '[:lower:]')
+        if echo "$release" | grep -qE 'microsoft|wsl'; then
+          echo "wsl"
+          return
+        fi
+      fi
+      echo "linux"
+      ;;
+    MINGW*|CYGWIN*|MSYS*)
+      # Windows Git Bash / Cygwin 에서 직접 실행된 경우
+      echo "windows"
+      ;;
+    *)
+      echo "unknown"
+      ;;
+  esac
+}
+
+OS=$(detect_os)
 
 echo -e "${BLUE}"
 echo "  ╔═══════════════════════════════════════╗"
@@ -18,148 +54,224 @@ echo "  ║   AI Quartermaster 설치               ║"
 echo "  ╚═══════════════════════════════════════╝"
 echo -e "${NC}"
 
-# 1. Check prerequisites
-echo -e "${YELLOW}1. 사전 요구사항 확인...${NC}"
+# ── Windows 감지: WSL 설치 안내 후 종료 ───────────────────────────────
+if [ "$OS" = "windows" ]; then
+  echo -e "  ${RED}✗ Windows 환경이 감지되었습니다.${NC}"
+  echo ""
+  echo -e "  AI Quartermaster는 WSL(Windows Subsystem for Linux)에서 실행해야 합니다."
+  echo ""
+  echo -e "  ${YELLOW}WSL 설치 방법:${NC}"
+  echo "    1. PowerShell(관리자)에서 실행:"
+  echo "       wsl --install"
+  echo "    2. 재부팅 후 Ubuntu 터미널을 열고 다시 설치 명령을 실행하세요."
+  echo ""
+  echo "    자세한 안내: https://learn.microsoft.com/ko-kr/windows/wsl/install"
+  echo ""
+  exit 1
+fi
 
-check_cmd() {
-  if ! command -v "$1" &>/dev/null; then
-    echo -e "  ${RED}✗ $1 — $2${NC}"
+# ── 1. Node.js 확인 ────────────────────────────────────────────────────
+echo -e "${YELLOW}1. Node.js 확인...${NC}"
+
+if ! command -v node &>/dev/null; then
+  echo -e "  ${RED}✗ Node.js가 설치되어 있지 않습니다.${NC}"
+  echo ""
+  case "$OS" in
+    macos)
+      echo -e "  ${YELLOW}macOS — Node.js 설치 방법:${NC}"
+      echo "    brew install node"
+      echo "    또는: https://nodejs.org/en/download"
+      ;;
+    wsl|linux)
+      echo -e "  ${YELLOW}Linux/WSL — Node.js 설치 방법:${NC}"
+      echo "    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -"
+      echo "    sudo apt-get install -y nodejs"
+      echo "    또는: https://nodejs.org/en/download"
+      ;;
+    *)
+      echo -e "  ${YELLOW}Node.js 설치: https://nodejs.org/en/download${NC}"
+      ;;
+  esac
+  echo ""
+  echo "  Node.js 20 이상 설치 후 다시 실행하세요."
+  exit 1
+fi
+
+NODE_VERSION=$(node -e "process.stdout.write(process.version)" 2>/dev/null)
+NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/v\([0-9]*\).*/\1/')
+if [ "${NODE_MAJOR:-0}" -lt 20 ] 2>/dev/null; then
+  echo -e "  ${RED}✗ Node.js $NODE_VERSION — v20 이상 필요합니다.${NC}"
+  echo "  https://nodejs.org/en/download 에서 최신 LTS를 설치하세요."
+  exit 1
+fi
+echo -e "  ${GREEN}✓ Node.js $NODE_VERSION${NC}"
+
+if ! command -v npm &>/dev/null; then
+  echo -e "  ${RED}✗ npm이 없습니다. Node.js를 재설치하세요: https://nodejs.org${NC}"
+  exit 1
+fi
+echo -e "  ${GREEN}✓ npm $(npm --version 2>/dev/null)${NC}"
+
+# gh / claude 확인 (선택 사항 — 경고만 출력)
+echo ""
+echo -e "${YELLOW}  [선택 도구 확인]${NC}"
+check_optional() {
+  local cmd="$1" url="$2"
+  if ! command -v "$cmd" &>/dev/null; then
+    echo -e "  ${YELLOW}⚠ $cmd 없음 — 나중에 설치: $url${NC}"
+  else
+    echo -e "  ${GREEN}✓ $cmd${NC}"
+  fi
+}
+check_optional "gh"     "https://cli.github.com"
+check_optional "claude" "https://docs.anthropic.com/en/docs/claude-code"
+echo ""
+
+# ── 2. 설치 ────────────────────────────────────────────────────────────
+NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX.log)
+
+if [ "$AQM_INSTALL_MODE" = "git" ]; then
+  # ── git-clone 모드 (AQM_INSTALL_MODE=git) ─────────────────────────
+  echo -e "${YELLOW}2. AI Quartermaster 설치 (git 모드)...${NC}"
+
+  if ! command -v git &>/dev/null; then
+    echo -e "  ${RED}✗ git — https://git-scm.com 에서 설치하세요${NC}"
     exit 1
   fi
-  echo -e "  ${GREEN}✓ $1${NC}"
-}
 
-check_cmd "git" "https://git-scm.com 에서 설치하세요"
-check_cmd "node" "https://nodejs.org 에서 Node.js 20+ 설치하세요"
-check_cmd "npm" "Node.js 설치 시 함께 설치됩니다"
-check_cmd "gh" "https://cli.github.com 에서 설치 후 gh auth login 하세요"
-check_cmd "claude" "https://docs.anthropic.com/en/docs/claude-code 에서 설치하세요"
-
-# Native build tools preflight (warning only — prebuilt binary로 충분할 수 있음)
-echo ""
-echo -e "${YELLOW}  [native build tools 확인]${NC}"
-NATIVE_WARN=0
-for tool in python3 make g++; do
-  if ! command -v "$tool" &>/dev/null; then
-    echo -e "  ${YELLOW}⚠ $tool 없음 — prebuilt binary 없을 경우 better-sqlite3 소스 빌드 실패 가능${NC}"
-    NATIVE_WARN=1
+  if [ -d "$AQM_HOME" ]; then
+    echo -e "  기존 설치 업데이트..."
+    cd "$AQM_HOME"
+    git pull --quiet
+    npm install --silent 2>"$NPM_LOG" || {
+      echo -e "  ${RED}✗ npm install 실패${NC}"
+      echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
+      tail -20 "$NPM_LOG"
+      exit 1
+    }
+    echo -e "  ${GREEN}✓ 업데이트 완료${NC}"
   else
-    echo -e "  ${GREEN}✓ $tool${NC}"
+    git clone --depth 1 "$REPO_URL" "$AQM_HOME" --quiet
+    cd "$AQM_HOME"
+    npm install --silent 2>"$NPM_LOG" || {
+      echo -e "  ${RED}✗ npm install 실패${NC}"
+      echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
+      tail -20 "$NPM_LOG"
+      exit 1
+    }
+    echo -e "  ${GREEN}✓ 설치 완료: $AQM_HOME${NC}"
   fi
-done
-if [ "$NATIVE_WARN" -eq 1 ]; then
-  echo -e "  ${YELLOW}→ 소스 빌드가 필요한 환경(Alpine Linux, 구버전 macOS arm64 등)에서는"
-  echo -e "    python3, make, g++ 설치 후 다시 시도하세요${NC}"
-fi
 
-# Print claude version
-CLAUDE_VERSION=$(claude --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-if [ -n "$CLAUDE_VERSION" ]; then
-  echo -e "  ${GREEN}  claude 버전: v${CLAUDE_VERSION}${NC}"
-fi
-echo ""
-
-# better-sqlite3 로드 검증 함수
-verify_better_sqlite3() {
+  # better-sqlite3 로드 검증
   echo -e "${YELLOW}  [better-sqlite3 로드 검증]${NC}"
   if node -e "require('better-sqlite3')" 2>/dev/null; then
     echo -e "  ${GREEN}✓ better-sqlite3 정상 로드${NC}"
   else
     echo -e "  ${RED}✗ better-sqlite3 로드 실패${NC}"
     echo ""
-    echo -e "  ${YELLOW}── 진단 정보 ──${NC}"
-    echo -e "  Node.js 버전: $(node -v 2>&1)"
-    echo -e "  시스템: $(uname -a 2>&1)"
-    echo -e "  패키지 상태:"
-    npm ls better-sqlite3 2>&1 | sed 's/^/    /'
-    echo ""
     echo -e "  ${YELLOW}해결 방법:${NC}"
-    echo -e "  1. python3, make, g++ 설치 후 npm rebuild better-sqlite3 실행"
-    echo -e "  2. 문제가 지속되면 위 진단 정보와 함께 이슈를 제보하세요:"
-    echo -e "     https://github.com/happytalkrz/AI-Quartermaster/issues"
+    echo "  1. python3, make, g++ 설치 후 npm rebuild better-sqlite3 실행"
+    echo "  2. 문제가 지속되면 이슈를 제보하세요:"
+    echo "     https://github.com/happytalkrz/AI-Quartermaster/issues"
     exit 1
   fi
-}
-
-# 2. Install or update
-NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX.log)
-
-if [ -d "$AQM_HOME" ]; then
-  echo -e "${YELLOW}2. 기존 설치 업데이트...${NC}"
-  cd "$AQM_HOME"
-  git pull --quiet
-  npm install --silent 2>"$NPM_LOG" || {
-    echo -e "  ${RED}✗ npm install 실패${NC}"
-    echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
-    echo -e "  ${YELLOW}→ tail -20 $NPM_LOG${NC}"
-    exit 1
-  }
-  echo -e "  ${GREEN}✓ 업데이트 완료${NC}"
-  verify_better_sqlite3
-else
-  echo -e "${YELLOW}2. AI Quartermaster 설치...${NC}"
-  git clone --depth 1 "$REPO_URL" "$AQM_HOME" --quiet
-  cd "$AQM_HOME"
-  npm install --silent 2>"$NPM_LOG" || {
-    echo -e "  ${RED}✗ npm install 실패${NC}"
-    echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
-    echo -e "  ${YELLOW}→ tail -20 $NPM_LOG${NC}"
-    exit 1
-  }
-  echo -e "  ${GREEN}✓ 설치 완료: $AQM_HOME${NC}"
-  verify_better_sqlite3
-fi
-echo ""
-
-# 3. Install aqm wrapper from bin/aqm
-echo -e "${YELLOW}3. aqm 명령어 등록...${NC}"
-mkdir -p "$BIN_DIR"
-cp "$AQM_HOME/bin/aqm" "$BIN_DIR/aqm"
-chmod +x "$BIN_DIR/aqm"
-echo -e "  ${GREEN}✓ aqm 명령어 생성: $BIN_DIR/aqm${NC}"
-
-# 4. Add to PATH if needed
-if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
   echo ""
-  echo -e "${YELLOW}4. PATH 등록...${NC}"
 
-  SHELL_RC=""
-  if [ -f "$HOME/.zshrc" ]; then
-    SHELL_RC="$HOME/.zshrc"
-  elif [ -f "$HOME/.bashrc" ]; then
-    SHELL_RC="$HOME/.bashrc"
-  elif [ -f "$HOME/.bash_profile" ]; then
-    SHELL_RC="$HOME/.bash_profile"
+  # aqm wrapper 등록
+  echo -e "${YELLOW}3. aqm 명령어 등록...${NC}"
+  mkdir -p "$BIN_DIR"
+  cp "$AQM_HOME/bin/aqm" "$BIN_DIR/aqm"
+  chmod +x "$BIN_DIR/aqm"
+  echo -e "  ${GREEN}✓ aqm 명령어 생성: $BIN_DIR/aqm${NC}"
+
+  # PATH 등록
+  if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+    echo ""
+    echo -e "${YELLOW}4. PATH 등록...${NC}"
+    SHELL_RC=""
+    if [ -f "$HOME/.zshrc" ]; then
+      SHELL_RC="$HOME/.zshrc"
+    elif [ -f "$HOME/.bashrc" ]; then
+      SHELL_RC="$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+      SHELL_RC="$HOME/.bash_profile"
+    fi
+
+    if [ -n "$SHELL_RC" ]; then
+      if ! grep -q '.local/bin' "$SHELL_RC" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
+        echo -e "  ${GREEN}✓ $SHELL_RC에 PATH 추가됨${NC}"
+        echo -e "  ${YELLOW}→ 새 터미널을 열거나 source $SHELL_RC 실행하세요${NC}"
+      else
+        echo -e "  ${GREEN}✓ PATH 이미 등록됨${NC}"
+      fi
+    else
+      echo -e "  ${YELLOW}→ $BIN_DIR 를 PATH에 수동 추가하세요${NC}"
+    fi
   fi
 
-  if [ -n "$SHELL_RC" ]; then
-    if ! grep -q '.local/bin' "$SHELL_RC" 2>/dev/null; then
-      echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC"
-      echo -e "  ${GREEN}✓ $SHELL_RC에 PATH 추가됨${NC}"
-      echo -e "  ${YELLOW}→ 새 터미널을 열거나 source $SHELL_RC 실행하세요${NC}"
-    else
-      echo -e "  ${GREEN}✓ PATH 이미 등록됨${NC}"
-    fi
+else
+  # ── npm global 모드 (기본) ─────────────────────────────────────────
+  echo -e "${YELLOW}2. AI Quartermaster 설치 (npm global)...${NC}"
+  npm install -g ai-quartermaster 2>"$NPM_LOG" || {
+    echo -e "  ${RED}✗ npm install -g 실패${NC}"
+    echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
+    tail -20 "$NPM_LOG"
+    exit 1
+  }
+  echo -e "  ${GREEN}✓ ai-quartermaster 설치 완료${NC}"
+  echo ""
+
+  # aqm 명령어 PATH 확인
+  echo -e "${YELLOW}3. aqm 명령어 확인...${NC}"
+  if command -v aqm &>/dev/null; then
+    echo -e "  ${GREEN}✓ aqm 정상 등록됨${NC}"
   else
-    echo -e "  ${YELLOW}→ $BIN_DIR 를 PATH에 수동 추가하세요${NC}"
+    NPM_GLOBAL_BIN=$(npm prefix -g 2>/dev/null)/bin
+    echo -e "  ${YELLOW}⚠ aqm 명령어가 PATH에 없습니다.${NC}"
+    echo -e "  ${YELLOW}→ 다음을 실행하여 PATH에 추가하세요:${NC}"
+    echo "    export PATH=\"\$PATH:$NPM_GLOBAL_BIN\""
+    echo ""
+    SHELL_RC=""
+    if [ -f "$HOME/.zshrc" ]; then
+      SHELL_RC="$HOME/.zshrc"
+    elif [ -f "$HOME/.bashrc" ]; then
+      SHELL_RC="$HOME/.bashrc"
+    elif [ -f "$HOME/.bash_profile" ]; then
+      SHELL_RC="$HOME/.bash_profile"
+    fi
+    if [ -n "$SHELL_RC" ]; then
+      if ! grep -qF "$NPM_GLOBAL_BIN" "$SHELL_RC" 2>/dev/null; then
+        echo "export PATH=\"\$PATH:$NPM_GLOBAL_BIN\"" >> "$SHELL_RC"
+        echo -e "  ${GREEN}✓ $SHELL_RC에 PATH 추가됨${NC}"
+        echo -e "  ${YELLOW}→ 새 터미널을 열거나 source $SHELL_RC 실행하세요${NC}"
+      fi
+    fi
   fi
 fi
 
+# ── 완료 메시지 ────────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}╔═══════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║        설치 완료!                      ║${NC}"
 echo -e "${GREEN}╚═══════════════════════════════════════╝${NC}"
 echo ""
-echo "Quick Start:"
-echo "  aqm setup                                       초기 설정"
-echo "  aqm start --daemon --mode polling               폴링 모드 백그라운드 실행"
-echo ""
-echo "Commands:"
-echo "  aqm start [--daemon] [--mode polling]           서버 시작"
-echo "  aqm stop / restart / logs                       서버 관리"
-echo "  aqm run --issue <n> --repo <owner/repo>         수동 실행"
-echo "  aqm resume --job <id>                           실패 파이프라인 재개"
-echo "  aqm plan --repo <owner/repo>                    이슈 분석"
-echo "  aqm status / stats / doctor                     모니터링"
-echo "  aqm help                                        전체 명령어"
-echo ""
+
+# ── aqm setup 자동 호출 ────────────────────────────────────────────────
+if command -v aqm &>/dev/null; then
+  echo -e "${YELLOW}초기 설정을 시작합니다...${NC}"
+  echo ""
+  aqm setup
+else
+  echo "설치 후 새 터미널을 열고 다음 명령어로 초기 설정을 완료하세요:"
+  echo ""
+  echo "  aqm setup"
+  echo ""
+  echo "Commands:"
+  echo "  aqm start [--daemon] [--mode polling]           서버 시작"
+  echo "  aqm stop / restart / logs                       서버 관리"
+  echo "  aqm run --issue <n> --repo <owner/repo>         수동 실행"
+  echo "  aqm status / stats / doctor                     모니터링"
+  echo "  aqm help                                        전체 명령어"
+  echo ""
+fi

--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,13 @@ if [ "$AQM_INSTALL_MODE" = "git" ]; then
 else
   # ── npm global 모드 (기본) ─────────────────────────────────────────
   echo -e "${YELLOW}2. AI Quartermaster 설치 (npm global)...${NC}"
+  # npm 패키지 존재 여부 먼저 확인
+  if ! npm view ai-quartermaster version 2>/dev/null | grep -q .; then
+    echo -e "  ${RED}✗ npm 패키지 'ai-quartermaster'를 찾을 수 없습니다${NC}"
+    echo -e "  ${YELLOW}→ 패키지가 아직 배포되지 않았거나 npm 레지스트리에 없습니다${NC}"
+    echo -e "  ${YELLOW}→ 소스 설치 방법: INSTALL_MODE=source bash <(curl -fsSL $INSTALL_URL)${NC}"
+    exit 1
+  fi
   npm install -g ai-quartermaster 2>"$NPM_LOG" || {
     echo -e "  ${RED}✗ npm install -g 실패${NC}"
     echo -e "  ${YELLOW}→ 로그: $NPM_LOG${NC}"
@@ -259,9 +266,18 @@ echo ""
 
 # ── aqm setup 자동 호출 ────────────────────────────────────────────────
 if command -v aqm &>/dev/null; then
-  echo -e "${YELLOW}초기 설정을 시작합니다...${NC}"
-  echo ""
-  aqm setup
+  if [ -t 0 ]; then
+    # 터미널에서 직접 실행 시: 대화형 설정 진행
+    echo -e "${YELLOW}초기 설정을 시작합니다...${NC}"
+    echo ""
+    aqm setup
+  else
+    # curl | bash 파이프 실행 시: stdin이 파이프이므로 대화형 프롬프트 불가
+    echo -e "${YELLOW}설치 완료! 설정을 시작하려면 새 터미널에서 실행하세요:${NC}"
+    echo ""
+    echo "  aqm setup"
+    echo ""
+  fi
 else
   echo "설치 후 새 터미널을 열고 다음 명령어로 초기 설정을 완료하세요:"
   echo ""

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -300,13 +300,16 @@ async function checkAqmDirWrite(): Promise<DoctorCheck> {
       detail: `${aqmDir} 디렉토리에 쓰기 권한이 있습니다.`,
       fixSteps: [],
     };
-  } catch {
+  } catch (err) {
+    const isEnoent = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
     return {
       id: 'aqm-dir-write',
       label: 'AQM 디렉토리 쓰기 권한',
       severity: 'critical',
       status: 'fail',
-      detail: `${aqmDir} 디렉토리에 쓰기 권한이 없습니다.`,
+      detail: isEnoent
+        ? `${aqmDir} 디렉토리가 존재하지 않습니다.`
+        : `${aqmDir} 디렉토리에 쓰기 권한이 없습니다.`,
       fixSteps: [
         `mkdir -p ${aqmDir} 명령어로 디렉토리를 생성하세요.`,
         `chmod u+w ${aqmDir} 명령어로 쓰기 권한을 부여하세요.`,

--- a/src/doctor/checks.ts
+++ b/src/doctor/checks.ts
@@ -288,6 +288,34 @@ async function checkSqlite3(): Promise<DoctorCheck> {
   }
 }
 
+async function checkAqmDirWrite(): Promise<DoctorCheck> {
+  const aqmDir = `${homedir()}/.aqm`;
+  try {
+    await access(aqmDir, constants.W_OK);
+    return {
+      id: 'aqm-dir-write',
+      label: 'AQM 디렉토리 쓰기 권한',
+      severity: 'critical',
+      status: 'pass',
+      detail: `${aqmDir} 디렉토리에 쓰기 권한이 있습니다.`,
+      fixSteps: [],
+    };
+  } catch {
+    return {
+      id: 'aqm-dir-write',
+      label: 'AQM 디렉토리 쓰기 권한',
+      severity: 'critical',
+      status: 'fail',
+      detail: `${aqmDir} 디렉토리에 쓰기 권한이 없습니다.`,
+      fixSteps: [
+        `mkdir -p ${aqmDir} 명령어로 디렉토리를 생성하세요.`,
+        `chmod u+w ${aqmDir} 명령어로 쓰기 권한을 부여하세요.`,
+      ],
+      healLevel: 1,
+    };
+  }
+}
+
 async function checkGitHubApiPing(): Promise<DoctorCheck> {
   try {
     const { stdout } = await execFileAsync('gh', ['api', '/user', '--jq', '.login']);
@@ -356,6 +384,7 @@ export async function runAllChecks(options: RunAllChecksOptions = {}): Promise<D
     checkNodeVersion(),
     checkGitIdentity(),
     checkSqlite3(),
+    checkAqmDirWrite(),
     checkGitHubApiPing(),
   ];
 

--- a/tests/detect-wsl.test.ts
+++ b/tests/detect-wsl.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { detectWSL } from '../src/utils/detect-wsl.js';
+
+/**
+ * detectWSL 엣지 케이스 테스트
+ * 기본 시나리오는 tests/utils/detect-wsl.test.ts에서 커버한다.
+ * 여기서는 빈 문자열, 대소문자, 복수 env var 동시 설정 등 경계 조건을 검증한다.
+ *
+ * 주의: WSL 환경에서 실행되므로 osreleasePath를 반드시 임시 파일로 지정해야
+ * /proc/sys/kernel/osrelease 의 실제 내용에 영향을 받지 않는다.
+ */
+describe('detectWSL (edge cases)', () => {
+  it('WSL_DISTRO_NAME=""(빈 문자열) → false', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, '6.1.0-generic\n');
+    expect(detectWSL({ env: { WSL_DISTRO_NAME: '' }, osreleasePath })).toBe(false);
+  });
+
+  it('WSL_INTEROP=""(빈 문자열) → false', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, '6.1.0-generic\n');
+    expect(detectWSL({ env: { WSL_INTEROP: '' }, osreleasePath })).toBe(false);
+  });
+
+  it('두 env var 동시 설정 → true', () => {
+    expect(detectWSL({
+      env: { WSL_DISTRO_NAME: 'Ubuntu', WSL_INTEROP: '/run/WSL/1_interop' },
+    })).toBe(true);
+  });
+
+  it('osrelease에 "Microsoft" (대문자 M) → true (소문자 변환 후 비교)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, '5.15.167.4-Microsoft-standard-WSL2\n');
+    expect(detectWSL({ env: {}, osreleasePath })).toBe(true);
+  });
+
+  it('osrelease에 "WSL" (대문자) → true (소문자 변환 후 비교)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, '5.10.0-WSL2-custom\n');
+    expect(detectWSL({ env: {}, osreleasePath })).toBe(true);
+  });
+
+  it('osrelease가 여러 줄이어도 "microsoft" 포함 시 → true', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, 'info: some\n5.15.167.4-microsoft-standard-WSL2\nextra: line\n');
+    expect(detectWSL({ env: {}, osreleasePath })).toBe(true);
+  });
+
+  it('WSL_DISTRO_NAME만 undefined → env var 조건 불충족', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wsl-edge-'));
+    const osreleasePath = join(dir, 'osrelease');
+    writeFileSync(osreleasePath, '6.1.0-generic\n');
+    expect(detectWSL({ env: { WSL_DISTRO_NAME: undefined }, osreleasePath })).toBe(false);
+  });
+
+  it('options 미전달 시 예외 없이 실행됨 (process.env 사용)', () => {
+    expect(() => detectWSL()).not.toThrow();
+  });
+});

--- a/tests/install-script.test.ts
+++ b/tests/install-script.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const INSTALL_SH = resolve(__dirname, '..', 'install.sh');
+
+/**
+ * install.sh에서 detect_os 함수를 추출하고,
+ * 하드코딩된 /proc/sys/kernel/osrelease 경로를 테스트용 경로로 교체한다.
+ */
+function extractDetectOsFn(osreleasePath: string): string {
+  const content = readFileSync(INSTALL_SH, 'utf-8');
+  const lines = content.split('\n');
+  const funcLines: string[] = [];
+  let collecting = false;
+  let braceDepth = 0;
+
+  for (const line of lines) {
+    if (!collecting && /^detect_os\(\)/.test(line)) {
+      collecting = true;
+    }
+    if (collecting) {
+      funcLines.push(line);
+      braceDepth += (line.match(/\{/g) ?? []).length;
+      braceDepth -= (line.match(/\}/g) ?? []).length;
+      if (braceDepth === 0 && funcLines.length > 1) break;
+    }
+  }
+
+  if (funcLines.length === 0) throw new Error('detect_os() function not found in install.sh');
+  return funcLines.join('\n').replace(/\/proc\/sys\/kernel\/osrelease/g, osreleasePath);
+}
+
+interface RunDetectOsOpts {
+  uname?: string;
+  wslDistroName?: string;
+  wslInterop?: string;
+  osreleaseContent?: string;
+}
+
+function runDetectOs(opts: RunDetectOsOpts = {}): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'aqm-detect-os-'));
+  try {
+    // mock uname 바이너리 — PATH 앞에 삽입해 시스템 uname을 대체
+    const mockUname = join(tmpDir, 'uname');
+    writeFileSync(mockUname, `#!/bin/bash\necho "${opts.uname ?? 'Linux'}"\n`);
+    chmodSync(mockUname, 0o755);
+
+    // osrelease 임시 파일 (내용이 주어진 경우에만 생성)
+    const osreleasePath = join(tmpDir, 'osrelease');
+    if (opts.osreleaseContent !== undefined) {
+      writeFileSync(osreleasePath, opts.osreleaseContent);
+    }
+
+    const detectOsFn = extractDetectOsFn(osreleasePath);
+    const script = `${detectOsFn}\ndetect_os`;
+
+    const env: NodeJS.ProcessEnv = {
+      HOME: process.env['HOME'] ?? '/tmp',
+      PATH: `${tmpDir}:${process.env['PATH'] ?? '/usr/bin:/bin'}`,
+    };
+    if (opts.wslDistroName !== undefined) env['WSL_DISTRO_NAME'] = opts.wslDistroName;
+    if (opts.wslInterop !== undefined) env['WSL_INTEROP'] = opts.wslInterop;
+
+    return execSync('bash', { input: script, env }).toString().trim();
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * install.sh의 Node.js 버전 체크 로직을 독립 실행해 통과 여부를 반환한다.
+ * true = v20 이상 (설치 계속), false = v20 미만 (exit 1)
+ */
+function checkNodeVersionAccepted(version: string): boolean {
+  const script = `
+NODE_VERSION="${version}"
+NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/v\\([0-9]*\\).*/\\1/')
+if [ "\${NODE_MAJOR:-0}" -lt 20 ] 2>/dev/null; then
+  exit 1
+fi
+exit 0
+`;
+  try {
+    execSync('bash', { input: script, stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('install.sh', () => {
+  describe('detect_os()', () => {
+    it('macOS: uname=Darwin → "macos"', () => {
+      expect(runDetectOs({ uname: 'Darwin' })).toBe('macos');
+    });
+
+    it('Linux: uname=Linux, WSL 마커 없음 → "linux"', () => {
+      expect(runDetectOs({ uname: 'Linux' })).toBe('linux');
+    });
+
+    it('WSL: WSL_DISTRO_NAME 설정 시 → "wsl"', () => {
+      expect(runDetectOs({ uname: 'Linux', wslDistroName: 'Ubuntu' })).toBe('wsl');
+    });
+
+    it('WSL: WSL_INTEROP 설정 시 → "wsl"', () => {
+      expect(runDetectOs({ uname: 'Linux', wslInterop: '/run/WSL/1_interop' })).toBe('wsl');
+    });
+
+    it('WSL: osrelease에 "microsoft" 포함 → "wsl"', () => {
+      expect(runDetectOs({
+        uname: 'Linux',
+        osreleaseContent: '5.15.167.4-microsoft-standard-WSL2\n',
+      })).toBe('wsl');
+    });
+
+    it('WSL: osrelease에 "WSL" 포함 (대소문자 무관) → "wsl"', () => {
+      expect(runDetectOs({
+        uname: 'Linux',
+        osreleaseContent: '5.10.0-WSL2-custom\n',
+      })).toBe('wsl');
+    });
+
+    it('WSL env var가 non-WSL osrelease보다 우선 → "wsl"', () => {
+      expect(runDetectOs({
+        uname: 'Linux',
+        wslDistroName: 'Ubuntu',
+        osreleaseContent: '6.1.0-generic\n',
+      })).toBe('wsl');
+    });
+
+    it('Linux: osrelease에 WSL 마커 없음 → "linux"', () => {
+      expect(runDetectOs({
+        uname: 'Linux',
+        osreleaseContent: '6.1.0-generic\n',
+      })).toBe('linux');
+    });
+
+    it('Windows: uname=MINGW64_NT-10.0 → "windows"', () => {
+      expect(runDetectOs({ uname: 'MINGW64_NT-10.0' })).toBe('windows');
+    });
+
+    it('Windows: uname=CYGWIN_NT-10.0 → "windows"', () => {
+      expect(runDetectOs({ uname: 'CYGWIN_NT-10.0' })).toBe('windows');
+    });
+
+    it('Windows: uname=MSYS_NT-10.0 → "windows"', () => {
+      expect(runDetectOs({ uname: 'MSYS_NT-10.0' })).toBe('windows');
+    });
+
+    it('알 수 없는 OS: uname=FreeBSD → "unknown"', () => {
+      expect(runDetectOs({ uname: 'FreeBSD' })).toBe('unknown');
+    });
+  });
+
+  describe('Node.js 버전 체크', () => {
+    it('v20.0.0 → 통과', () => {
+      expect(checkNodeVersionAccepted('v20.0.0')).toBe(true);
+    });
+
+    it('v22.5.1 → 통과', () => {
+      expect(checkNodeVersionAccepted('v22.5.1')).toBe(true);
+    });
+
+    it('v20.17.0 → 통과 (정확히 v20)', () => {
+      expect(checkNodeVersionAccepted('v20.17.0')).toBe(true);
+    });
+
+    it('v18.20.0 → 거부 (v20 미만)', () => {
+      expect(checkNodeVersionAccepted('v18.20.0')).toBe(false);
+    });
+
+    it('v16.0.0 → 거부 (v20 미만)', () => {
+      expect(checkNodeVersionAccepted('v16.0.0')).toBe(false);
+    });
+
+    it('v19.9.9 → 거부 (v20 미만)', () => {
+      expect(checkNodeVersionAccepted('v19.9.9')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #778 — feat: 설치 원클릭화 — curl 1줄 스크립트 + Node/WSL 자동 감지 (Plan B B4)

현재 install.sh는 git-clone 기반으로 Node/npm/gh/claude 등 모든 사전 요구사항이 설치된 환경만 지원한다. 비개발자 원클릭 설치를 위해: (1) Node 미설치 시 안내 메시지 출력, (2) npm global install 경로 지원, (3) Windows에서 WSL 감지/안내, (4) 설치 후 aqm setup 자동 트리거가 필요하다.

## Requirements

- macOS/Linux: curl -fsSL <url> | bash 1줄로 설치 완료 — Node 미설치 시 OS별 설치 안내 출력
- npm install -g ai-quartermaster 경로를 기본으로 사용 (기존 git-clone은 폴백)
- Windows/WSL 감지: bash 스크립트 내에서 WSL 환경 판별, WSL 미설치 시 설치 안내 링크 표시
- 설치 완료 후 aqm setup 자동 실행 트리거 (Setup Wizard 연결)
- 기존 install.sh의 git-clone 업데이트 경로도 유지 (하위 호환)
- npx tsc --noEmit + npx vitest run 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: install.sh 원클릭 스크립트 리팩터링 — SUCCESS (414a80b1)
- Phase 1: install.sh 테스트 추가 — SUCCESS (affe4517)
- Phase 2: 타입체크 + 전체 테스트 검증 — SUCCESS (affe4517)

## Risks

- npm install -g 권한 문제: sudo 필요 여부가 OS/설치 방식에 따라 다름 — nvm 환경은 sudo 불필요, 시스템 Node는 필요할 수 있음
- 기존 git-clone 사용자의 install.sh 업데이트 경로가 깨지지 않도록 하위 호환 유지 필요
- curl | bash 파이프에서 stdin이 파이프로 잡혀 있어 interactive prompt(aqm setup)가 동작하지 않을 수 있음 — /dev/tty 리다이렉션 필요

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.4338 (review: $0.1802)
- **Phases**: 4/4 completed
- **Branch**: `aq/778-feat-curl-1-node-wsl-plan-b-b4` → `develop`
- **Tokens**: 96 input, 45441 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| install.sh 원클릭 스크립트 리팩터링 | $0.4935 | 0 | $0.0000 |
| install.sh 테스트 추가 | $1.0270 | 0 | $0.0000 |
| 타입체크 + 전체 테스트 검증 | $0.2003 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.7208 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #778