### PR TITLE
[AQ-#791] fix(update): aqm update false-success 버그 수정

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -172,9 +172,47 @@ case "${1:-}" in
     echo "AI Quartermaster 업데이트 중... (브랜치: $BRANCH)"
     cd "$AQM_ROOT"
     BEFORE=$(git rev-parse HEAD)
-    git fetch --quiet origin
-    git checkout --quiet "$BRANCH"
-    git pull --quiet origin "$BRANCH"
+
+    GIT_ERR=$(git fetch --quiet origin 2>&1)
+    if [ $? -ne 0 ]; then
+      echo "git fetch 실패!"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+
+    GIT_ERR=$(git checkout --quiet "$BRANCH" 2>&1)
+    if [ $? -ne 0 ]; then
+      echo "브랜치 전환 실패: $BRANCH"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+
+    GIT_ERR=$(git pull --quiet origin "$BRANCH" 2>&1)
+    PULL_EXIT=$?
+    if [ $PULL_EXIT -ne 0 ]; then
+      if echo "$GIT_ERR" | grep -qE "CONFLICT|Pull is not possible|Cannot pull"; then
+        echo "머지 충돌로 업데이트 중단!"
+        echo "$GIT_ERR"
+        echo ""
+        echo "수동 해결 방법:"
+        echo "  cd $AQM_ROOT"
+        echo "  git merge --abort  # 또는 충돌 파일 직접 수정 후 git add / git commit"
+        exit 1
+      fi
+      echo "git pull 실패!"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+    if echo "$GIT_ERR" | grep -qE "CONFLICT|Pull is not possible"; then
+      echo "머지 충돌로 업데이트 중단!"
+      echo "$GIT_ERR"
+      echo ""
+      echo "수동 해결 방법:"
+      echo "  cd $AQM_ROOT"
+      echo "  git merge --abort  # 또는 충돌 파일 직접 수정 후 git add / git commit"
+      exit 1
+    fi
+
     AFTER=$(git rev-parse HEAD)
 
     # Handle --clean option

--- a/src/update/self-updater.ts
+++ b/src/update/self-updater.ts
@@ -96,9 +96,10 @@ export class SelfUpdater {
   }
 
   /**
-   * Performs git pull to update to latest commits
+   * Performs git pull to update to latest commits.
+   * @param remoteHash - When provided, verifies HEAD matches this hash after pull.
    */
-  async pullUpdates(): Promise<void> {
+  async pullUpdates(remoteHash?: string): Promise<void> {
     logger.info("업데이트 적용 중 — git pull 실행...");
 
     const pullResult = await runCli(
@@ -107,7 +108,33 @@ export class SelfUpdater {
       { cwd: this.options.cwd }
     );
     if (pullResult.exitCode !== 0) {
-      throw new Error(`git pull 실패: ${pullResult.stderr}`);
+      const stderr = pullResult.stderr;
+      let detail = stderr;
+      if (stderr.includes("CONFLICT")) {
+        detail = `머지 충돌 발생\n${stderr}`;
+      } else if (stderr.includes("Could not resolve host")) {
+        detail = `네트워크 오류 (호스트 연결 실패)\n${stderr}`;
+      } else if (stderr.includes("Authentication failed")) {
+        detail = `인증 실패\n${stderr}`;
+      }
+      throw new Error(`git pull 실패: ${detail}`);
+    }
+
+    if (remoteHash !== undefined) {
+      const headResult = await runCli(
+        this.gitConfig.gitPath,
+        ["rev-parse", "HEAD"],
+        { cwd: this.options.cwd }
+      );
+      if (headResult.exitCode !== 0) {
+        throw new Error(`pull 후 HEAD 확인 실패: ${headResult.stderr}`);
+      }
+      const actualHead = headResult.stdout.trim();
+      if (actualHead !== remoteHash) {
+        throw new Error(
+          `git pull 성공했으나 HEAD가 원격과 동기화되지 않음 (HEAD: ${actualHead.substring(0, 8)}, 원격: ${remoteHash.substring(0, 8)})`
+        );
+      }
     }
 
     logger.info("git pull 완료");
@@ -175,7 +202,7 @@ export class SelfUpdater {
 
     logger.info(`새 업데이트 발견 — ${updateInfo.currentHash.substring(0, 8)} -> ${updateInfo.remoteHash.substring(0, 8)}`);
 
-    await this.pullUpdates();
+    await this.pullUpdates(updateInfo.remoteHash);
 
     if (this.shouldRunNpmCi(updateInfo)) {
       await this.runNpmCi();

--- a/tests/update/self-updater.test.ts
+++ b/tests/update/self-updater.test.ts
@@ -152,10 +152,43 @@ describe("SelfUpdater", () => {
       expect(mockRunCli).toHaveBeenCalledWith("git", ["pull", "origin", "main"], { cwd: "/test/project" });
     });
 
-    it("should throw error when git pull fails", async () => {
-      mockRunCli.mockResolvedValueOnce({ stdout: "", stderr: "merge conflict", exitCode: 1 });
+    it("should throw error when git pull fails with generic error", async () => {
+      mockRunCli.mockResolvedValueOnce({ stdout: "", stderr: "some generic error", exitCode: 1 });
 
-      await expect(selfUpdater.pullUpdates()).rejects.toThrow("git pull 실패: merge conflict");
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("git pull 실패: some generic error");
+    });
+
+    it("should throw merge conflict error when CONFLICT keyword in stderr", async () => {
+      mockRunCli.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "CONFLICT (content): Merge conflict in src/foo.ts",
+        exitCode: 1,
+      });
+
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("머지 충돌 발생");
+    });
+
+    it("should throw network error when host resolution fails", async () => {
+      mockRunCli.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "fatal: Could not resolve host: github.com",
+        exitCode: 128,
+      });
+
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("네트워크 오류 (호스트 연결 실패)");
+    });
+
+    it("should throw when HEAD does not match remoteHash after pull", async () => {
+      const remoteHash = "def456ghi789";
+      const unexpectedHead = "zzz999yyy888";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${unexpectedHead}\n`, stderr: "", exitCode: 0 }); // git rev-parse HEAD
+
+      await expect(selfUpdater.pullUpdates(remoteHash)).rejects.toThrow(
+        "git pull 성공했으나 HEAD가 원격과 동기화되지 않음"
+      );
     });
   });
 

--- a/tests/update/self-updater.test.ts
+++ b/tests/update/self-updater.test.ts
@@ -236,6 +236,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "package-lock.json\n", stderr: "", exitCode: 0 }) // diff package-lock
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "added 150 packages\n", stderr: "", exitCode: 0 }) // npm ci
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // npm run build
 
@@ -257,6 +258,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock (no changes)
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // npm run build
 
       const result = await selfUpdater.performSelfUpdate();
@@ -280,6 +282,66 @@ describe("SelfUpdater", () => {
       await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("git pull 실패: merge conflict");
     });
 
+    it("should throw conflict error with context when CONFLICT keyword in stderr", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "CONFLICT (content): Merge conflict in src/foo.ts", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("머지 충돌 발생");
+    });
+
+    it("should throw network error with context when host resolution fails", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "fatal: Could not resolve host: github.com", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("네트워크 오류 (호스트 연결 실패)");
+    });
+
+    it("should throw auth error with context when authentication fails", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "fatal: Authentication failed for 'https://github.com/repo'", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("인증 실패");
+    });
+
+    it("should throw when HEAD does not match remoteHash after pull", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+      const unexpectedHead = "zzz999yyy888";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${unexpectedHead}\n`, stderr: "", exitCode: 0 }); // git rev-parse HEAD (post-pull)
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow(
+        "git pull 성공했으나 HEAD가 원격과 동기화되지 않음"
+      );
+    });
+
     it("should propagate error when npm ci fails", async () => {
       const currentHash = "abc123def456";
       const remoteHash = "def456ghi789";
@@ -290,6 +352,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "package-lock.json\n", stderr: "", exitCode: 0 }) // diff package-lock
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "", stderr: "install failed", exitCode: 1 }); // npm ci
 
       await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("npm ci 실패: install failed");


