### PR TITLE
fix(store): jobs.cache_hit_ratio가 항상 null로 저장되는 버그 수정 (#796)

### DIFF
--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -310,6 +310,7 @@ export class JobStore extends EventEmitter {
       costUsd: job.costUsd,
       totalCostUsd: job.totalCostUsd,
       totalUsage: job.totalUsage,
+      cacheHitRatio: job.cacheHitRatio,
       triggerReason: job.triggerReason,
       diagnosis: job.diagnosis
     };
@@ -422,6 +423,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as QueuedJob;
         break;
@@ -444,6 +446,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           error: baseFields.error,
           priority: baseFields.priority
         } as RunningJob;
@@ -469,6 +472,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as SuccessJob;
         break;
@@ -494,6 +498,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority,
           diagnosis: baseFields.diagnosis
         } as FailureJob;
@@ -519,6 +524,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as CancelledJob;
         break;
@@ -544,6 +550,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as ArchivedJob;
         break;

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -327,6 +327,25 @@ export class AQDatabase {
       logger.info("Migration: added cache_hit_ratio column to jobs table");
     }
 
+    // cache_hit_ratio 백필: jobToDbJob 누락 버그로 null로 남은 기존 잡 재계산
+    const refreshedCols = this.db.pragma("table_info(jobs)") as Array<{ name: string }>;
+    const hasReadTokens = refreshedCols.some(col => col.name === "total_cache_read_input_tokens");
+    const hasInputTokens = refreshedCols.some(col => col.name === "total_input_tokens");
+    if (hasReadTokens && hasInputTokens) {
+      const backfill = this.db.prepare(`
+        UPDATE jobs
+        SET cache_hit_ratio = CAST(total_cache_read_input_tokens AS REAL)
+          / (total_input_tokens + total_cache_read_input_tokens)
+        WHERE cache_hit_ratio IS NULL
+          AND total_cache_read_input_tokens IS NOT NULL
+          AND total_input_tokens IS NOT NULL
+          AND (total_input_tokens + total_cache_read_input_tokens) > 0
+      `).run();
+      if (backfill.changes > 0) {
+        logger.info(`Migration: backfilled cache_hit_ratio for ${backfill.changes} jobs`);
+      }
+    }
+
     // jobs 테이블에 cost_breakdown 컬럼 추가 (기존 DB 마이그레이션)
     const hasCostBreakdown = jobColumns.some(col => col.name === "cost_breakdown");
     if (!hasCostBreakdown) {

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -1575,4 +1575,21 @@ describe("JobStore", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("cacheHitRatio persistence", () => {
+    it("should persist cacheHitRatio when setCosts is applied", () => {
+      const job = store.create(100, "test/repo");
+      const usage = {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 900
+      };
+
+      store.update(job.id, { totalCostUsd: 0.1, totalUsage: usage, cacheHitRatio: 0.9 });
+
+      const reloaded = store.get(job.id);
+      expect(reloaded?.cacheHitRatio).toBeCloseTo(0.9, 2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `update()`의 6개 상태별 재조립 블록(queued/running/success/failure/cancelled/archived)에서 `cacheHitRatio` 필드 누락 → `baseFields`로 병합해도 재조립 시 드롭됨
- `jobToDbJob()`에서도 `cacheHitRatio` 누락 → SQL UPDATE 파라미터 position 20이 항상 null
- 결과: raw 토큰(`total_cache_read_input_tokens` 등)은 정상 저장되지만 `cache_hit_ratio` 컬럼은 항상 null → 대시보드 렌더 코드(`render-jobs.js:141`, `render-repos.js:86`)가 표시 못 함
- migrateSchema에 1회성 backfill 추가 (legacy schema 방어 포함)
- 테스트: setCosts 적용 후 재조회 시 cacheHitRatio 보존 검증

## Closes #796

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 전체 3369 pass
- [ ] 실사용: 다음 성공 잡 완료 시 `cache_hit_ratio` 컬럼이 null이 아닌지 DB 직접 확인
- [ ] backfill: 서버 재기동 시 기존 93건에 ratio 채워지는지 로그(`backfilled cache_hit_ratio for N jobs`) 확인