### PR TITLE
hotfix: package.json 버전 0.8.4 → 0.8.6 동기화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.4",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.8.4",
+      "version": "0.8.6",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.4",
+  "version": "0.8.6",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- `package.json` / `package-lock.json` version 필드를 0.8.4 → 0.8.6 동기화
- v0.8.5(#787) / v0.8.6(#788) 릴리스 PR에서 version bump 누락된 것 보정

## 증상
- `aqm --version` 출력이 코드 상태(v0.8.6, SHA 389fd63)와 불일치하여 v0.8.4로 표시됨

## Changes
- `package.json`: 0.8.4 → 0.8.6
- `package-lock.json`: 루트 + ai-quartermaster 패키지 항목 동일 갱신

## Verification
- 단순 메타데이터 갱신 (런타임 영향 없음)
- 머지 후 `aqm update` → `aqm --version` 확인

## Follow-up (별 이슈)
- 릴리스 워크플로우에 version bump 강제 (lint/CI)
- `aqm update` 스크립트가 git merge 실패해도 "이미 최신 버전입니다" 출력하는 false-success 버그