### PR TITLE
feat(metrics): PR 본문 캐시 히트율 표시 + 포맷 버그 수정

### DIFF
--- a/prompts/pr-body.md
+++ b/prompts/pr-body.md
@@ -23,6 +23,7 @@ Resolves #{{issue.number}} — {{issue.title}}
 - **Phases**: {{stats.successCount}}/{{stats.phaseCount}} completed
 - **Branch**: `{{branch.work}}` → `{{branch.base}}`
 - **Tokens**: {{stats.inputTokens}} input, {{stats.outputTokens}} output
+- **Cache Hit**: {{stats.cacheHitRatio}} (절감 토큰: {{stats.cacheSavedTokens}})
 
 {{stats.phaseCostTable}}
 {{stats.modelSummary}}

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -117,7 +117,7 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
-        cacheHitRatio: ctx.totalUsage ? `${calculateCacheHitRatio(ctx.totalUsage).toFixed(1)}%` : '0.0%',
+        cacheHitRatio: ctx.totalUsage ? `${(calculateCacheHitRatio(ctx.totalUsage) * 100).toFixed(1)}%` : '0.0%',
         cacheSavedTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
         phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -3,6 +3,7 @@ import { runCli } from "../utils/cli-runner.js";
 import { renderTemplate, loadTemplate } from "../prompt/template-renderer.js";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
+import { calculateCacheHitRatio } from "../claude/token-pricing.js";
 import type { PrConfig, GhCliConfig, MergeMethod } from "../types/config.js";
 import type { Plan, PhaseResult, PrConflictInfo, MergeStateStatus, UsageInfo, CostBreakdown } from "../types/pipeline.js";
 
@@ -116,6 +117,8 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
+        cacheHitRatio: ctx.totalUsage ? `${calculateCacheHitRatio(ctx.totalUsage).toFixed(1)}%` : '0.0%',
+        cacheSavedTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
         phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),
         reviewCostUsd: ctx.costBreakdown?.reviewCostUsd?.toFixed(4) || '0.0000',

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -495,7 +495,7 @@ export async function executePostProcessingPhases(
   }
 
   if (!reviewResult.success) {
-    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
     saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
     throw new Error(reviewResult.error || "Review phase failed");
   }
@@ -551,7 +551,7 @@ export async function executePostProcessingPhases(
     }
 
     if (!simplifyResult.success) {
-      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
       saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
       throw new Error(simplifyResult.error || "Simplify phase failed");
     }
@@ -745,7 +745,7 @@ export async function executePostProcessingPhases(
 
     return {
       prUrl,
-      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl),
+      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl, coreResult.totalUsage),
       totalCostUsd: updatedTotalCostUsd,
     };
   }

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -1,5 +1,6 @@
-import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown } from "../../types/pipeline.js";
+import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown, UsageInfo } from "../../types/pipeline.js";
 import { getLogger } from "../../utils/logger.js";
+import { calculateCacheHitRatio } from "../../claude/token-pricing.js";
 
 export type { DiagnosisReport };
 
