### PR TITLE
[AQ-#792] ci: 릴리스 시 package.json version bump 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,50 @@ jobs:
           name: visual-baseline-snapshots
           path: tests/visual/__snapshots__/
 
+  version-bump-check:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract target version
+        id: extract
+        run: |
+          TARGET=$(echo "${{ github.event.pull_request.title }}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+          if [ -z "$TARGET" ]; then
+            TARGET=$(echo "${{ github.head_ref }}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+          fi
+          if [ -z "$TARGET" ]; then
+            echo "::warning::버전을 PR 제목 또는 브랜치명에서 감지하지 못했습니다. version-bump-check를 건너뜁니다."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check package.json and package-lock.json version
+        if: steps.extract.outputs.skip == 'false'
+        run: |
+          TARGET="${{ steps.extract.outputs.target }}"
+          PKG=$(node -p "require('./package.json').version")
+          LOCK=$(node -p "require('./package-lock.json').version")
+          echo "목표 버전  : $TARGET"
+          echo "package.json     : $PKG"
+          echo "package-lock.json: $LOCK"
+          FAIL=0
+          if [ "$PKG" != "$TARGET" ]; then
+            echo "::error::package.json version($PKG)이 목표 버전($TARGET)과 다릅니다."
+            FAIL=1
+          fi
+          if [ "$LOCK" != "$TARGET" ]; then
+            echo "::error::package-lock.json version($LOCK)이 목표 버전($TARGET)과 다릅니다."
+            FAIL=1
+          fi
+          if [ "$FAIL" -eq 1 ]; then
+            exit 1
+          fi
+          echo "✓ 버전 일치 확인 완료 ($TARGET)"
+
   visual-regression:
     name: visual-regression (advisory)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves #792 — ci: 릴리스 시 package.json version bump 검증 추가

PR #789 사고처럼 릴리스 PR에서 package.json/package-lock.json의 version 필드 bump가 누락되어 `aqm --version`이 구버전을 반환하는 사태를 CI 레벨에서 차단해야 한다. main 대상 릴리스 PR(release:/hotfix: 커밋)에 대해 package.json/package-lock.json version이 PR 제목/브랜치의 목표 버전과 일치하는지 검증하고, 불일치 시 CI를 실패시켜 머지를 차단한다.

## Requirements

- release-smoke 또는 신규 job에서 package.json과 package-lock.json의 version 필드가 일치하는지 확인
- PR 제목(예: `release: v0.8.7 ...`) 또는 브랜치명(`hotfix/v0.8.7-...`)에서 목표 버전을 추출
- 추출한 목표 버전과 package.json version이 일치하지 않으면 CI 실패
- main 대상 PR(release/hotfix 성격)에만 적용하고 일반 feature PR은 영향받지 않도록 조건 분기
- `.github/workflows/ci.yml`만 수정, 다른 파일에 영향 없음

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: ci.yml에 version-bump-check job 추가 — SUCCESS (cb90dcfe)

## Risks

- 버전 추출 정규식이 부정확해 일반 PR을 오탐 차단할 위험 — 릴리스성 브랜치(release/, hotfix/) 조건으로 좁혀 최소화
- PR 제목 규칙이 깨진 경우 폴백 부재 — 브랜치명 폴백 + 둘 다 없으면 스킵 처리
- package-lock.json의 top-level `version`과 `packages[""].version` 둘 다 존재 — Node로 require해서 top-level만 체크하고 필요 시 둘 다 비교

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $0.8593 (review: $0.1158)
- **Phases**: 2/2 completed
- **Branch**: `aq/792-ci-package-json-version-bump` → `develop`
- **Tokens**: 35 input, 5271 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| ci.yml에 version-bump-check job 추가 | $0.2534 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.2534 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #792