### PR TITLE
fix(publish): draft PR 생성 시 이슈 위양성 close 제거 (#801)

### DIFF
--- a/src/pipeline/phases/pipeline-publish.ts
+++ b/src/pipeline/phases/pipeline-publish.ts
@@ -1,4 +1,4 @@
-import { createDraftPR, enableAutoMerge, closeIssue, addIssueComment } from "../../github/pr-creator.js";
+import { createDraftPR, enableAutoMerge, addIssueComment } from "../../github/pr-creator.js";
 import { parseDependencies, checkDependencyPRsMerged } from "../../queue/dependency-resolver.js";
 import { pushBranch, checkConflicts, attemptRebase } from "../../git/branch-manager.js";
 import { removeWorktree } from "../../git/worktree-manager.js";
@@ -229,23 +229,9 @@ gh pr merge ${prResult.number} --${projectConfig.pr.mergeMethod}
       }
     }
 
-    // === Close the issue since PR is created ===
-    try {
-      jl?.setStep("이슈 닫는 중...");
-      const closed = await closeIssue(
-        issueNumber,
-        repo,
-        { ghPath: projectConfig.commands.ghCli.path, dryRun }
-      );
-      if (closed) {
-        jl?.log(`이슈 #${issueNumber} 닫음`);
-      } else {
-        jl?.log(`이슈 닫기 실패 (경고만, 계속 진행)`);
-      }
-    } catch (err: unknown) {
-      logger.warn(`Failed to close issue #${issueNumber}: ${getErrorMessage(err)}`);
-      jl?.log(`이슈 닫기 실패 (경고만, 계속 진행)`);
-    }
+    // NOTE: 이슈 close는 draft PR 생성 시점이 아니라 PR이 실제 머지될 때에만
+    // 수행되어야 한다 (GitHub "Closes #N" auto-close 또는 별도 merge 이벤트 핸들러).
+    // draft PR 생성 직후 closeIssue()를 호출하면 위양성으로 이슈가 닫힌다 (#801).
 
     jl?.setStep("완료");
 

--- a/tests/pipeline/orchestrator.test.ts
+++ b/tests/pipeline/orchestrator.test.ts
@@ -253,23 +253,8 @@ describe("runPipeline", () => {
     expect(pushOrder).toBeLessThan(prOrder);
   });
 
-  it("should close issue after PR creation", async () => {
+  it("should NOT close issue after draft PR creation (#801)", async () => {
     setupSuccessMocks();
-    await runPipeline({
-      issueNumber: 42,
-      repo: "test/repo",
-      config: makeConfig(),
-      projectRoot: "/tmp/project",
-    });
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", expect.objectContaining({
-      ghPath: expect.any(String),
-      dryRun: false,
-    }));
-  });
-
-  it("should continue pipeline even if issue close fails", async () => {
-    setupSuccessMocks();
-    mockCloseIssue.mockResolvedValue(false);
     const result = await runPipeline({
       issueNumber: 42,
       repo: "test/repo",
@@ -277,14 +262,9 @@ describe("runPipeline", () => {
       projectRoot: "/tmp/project",
     });
     expect(result.success).toBe(true);
-    expect(result.state).toBe("DONE");
-    // Verify closeIssue was called with correct parameters even though it returned false
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", expect.objectContaining({
-      ghPath: expect.any(String),
-      dryRun: false,
-    }));
-    // Pipeline should still produce a PR URL despite issue close failure
     expect(result.prUrl).toBe("https://github.com/test/repo/pull/1");
+    // Draft PR 생성 시점에는 이슈를 닫지 않는다. PR 머지 시점에만 닫혀야 한다.
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 
   describe("review fix loop", () => {

--- a/tests/pipeline/pipeline-publish.test.ts
+++ b/tests/pipeline/pipeline-publish.test.ts
@@ -241,7 +241,8 @@ describe("pushAndCreatePR", () => {
       "squash",
       { ghPath: "gh", dryRun: false, isDraft: true, deleteBranch: false }
     );
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", { ghPath: "gh", dryRun: false });
+    // #801: draft PR 생성 시점에 closeIssue를 호출하면 이슈가 위양성 close됨
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 
   it("should handle safety validation failure", async () => {
@@ -352,16 +353,6 @@ describe("pushAndCreatePR", () => {
 
     expect(result.success).toBe(true);
     expect(context.jl?.log).toHaveBeenCalledWith("Auto-merge 활성화 실패 (경고만, 계속 진행)");
-  });
-
-  it("should continue when issue close fails", async () => {
-    const context = makePublishContext();
-    mockCloseIssue.mockRejectedValue(new Error("Issue close failed"));
-
-    const result = await pushAndCreatePR(context);
-
-    expect(result.success).toBe(true);
-    expect(context.jl?.log).toHaveBeenCalledWith("이슈 닫기 실패 (경고만, 계속 진행)");
   });
 
   it("should skip push in dry run mode", async () => {
@@ -487,6 +478,15 @@ describe("pushAndCreatePR", () => {
 
     expect(result.success).toBe(true);
     expect(context.jl?.log).toHaveBeenCalledWith("의존성 코멘트 추가 실패 (경고만, 계속 진행)");
+  });
+
+  it("should NOT call closeIssue after draft PR creation (#801 regression guard)", async () => {
+    const context = makePublishContext();
+
+    const result = await pushAndCreatePR(context);
+
+    expect(result.success).toBe(true);
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

`pushAndCreatePR()`에서 draft PR 생성 직후 `closeIssue()`를 무조건 호출하여 이슈가 **머지 전에 close**되던 버그 수정.

## 증상
최근 세션에서 #791/#792/#795/#796 등 draft PR 생성 직후 이슈가 자동 close됨. 타임라인: `labeled` → `referenced`/`cross-referenced` → `closed` (4분 내).

## 근본 원인
`src/pipeline/phases/pipeline-publish.ts:232-248` — PR 머지 여부와 무관하게 draft PR 생성 시점에 `closeIssue()` 호출. 메모리에 "#726(v0.7.3)에서 fix"라 기록됐으나, #726은 AutomationDispatcher의 `pr-merged` 이벤트 타입만 교체했고 이 직접 호출은 건드리지 않음. **회귀가 아니라 원 설계 결함**.

## 수정
- `pipeline-publish.ts:232-248` closeIssue 블록 제거 (+ import 정리)
- 이슈 close는 PR 실제 머지 시점(GitHub `Closes #N` auto-close)에 위임
- 기존 테스트 업데이트: `pushAndCreatePR` + `runPipeline` 양쪽에서 `closeIssue`가 호출되지 않음 단언
- 회귀 방지 테스트 1건 추가

## Closes #801

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 전체 **3383 pass**
- [ ] 실사용: 다음 이슈 처리 시 draft PR 생성 후 이슈가 여전히 OPEN 상태 유지 확인