@@ -34,6 +35,10 @@ export interface PipelineReport {
   verificationIncomplete?: string[];
   /** phase/model별 비용 세분화 (Total 분해 출력용) */
   costBreakdown?: CostBreakdown;
+  /** 전체 토큰 사용량 (캐시 히트율 계산용) */
+  totalUsage?: UsageInfo;
+  /** 캐시 히트율 (0~1, cache_read / (input + cache_read)) */
+  cacheHitRatio?: number;
 }
 
 /**
@@ -55,9 +60,11 @@ export function formatResult(
   plan: Plan,
   phaseResults: PhaseResult[],
   startTime: number,
-  prUrl?: string
+  prUrl?: string,
+  totalUsage?: UsageInfo
 ): PipelineReport {
   const failedPhase = phaseResults.find(r => !r.success);
+  const cacheHitRatio = totalUsage ? calculateCacheHitRatio(totalUsage) : undefined;
   return {
     issueNumber,
     repo,
@@ -81,6 +88,8 @@ export function formatResult(
     prUrl,
     errorCategory: failedPhase?.errorCategory,
     errorSummary: failedPhase?.error?.slice(0, 500),
+    totalUsage,
+    cacheHitRatio,
   };
 }
 
@@ -122,6 +131,12 @@ export function printResult(report: PipelineReport): void {
     if (bd.setupCostUsd && bd.setupCostUsd > 0) console.log(`  setup    $${bd.setupCostUsd.toFixed(4)}`);
     if (bd.publishCostUsd && bd.publishCostUsd > 0) console.log(`  publish  $${bd.publishCostUsd.toFixed(4)}`);
     if (bd.overheadCostUsd && bd.overheadCostUsd > 0) console.log(`  overhead $${bd.overheadCostUsd.toFixed(4)}`);
+  }
+
+  if (report.totalUsage && (report.totalUsage.input_tokens + (report.totalUsage.cache_read_input_tokens ?? 0)) > 0) {
+    const hitPct = ((report.cacheHitRatio ?? 0) * 100).toFixed(1);
+    const savedTokens = report.totalUsage.cache_read_input_tokens ?? 0;
+    console.log(`캐시 히트율: ${hitPct}%, 절감 토큰: ${savedTokens}`);
   }
 
   if (report.verificationIncomplete && report.verificationIncomplete.length > 0) {

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -488,6 +488,39 @@ describe("enableAutoMerge", () => {
   });
 });
 
+describe("createDraftPR cache stats template variables", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should pass cacheHitRatio and cacheSavedTokens to pr-body template stats (Cache Hit line)", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/20", stderr: "", exitCode: 0 });
+    const ctxWithUsage = {
+      ...ctx,
+      totalUsage: {
+        input_tokens: 0,
+        output_tokens: 500,
+        cache_read_input_tokens: 1000,
+      },
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    // calls[0] = title renderTemplate, calls[1] = body renderTemplate
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    // cache_read / (input + cache_read) = 1000/1000 = 1.0 → "1.0%"
+    expect(stats.cacheHitRatio).toBe("1.0%");
+    expect(stats.cacheSavedTokens).toBe(1000);
+  });
+
+  it("should default cacheHitRatio to '0.0%' and cacheSavedTokens to 0 when totalUsage is absent", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/21", stderr: "", exitCode: 0 });
+    const ctxWithoutUsage = { ...ctx, totalUsage: undefined };
+    await createDraftPR(prConfig, ghConfig, ctxWithoutUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    expect(stats.cacheHitRatio).toBe("0.0%");
+    expect(stats.cacheSavedTokens).toBe(0);
+  });
+});
+
 describe("addIssueComment", () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -491,7 +491,7 @@ describe("enableAutoMerge", () => {
 describe("createDraftPR cache stats template variables", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("should pass cacheHitRatio and cacheSavedTokens to pr-body template stats (Cache Hit line)", async () => {
+  it("should pass cacheHitRatio as percent (100% case) to pr-body template stats", async () => {
     mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/20", stderr: "", exitCode: 0 });
     const ctxWithUsage = {
       ...ctx,
@@ -502,12 +502,29 @@ describe("createDraftPR cache stats template variables", () => {
       },
     };
     await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
-    // calls[0] = title renderTemplate, calls[1] = body renderTemplate
     const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
     const stats = templateVars.stats as Record<string, unknown>;
-    // cache_read / (input + cache_read) = 1000/1000 = 1.0 → "1.0%"
-    expect(stats.cacheHitRatio).toBe("1.0%");
+    // cache_read / (input + cache_read) = 1000/1000 = 1.0 → "100.0%"
+    expect(stats.cacheHitRatio).toBe("100.0%");
     expect(stats.cacheSavedTokens).toBe(1000);
+  });
+
+  it("should pass cacheHitRatio as percent (75% mid-value case) to pr-body template stats", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/22", stderr: "", exitCode: 0 });
+    const ctxWithUsage = {
+      ...ctx,
+      totalUsage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 3000,
+      },
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    // 3000 / (1000 + 3000) = 0.75 → "75.0%"
+    expect(stats.cacheHitRatio).toBe("75.0%");
+    expect(stats.cacheSavedTokens).toBe(3000);
   });
 
   it("should default cacheHitRatio to '0.0%' and cacheSavedTokens to 0 when totalUsage is absent", async () => {

--- a/tests/pipeline/reporting/result-reporter.test.ts
+++ b/tests/pipeline/reporting/result-reporter.test.ts
@@ -4,7 +4,8 @@ vi.mock("../../../src/utils/logger.js", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
-import { formatResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import { formatResult, printResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import type { PipelineReport } from "../../../src/pipeline/reporting/result-reporter.js";
 import type { Plan, PhaseResult } from "../../../src/types/pipeline.js";
 
 function makePlan(overrides: Partial<Plan> = {}): Plan {
@@ -68,5 +69,80 @@ describe("formatResult usedModel field", () => {
     const report = formatResult(42, "test/repo", plan, results, Date.now() - 3000);
     expect(report.phases[0].usedModel).toBeUndefined();
     expect(report.phases[1].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+describe("formatResult cacheHitRatio", () => {
+  it("calculates cacheHitRatio from totalUsage when cache tokens are present", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const totalUsage = { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 };
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000, undefined, totalUsage);
+    expect(report.totalUsage).toEqual(totalUsage);
+    expect(report.cacheHitRatio).toBeCloseTo(0.75, 5);
+  });
+
+  it("leaves cacheHitRatio undefined when totalUsage is not provided", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.totalUsage).toBeUndefined();
+    expect(report.cacheHitRatio).toBeUndefined();
+  });
+});
+
+describe("printResult cache line", () => {
+  it("outputs '캐시 히트율' line with percentage and saved tokens when cache tokens are present", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 },
+      cacheHitRatio: 0.75,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("캐시 히트율: 75.0%, 절감 토큰: 3000");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when totalUsage is absent", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when input + cache_read denominator is zero", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 0, output_tokens: 0 },
+      cacheHitRatio: 0,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

AQM이 생성했던 PR #797(closed)의 구현 3건(cacheHitRatio PR body/report 추가)을 보존하고, **cacheHitRatio 퍼센트 변환 버그**를 수정한 PR.

## 수정 내용

- `src/github/pr-creator.ts:120` — `calculateCacheHitRatio()`는 0~1 범위를 반환하므로 `.toFixed(1) + '%'`로는 99%가 "1.0%"로 표기되던 버그. `* 100` 추가해 "99.9%"로 출력
- `tests/github/pr-creator.test.ts` — 100% 케이스 기대값을 "100.0%"로 수정 + 75% 중간값 테스트 추가 (원 테스트가 100% 케이스만 커버해 버그를 못 잡음)

## 기존 AQM 구현(보존)

- `prompts/pr-body.md` — PR body에 Cache Hit 라인 추가
- `src/pipeline/reporting/result-reporter.ts` — PipelineReport에 totalUsage·cacheHitRatio 필드 + printResult 캐시 히트율 콘솔 출력
- `src/pipeline/phases/pipeline-phases.ts` — formatResult에 totalUsage 전달

## 관련
- #795 원 이슈 (close 상태 유지, 기능 자체는 가치 있어서 구현 반영)
- PR #798(#796) 머지 후 jobs.cache_hit_ratio DB 저장이 정상화됐기 때문에 PR body 값도 신뢰 가능

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run tests/github/pr-creator.test.ts tests/pipeline/reporting/result-reporter.test.ts` — 59 pass
- [ ] 실사용: 다음 생성 PR body에 "Cache Hit: XX.X%" 정상 표시 확인