### PR DESCRIPTION
## Summary

Resolves #791 — fix(update): aqm update false-success 버그 수정

`aqm update` 명령이 `git pull` 실패(머지 충돌, 네트워크 오류 등) 시에도 "이미 최신 버전입니다"를 출력하며 성공으로 종료되는 false-success 버그. v0.8.4 → 0.8.6 릴리스 후 실제 사고 발생. 원인 두 갈래: (1) `bin/aqm` update 블록이 `git pull --quiet`의 종료 코드를 검사하지 않고 BEFORE/AFTER HEAD 해시 동등성만으로 최신 여부를 판정. (2) `src/update/self-updater.ts` `pullUpdates()`가 pull 후 실제 HEAD가 remoteHash로 이동했는지 재검증하지 않아 조용한 no-op pull을 성공으로 오인할 수 있음. 해결책: 종료 코드·stderr 검사를 강제하고, pull 후 `git rev-parse HEAD == remoteHash` 검증으로 실제 업데이트 여부를 확정한다. 사용자 메시지는 실패 원인(conflict/network/auth)을 구분해 노출한다.

## Requirements

- bin/aqm update 블록에서 git fetch/checkout/pull 각각의 종료 코드를 검사하고 실패 시 stderr를 출력하며 비-0 종료
- bin/aqm update 블록이 BEFORE/AFTER 동등성 + pull 성공 여부 모두 고려하여 false-success 제거
- src/update/self-updater.ts pullUpdates()가 종료 코드·stderr로 머지 충돌/네트워크/인증 실패를 분류하는 명확한 에러 메시지 throw
- src/update/self-updater.ts에 pull 후 실제 HEAD가 remoteHash와 일치하는지 재검증하는 로직 추가 (불일치 시 throw)
- tests/update/self-updater.test.ts에 머지 충돌·네트워크 오류·HEAD 미이동 false-success 시나리오 단위 테스트 추가
- npx tsc --noEmit 통과
- npx vitest run 전체 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: self-updater 성공 판정 강화 — SUCCESS (6da3f9c5)
- Phase 1: bin/aqm update 종료 코드 검사 — SUCCESS (d6f20b61)
- Phase 2: self-updater 테스트 보강 — SUCCESS (d16b333f)
- Phase 3: 전체 검증 — SUCCESS (d16b333f)

## Risks

- bin/aqm은 shell script이므로 타입체크 대상이 아님 — 스모크 테스트나 수동 검증 필요
- pullUpdates() 시그니처 변경으로 호출처 cli.ts 영향 가능성 (현 구조상 void 반환 유지로 최소화)
- 기존 테스트가 stderr 문자열 매칭에 의존 — 에러 메시지 포맷 변경 시 테스트 업데이트 필요
- git pull이 성공하지만 HEAD가 remoteHash로 정확히 이동하지 않는 엣지 케이스(예: 로컬 커밋 존재로 인한 merge commit)에서 새 검증이 과민 반응할 수 있음 → 'HEAD가 remoteHash의 조상을 포함' 또는 '정확 일치' 기준 신중 선택

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.1993 (review: $0.1441)
- **Phases**: 5/5 completed
- **Branch**: `aq/791-fix-update-aqm-update-false-success` → `develop`
- **Tokens**: 115 input, 27261 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| self-updater 성공 판정 강화 | $0.5291 | 0 | $0.0000 |
| bin/aqm update 종료 코드 검사 | $0.3213 | 0 | $0.0000 |
| self-updater 테스트 보강 | $0.2975 | 0 | $0.0000 |
| 전체 검증 | $0.2095 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.3574 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #791