### PR TITLE
[AQ-#795] feat(metrics): 잡 리포트에 프롬프트 캐시 히트 비율 표시

### DIFF
--- a/prompts/pr-body.md
+++ b/prompts/pr-body.md
@@ -23,6 +23,7 @@ Resolves #{{issue.number}} — {{issue.title}}
 - **Phases**: {{stats.successCount}}/{{stats.phaseCount}} completed
 - **Branch**: `{{branch.work}}` → `{{branch.base}}`
 - **Tokens**: {{stats.inputTokens}} input, {{stats.outputTokens}} output
+- **Cache Hit**: {{stats.cacheHitRatio}} (절감 토큰: {{stats.cacheSavedTokens}})
 
 {{stats.phaseCostTable}}
 {{stats.modelSummary}}

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -3,6 +3,7 @@ import { runCli } from "../utils/cli-runner.js";
 import { renderTemplate, loadTemplate } from "../prompt/template-renderer.js";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
+import { calculateCacheHitRatio } from "../claude/token-pricing.js";
 import type { PrConfig, GhCliConfig, MergeMethod } from "../types/config.js";
 import type { Plan, PhaseResult, PrConflictInfo, MergeStateStatus, UsageInfo, CostBreakdown } from "../types/pipeline.js";
 
@@ -116,6 +117,8 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
+        cacheHitRatio: ctx.totalUsage ? `${calculateCacheHitRatio(ctx.totalUsage).toFixed(1)}%` : '0.0%',
+        cacheSavedTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
         phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),
         reviewCostUsd: ctx.costBreakdown?.reviewCostUsd?.toFixed(4) || '0.0000',

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -495,7 +495,7 @@ export async function executePostProcessingPhases(
   }
 
   if (!reviewResult.success) {
-    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
     saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
     throw new Error(reviewResult.error || "Review phase failed");
   }
@@ -551,7 +551,7 @@ export async function executePostProcessingPhases(
     }
 
     if (!simplifyResult.success) {
-      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
       saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
       throw new Error(simplifyResult.error || "Simplify phase failed");
     }
@@ -745,7 +745,7 @@ export async function executePostProcessingPhases(
 
     return {
       prUrl,
-      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl),
+      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl, coreResult.totalUsage),
       totalCostUsd: updatedTotalCostUsd,
     };
   }

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -1,5 +1,6 @@
-import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown } from "../../types/pipeline.js";
+import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown, UsageInfo } from "../../types/pipeline.js";
 import { getLogger } from "../../utils/logger.js";
+import { calculateCacheHitRatio } from "../../claude/token-pricing.js";
 
 export type { DiagnosisReport };
 
@@ -34,6 +35,10 @@ export interface PipelineReport {
   verificationIncomplete?: string[];
   /** phase/model별 비용 세분화 (Total 분해 출력용) */
   costBreakdown?: CostBreakdown;
+  /** 전체 토큰 사용량 (캐시 히트율 계산용) */
+  totalUsage?: UsageInfo;
+  /** 캐시 히트율 (0~1, cache_read / (input + cache_read)) */
+  cacheHitRatio?: number;
 }
 
 /**
@@ -55,9 +60,11 @@ export function formatResult(
   plan: Plan,
   phaseResults: PhaseResult[],
   startTime: number,
-  prUrl?: string
+  prUrl?: string,
+  totalUsage?: UsageInfo
 ): PipelineReport {
   const failedPhase = phaseResults.find(r => !r.success);
+  const cacheHitRatio = totalUsage ? calculateCacheHitRatio(totalUsage) : undefined;
   return {
     issueNumber,
     repo,
@@ -81,6 +88,8 @@ export function formatResult(
     prUrl,
     errorCategory: failedPhase?.errorCategory,
     errorSummary: failedPhase?.error?.slice(0, 500),
+    totalUsage,
+    cacheHitRatio,
   };
 }
 
@@ -122,6 +131,12 @@ export function printResult(report: PipelineReport): void {
     if (bd.setupCostUsd && bd.setupCostUsd > 0) console.log(`  setup    $${bd.setupCostUsd.toFixed(4)}`);
     if (bd.publishCostUsd && bd.publishCostUsd > 0) console.log(`  publish  $${bd.publishCostUsd.toFixed(4)}`);
     if (bd.overheadCostUsd && bd.overheadCostUsd > 0) console.log(`  overhead $${bd.overheadCostUsd.toFixed(4)}`);
+  }
+
+  if (report.totalUsage && (report.totalUsage.input_tokens + (report.totalUsage.cache_read_input_tokens ?? 0)) > 0) {
+    const hitPct = ((report.cacheHitRatio ?? 0) * 100).toFixed(1);
+    const savedTokens = report.totalUsage.cache_read_input_tokens ?? 0;
+    console.log(`캐시 히트율: ${hitPct}%, 절감 토큰: ${savedTokens}`);
   }
 
   if (report.verificationIncomplete && report.verificationIncomplete.length > 0) {

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -488,6 +488,39 @@ describe("enableAutoMerge", () => {
   });
 });
 
+describe("createDraftPR cache stats template variables", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should pass cacheHitRatio and cacheSavedTokens to pr-body template stats (Cache Hit line)", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/20", stderr: "", exitCode: 0 });
+    const ctxWithUsage = {
+      ...ctx,
+      totalUsage: {
+        input_tokens: 0,
+        output_tokens: 500,
+        cache_read_input_tokens: 1000,
+      },
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    // calls[0] = title renderTemplate, calls[1] = body renderTemplate
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    // cache_read / (input + cache_read) = 1000/1000 = 1.0 → "1.0%"
+    expect(stats.cacheHitRatio).toBe("1.0%");
+    expect(stats.cacheSavedTokens).toBe(1000);
+  });
+
+  it("should default cacheHitRatio to '0.0%' and cacheSavedTokens to 0 when totalUsage is absent", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/21", stderr: "", exitCode: 0 });
+    const ctxWithoutUsage = { ...ctx, totalUsage: undefined };
+    await createDraftPR(prConfig, ghConfig, ctxWithoutUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    expect(stats.cacheHitRatio).toBe("0.0%");
+    expect(stats.cacheSavedTokens).toBe(0);
+  });
+});
+
 describe("addIssueComment", () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/tests/pipeline/reporting/result-reporter.test.ts
+++ b/tests/pipeline/reporting/result-reporter.test.ts
@@ -4,7 +4,8 @@ vi.mock("../../../src/utils/logger.js", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
-import { formatResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import { formatResult, printResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import type { PipelineReport } from "../../../src/pipeline/reporting/result-reporter.js";
 import type { Plan, PhaseResult } from "../../../src/types/pipeline.js";
 
 function makePlan(overrides: Partial<Plan> = {}): Plan {
@@ -68,5 +69,80 @@ describe("formatResult usedModel field", () => {
     const report = formatResult(42, "test/repo", plan, results, Date.now() - 3000);
     expect(report.phases[0].usedModel).toBeUndefined();
     expect(report.phases[1].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+describe("formatResult cacheHitRatio", () => {
+  it("calculates cacheHitRatio from totalUsage when cache tokens are present", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const totalUsage = { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 };
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000, undefined, totalUsage);
+    expect(report.totalUsage).toEqual(totalUsage);
+    expect(report.cacheHitRatio).toBeCloseTo(0.75, 5);
+  });
+
+  it("leaves cacheHitRatio undefined when totalUsage is not provided", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.totalUsage).toBeUndefined();
+    expect(report.cacheHitRatio).toBeUndefined();
+  });
+});
+
+describe("printResult cache line", () => {
+  it("outputs '캐시 히트율' line with percentage and saved tokens when cache tokens are present", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 },
+      cacheHitRatio: 0.75,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("캐시 히트율: 75.0%, 절감 토큰: 3000");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when totalUsage is absent", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when input + cache_read denominator is zero", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 0, output_tokens: 0 },
+      cacheHitRatio: 0,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Resolves #795 — feat(metrics): 잡 리포트에 프롬프트 캐시 히트 비율 표시

Claude CLI가 반환하는 Phase별 `cache_read_input_tokens` / `cache_creation_input_tokens`는 이미 `core-loop.ts`의 `sumUsage()`가 합산해 `CoreLoopResult.totalUsage`에 담고 있지만, 최종 잡 리포트(`PipelineReport` → `printResult()` 콘솔 출력, `pr-body.md` 템플릿)에는 캐시 히트율과 절감 토큰 요약이 노출되지 않아 5분 TTL 프롬프트 캐시가 실제로 얼마나 활용되고 있는지 가시화되지 않는다. 본 이슈는 기존 집계 데이터와 `calculateCacheHitRatio()`(이미 구현됨)를 연결해 (1) `PipelineReport`에 `totalUsage`/`cacheHitRatio`를 싣고, (2) 파이프라인 완료 리포트와 PR 본문에 "캐시 히트율: X%, 절감 토큰: Y" 1줄 요약을 추가한다. 숫자 수집·표시에만 집중하고 캐시 전략 자체는 변경하지 않는다.

## Requirements

- PhaseResult.usage에 이미 담기는 cache_read/creation 토큰이 pipeline 완료 시점까지 누락 없이 PipelineReport.totalUsage로 전달된다
- 리포트 1줄 요약 '캐시 히트율: X%, 절감 토큰: Y' 가 printResult() 콘솔 출력에 추가된다 (X는 소수점 1자리 %, Y는 cache_read_input_tokens)
- PR 본문(pr-body.md)에도 동일한 캐시 히트율/절감 토큰 1줄이 표시된다
- usage가 없거나 토큰이 0인 경우 요약 라인은 생략되어 기존 출력과 호환된다
- 기존 printResult/ PR 본문의 비용·토큰 출력과 중복되지 않고 단일 라인으로만 요약된다
- `npx tsc --noEmit` 및 `npx vitest run` 전체 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 리포트 스키마에 totalUsage·cacheHitRatio 추가 및 콘솔 요약 라인 구현 — SUCCESS (21aac397)
- Phase 1: PR 본문 템플릿에 캐시 히트율·절감 토큰 라인 추가 — SUCCESS (42774141)
- Phase 2: 단위 테스트 추가 및 기존 테스트 회귀 확인 — SUCCESS (d626c30e)

## Risks

- PipelineReport에 totalUsage 필드를 추가할 때 기존 소비자(대시보드 API 응답 직렬화/테스트 스냅샷)가 변경된 스키마에서 깨질 수 있음 — optional 필드로 추가하고 기존 테스트 influence를 최소화
- Phase 실패 조기 반환 경로(core-loop.ts의 중간 return 지점)에서 totalUsage가 formatResult에 전달되지 않으면 성공 케이스만 캐시 정보가 보이고 실패 케이스는 누락되는 비대칭 발생 — formatResult 호출부 전수 확인
- pr-body.md 템플릿에 새 변수를 추가하면 오래된 프롬프트 버전을 로드하는 외부 프로젝트에서 미치환 `{{stats.cacheHitRatio}}` 문자열이 PR에 그대로 노출될 수 있음 — renderTemplate의 기존 동작 확인 및 기본값 보장
- 계산 분모(input+cache_read)가 0인 초기/노아웃 케이스에서 NaN/Infinity 출력 가능 — 기존 calculateCacheHitRatio는 0 반환하지만 '절감 토큰' 라인 자체를 억제할 조건을 명시
- 다른 소비자(job-store.ts, job-logger.ts)가 이미 cacheHitRatio를 계산·저장하고 있으므로 리포트/PR 측 신규 계산과 반올림·표시 방식이 불일치하면 대시보드와 PR 수치가 다르게 보일 위험 — 동일한 calculateCacheHitRatio 함수로 통일

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.8658 (review: $0.1648)
- **Phases**: 4/4 completed
- **Branch**: `aq/795-feat-metrics` → `develop`
- **Tokens**: 159 input, 36123 output


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 리포트 스키마에 totalUsage·cacheHitRatio 추가 및 콘솔 요약 라인 구현 | $0.6190 | 0 | $0.0000 |
| PR 본문 템플릿에 캐시 히트율·절감 토큰 라인 추가 | $0.2855 | 0 | $0.0000 |
| 단위 테스트 추가 및 기존 테스트 회귀 확인 | $0.9198 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.8242 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #795