### PR TITLE
release: v0.8.7 — Plan B B6 튜토리얼 + AQM 신뢰성(self-updater/cache/draft-PR close) fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,50 @@ jobs:
           name: visual-baseline-snapshots
           path: tests/visual/__snapshots__/
 
+  version-bump-check:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract target version
+        id: extract
+        run: |
+          TARGET=$(echo "${{ github.event.pull_request.title }}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+          if [ -z "$TARGET" ]; then
+            TARGET=$(echo "${{ github.head_ref }}" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
+          fi
+          if [ -z "$TARGET" ]; then
+            echo "::warning::버전을 PR 제목 또는 브랜치명에서 감지하지 못했습니다. version-bump-check를 건너뜁니다."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check package.json and package-lock.json version
+        if: steps.extract.outputs.skip == 'false'
+        run: |
+          TARGET="${{ steps.extract.outputs.target }}"
+          PKG=$(node -p "require('./package.json').version")
+          LOCK=$(node -p "require('./package-lock.json').version")
+          echo "목표 버전  : $TARGET"
+          echo "package.json     : $PKG"
+          echo "package-lock.json: $LOCK"
+          FAIL=0
+          if [ "$PKG" != "$TARGET" ]; then
+            echo "::error::package.json version($PKG)이 목표 버전($TARGET)과 다릅니다."
+            FAIL=1
+          fi
+          if [ "$LOCK" != "$TARGET" ]; then
+            echo "::error::package-lock.json version($LOCK)이 목표 버전($TARGET)과 다릅니다."
+            FAIL=1
+          fi
+          if [ "$FAIL" -eq 1 ]; then
+            exit 1
+          fi
+          echo "✓ 버전 일치 확인 완료 ($TARGET)"
+
   visual-regression:
     name: visual-regression (advisory)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ coverage/
 # Playwright artifacts
 test-results/
 playwright-report/
+.playwright-mcp/
+qa-*.png
 
 # Logs
 logs/
@@ -48,6 +50,7 @@ stitch-proxy.sh
 .claude/worktrees/
 .claude/settings*.json
 .claude/skill-usage.jsonl
+.claude/scheduled_tasks.lock
 .claude/doc/
 AGENTS.md
 .cursorrules

--- a/bin/aqm
+++ b/bin/aqm
@@ -172,9 +172,47 @@ case "${1:-}" in
     echo "AI Quartermaster 업데이트 중... (브랜치: $BRANCH)"
     cd "$AQM_ROOT"
     BEFORE=$(git rev-parse HEAD)
-    git fetch --quiet origin
-    git checkout --quiet "$BRANCH"
-    git pull --quiet origin "$BRANCH"
+
+    GIT_ERR=$(git fetch --quiet origin 2>&1)
+    if [ $? -ne 0 ]; then
+      echo "git fetch 실패!"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+
+    GIT_ERR=$(git checkout --quiet "$BRANCH" 2>&1)
+    if [ $? -ne 0 ]; then
+      echo "브랜치 전환 실패: $BRANCH"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+
+    GIT_ERR=$(git pull --quiet origin "$BRANCH" 2>&1)
+    PULL_EXIT=$?
+    if [ $PULL_EXIT -ne 0 ]; then
+      if echo "$GIT_ERR" | grep -qE "CONFLICT|Pull is not possible|Cannot pull"; then
+        echo "머지 충돌로 업데이트 중단!"
+        echo "$GIT_ERR"
+        echo ""
+        echo "수동 해결 방법:"
+        echo "  cd $AQM_ROOT"
+        echo "  git merge --abort  # 또는 충돌 파일 직접 수정 후 git add / git commit"
+        exit 1
+      fi
+      echo "git pull 실패!"
+      echo "$GIT_ERR"
+      exit 1
+    fi
+    if echo "$GIT_ERR" | grep -qE "CONFLICT|Pull is not possible"; then
+      echo "머지 충돌로 업데이트 중단!"
+      echo "$GIT_ERR"
+      echo ""
+      echo "수동 해결 방법:"
+      echo "  cd $AQM_ROOT"
+      echo "  git merge --abort  # 또는 충돌 파일 직접 수정 후 git add / git commit"
+      exit 1
+    fi
+
     AFTER=$(git rev-parse HEAD)
 
     # Handle --clean option

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/prompts/pr-body.md
+++ b/prompts/pr-body.md
@@ -23,6 +23,7 @@ Resolves #{{issue.number}} — {{issue.title}}
 - **Phases**: {{stats.successCount}}/{{stats.phaseCount}} completed
 - **Branch**: `{{branch.work}}` → `{{branch.base}}`
 - **Tokens**: {{stats.inputTokens}} input, {{stats.outputTokens}} output
+- **Cache Hit**: {{stats.cacheHitRatio}} (절감 토큰: {{stats.cacheSavedTokens}})
 
 {{stats.phaseCostTable}}
 {{stats.modelSummary}}

--- a/src/github/pr-creator.ts
+++ b/src/github/pr-creator.ts
@@ -3,6 +3,7 @@ import { runCli } from "../utils/cli-runner.js";
 import { renderTemplate, loadTemplate } from "../prompt/template-renderer.js";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
+import { calculateCacheHitRatio } from "../claude/token-pricing.js";
 import type { PrConfig, GhCliConfig, MergeMethod } from "../types/config.js";
 import type { Plan, PhaseResult, PrConflictInfo, MergeStateStatus, UsageInfo, CostBreakdown } from "../types/pipeline.js";
 
@@ -116,6 +117,8 @@ export async function createDraftPR(
         outputTokens: ctx.totalUsage?.output_tokens || 0,
         cacheCreationTokens: ctx.totalUsage?.cache_creation_input_tokens || 0,
         cacheReadTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
+        cacheHitRatio: ctx.totalUsage ? `${(calculateCacheHitRatio(ctx.totalUsage) * 100).toFixed(1)}%` : '0.0%',
+        cacheSavedTokens: ctx.totalUsage?.cache_read_input_tokens || 0,
         phaseCostTable: buildPhaseCostTable(ctx.costBreakdown, ctx.phaseResults),
         modelSummary: buildModelSummary(ctx.costBreakdown),
         reviewCostUsd: ctx.costBreakdown?.reviewCostUsd?.toFixed(4) || '0.0000',

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -495,7 +495,7 @@ export async function executePostProcessingPhases(
   }
 
   if (!reviewResult.success) {
-    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
     saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
     throw new Error(reviewResult.error || "Review phase failed");
   }
@@ -551,7 +551,7 @@ export async function executePostProcessingPhases(
     }
 
     if (!simplifyResult.success) {
-      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime);
+      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
       saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
       throw new Error(simplifyResult.error || "Simplify phase failed");
     }
@@ -745,7 +745,7 @@ export async function executePostProcessingPhases(
 
     return {
       prUrl,
-      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl),
+      report: formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, prUrl, coreResult.totalUsage),
       totalCostUsd: updatedTotalCostUsd,
     };
   }

--- a/src/pipeline/phases/pipeline-publish.ts
+++ b/src/pipeline/phases/pipeline-publish.ts
@@ -1,4 +1,4 @@
-import { createDraftPR, enableAutoMerge, closeIssue, addIssueComment } from "../../github/pr-creator.js";
+import { createDraftPR, enableAutoMerge, addIssueComment } from "../../github/pr-creator.js";
 import { parseDependencies, checkDependencyPRsMerged } from "../../queue/dependency-resolver.js";
 import { pushBranch, checkConflicts, attemptRebase } from "../../git/branch-manager.js";
 import { removeWorktree } from "../../git/worktree-manager.js";
@@ -229,23 +229,9 @@ gh pr merge ${prResult.number} --${projectConfig.pr.mergeMethod}
       }
     }
 
-    // === Close the issue since PR is created ===
-    try {
-      jl?.setStep("이슈 닫는 중...");
-      const closed = await closeIssue(
-        issueNumber,
-        repo,
-        { ghPath: projectConfig.commands.ghCli.path, dryRun }
-      );
-      if (closed) {
-        jl?.log(`이슈 #${issueNumber} 닫음`);
-      } else {
-        jl?.log(`이슈 닫기 실패 (경고만, 계속 진행)`);
-      }
-    } catch (err: unknown) {
-      logger.warn(`Failed to close issue #${issueNumber}: ${getErrorMessage(err)}`);
-      jl?.log(`이슈 닫기 실패 (경고만, 계속 진행)`);
-    }
+    // NOTE: 이슈 close는 draft PR 생성 시점이 아니라 PR이 실제 머지될 때에만
+    // 수행되어야 한다 (GitHub "Closes #N" auto-close 또는 별도 merge 이벤트 핸들러).
+    // draft PR 생성 직후 closeIssue()를 호출하면 위양성으로 이슈가 닫힌다 (#801).
 
     jl?.setStep("완료");
 

--- a/src/pipeline/reporting/result-reporter.ts
+++ b/src/pipeline/reporting/result-reporter.ts
@@ -1,5 +1,6 @@
-import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown } from "../../types/pipeline.js";
+import type { Plan, PhaseResult, ErrorCategory, DiagnosisReport, CostBreakdown, UsageInfo } from "../../types/pipeline.js";
 import { getLogger } from "../../utils/logger.js";
+import { calculateCacheHitRatio } from "../../claude/token-pricing.js";
 
 export type { DiagnosisReport };
 
@@ -34,6 +35,10 @@ export interface PipelineReport {
   verificationIncomplete?: string[];
   /** phase/model별 비용 세분화 (Total 분해 출력용) */
   costBreakdown?: CostBreakdown;
+  /** 전체 토큰 사용량 (캐시 히트율 계산용) */
+  totalUsage?: UsageInfo;
+  /** 캐시 히트율 (0~1, cache_read / (input + cache_read)) */
+  cacheHitRatio?: number;
 }
 
 /**
@@ -55,9 +60,11 @@ export function formatResult(
   plan: Plan,
   phaseResults: PhaseResult[],
   startTime: number,
-  prUrl?: string
+  prUrl?: string,
+  totalUsage?: UsageInfo
 ): PipelineReport {
   const failedPhase = phaseResults.find(r => !r.success);
+  const cacheHitRatio = totalUsage ? calculateCacheHitRatio(totalUsage) : undefined;
   return {
     issueNumber,
     repo,
@@ -81,6 +88,8 @@ export function formatResult(
     prUrl,
     errorCategory: failedPhase?.errorCategory,
     errorSummary: failedPhase?.error?.slice(0, 500),
+    totalUsage,
+    cacheHitRatio,
   };
 }
 
@@ -122,6 +131,12 @@ export function printResult(report: PipelineReport): void {
     if (bd.setupCostUsd && bd.setupCostUsd > 0) console.log(`  setup    $${bd.setupCostUsd.toFixed(4)}`);
     if (bd.publishCostUsd && bd.publishCostUsd > 0) console.log(`  publish  $${bd.publishCostUsd.toFixed(4)}`);
     if (bd.overheadCostUsd && bd.overheadCostUsd > 0) console.log(`  overhead $${bd.overheadCostUsd.toFixed(4)}`);
+  }
+
+  if (report.totalUsage && (report.totalUsage.input_tokens + (report.totalUsage.cache_read_input_tokens ?? 0)) > 0) {
+    const hitPct = ((report.cacheHitRatio ?? 0) * 100).toFixed(1);
+    const savedTokens = report.totalUsage.cache_read_input_tokens ?? 0;
+    console.log(`캐시 히트율: ${hitPct}%, 절감 토큰: ${savedTokens}`);
   }
 
   if (report.verificationIncomplete && report.verificationIncomplete.length > 0) {

--- a/src/queue/job-store.ts
+++ b/src/queue/job-store.ts
@@ -310,6 +310,7 @@ export class JobStore extends EventEmitter {
       costUsd: job.costUsd,
       totalCostUsd: job.totalCostUsd,
       totalUsage: job.totalUsage,
+      cacheHitRatio: job.cacheHitRatio,
       triggerReason: job.triggerReason,
       diagnosis: job.diagnosis
     };
@@ -422,6 +423,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as QueuedJob;
         break;
@@ -444,6 +446,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           error: baseFields.error,
           priority: baseFields.priority
         } as RunningJob;
@@ -469,6 +472,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as SuccessJob;
         break;
@@ -494,6 +498,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority,
           diagnosis: baseFields.diagnosis
         } as FailureJob;
@@ -519,6 +524,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as CancelledJob;
         break;
@@ -544,6 +550,7 @@ export class JobStore extends EventEmitter {
           costUsd: baseFields.costUsd,
           totalCostUsd: baseFields.totalCostUsd,
           totalUsage: baseFields.totalUsage,
+          cacheHitRatio: baseFields.cacheHitRatio,
           priority: baseFields.priority
         } as ArchivedJob;
         break;

--- a/src/server/public/js/app.js
+++ b/src/server/public/js/app.js
@@ -1919,3 +1919,9 @@ window.toggleProjectDropdown = toggleProjectDropdown;
 window.toggleJobProjectDropdown = toggleJobProjectDropdown;
 window.setProject = setProject;
 window.setAutomationsView = setAutomationsView;
+
+// Tutorial: launch after setup wizard redirect
+if (localStorage.getItem('aqm-tutorial-pending') === 'true') {
+  localStorage.removeItem('aqm-tutorial-pending');
+  if (typeof initTutorial === 'function') initTutorial();
+}

--- a/src/server/public/js/i18n.js
+++ b/src/server/public/js/i18n.js
@@ -81,6 +81,21 @@ var i18n = {
       tabs: { general: "일반", safety: "안전", review: "리뷰" },
       saveState: { saving: "저장 중...", saved: "저장됨", saveFailed: "저장 실패" },
       form: { edit: "편집", reset: "초기화", resetConfirm: "설정을 초기화하시겠습니까?", saveChanges: "변경사항 저장", discardChanges: "변경사항 취소" }
+    },
+    tutorial: {
+      step1Title: "이슈 만들기",
+      step1Desc: "사이드바의 '새 이슈' 메뉴에서 카테고리를 선택하고 이슈를 작성해 보세요. AQM이 자동으로 처리를 시작합니다.",
+      step2Title: "파이프라인 관찰",
+      step2Desc: "대시보드에서 이슈가 처리되는 과정을 실시간으로 확인할 수 있습니다. 각 단계의 진행률이 표시됩니다.",
+      step3Title: "PR 확인",
+      step3Desc: "처리가 완료되면 자동으로 Pull Request가 생성됩니다. 작업 상세에서 PR 링크를 확인하세요.",
+      step4Title: "준비 완료!",
+      step4Desc: "이제 AQM 사용 준비가 끝났습니다. 직접 이슈를 만들어 보세요!",
+      next: "다음",
+      done: "시작하기",
+      skip: "건너뛰기",
+      createIssue: "이슈 만들기",
+      stepOf: "/ "
     }
   },
   en: {
@@ -158,6 +173,21 @@ var i18n = {
       tabs: { general: "General", safety: "Safety", review: "Review" },
       saveState: { saving: "Saving...", saved: "Saved", saveFailed: "Save Failed" },
       form: { edit: "Edit", reset: "Reset", resetConfirm: "Reset all settings to default?", saveChanges: "Save Changes", discardChanges: "Discard Changes" }
+    },
+    tutorial: {
+      step1Title: "Create an Issue",
+      step1Desc: "Go to 'New Issue' in the sidebar, pick a category, and describe what you need. AQM will start processing automatically.",
+      step2Title: "Watch the Pipeline",
+      step2Desc: "The dashboard shows real-time progress as your issue is processed. You can see each phase's status.",
+      step3Title: "Check the PR",
+      step3Desc: "Once complete, a Pull Request is created automatically. Find the PR link in the job details.",
+      step4Title: "You're All Set!",
+      step4Desc: "AQM is ready to use. Try creating your first issue!",
+      next: "Next",
+      done: "Get Started",
+      skip: "Skip",
+      createIssue: "Create Issue",
+      stepOf: "of "
     }
   }
 };

--- a/src/server/public/js/setup.js
+++ b/src/server/public/js/setup.js
@@ -317,6 +317,7 @@ function setupApplyConfig() {
           statusEl.className = 'mt-4 text-xs text-[#3fb950] text-center';
           statusEl.textContent = '저장 완료! 대시보드로 이동합니다...';
         }
+        localStorage.setItem('aqm-tutorial-pending', 'true');
         setTimeout(function () { window.location.href = '/'; }, 1500);
       } else {
         var msg = data.error || '저장에 실패했습니다.';

--- a/src/server/public/js/tutorial.js
+++ b/src/server/public/js/tutorial.js
@@ -1,0 +1,169 @@
+// @ts-check
+'use strict';
+
+/* ══════════════════════════════════════════════════════════════
+   Tutorial Overlay — Plan B B6
+   ══════════════════════════════════════════════════════════════ */
+
+var TUTORIAL_TOTAL_STEPS = 4;
+
+/** @type {Record<string, string>} */
+var TUTORIAL_ICONS = {
+  '1': 'school',
+  '2': 'monitoring',
+  '3': 'merge',
+  '4': 'celebration',
+};
+
+/** @returns {number} */
+function getTutorialStep() {
+  return parseInt(localStorage.getItem('aqm-tutorial-step') || '1', 10);
+}
+
+/** @param {number} step @returns {void} */
+function setTutorialStep(step) {
+  localStorage.setItem('aqm-tutorial-step', String(step));
+}
+
+/** @returns {boolean} */
+function isTutorialViewed() {
+  return localStorage.getItem('aqm-tutorial-viewed') === 'true';
+}
+
+/** @returns {void} */
+function markTutorialViewed() {
+  localStorage.setItem('aqm-tutorial-viewed', 'true');
+}
+
+/**
+ * @param {number} step
+ * @returns {{ title: string, desc: string }}
+ */
+function getTutorialContent(step) {
+  var lang = typeof currentLang !== 'undefined' ? currentLang : 'ko';
+  var tkeys = (typeof i18n !== 'undefined' && i18n[lang] && /** @type {any} */ (i18n[lang]).tutorial)
+    ? /** @type {any} */ (i18n[lang]).tutorial
+    : null;
+
+  if (!tkeys) {
+    // fallback strings
+    var fallback = /** @type {Record<string, {title:string, desc:string}>} */ ({
+      '1': { title: '이슈 만들기', desc: "사이드바의 '새 이슈' 메뉴에서 카테고리를 선택하고 이슈를 작성해 보세요. AQM이 자동으로 처리를 시작합니다." },
+      '2': { title: '파이프라인 관찰', desc: '대시보드에서 이슈가 처리되는 과정을 실시간으로 확인할 수 있습니다. 각 단계의 진행률이 표시됩니다.' },
+      '3': { title: 'PR 확인', desc: '처리가 완료되면 자동으로 Pull Request가 생성됩니다. 작업 상세에서 PR 링크를 확인하세요.' },
+      '4': { title: '준비 완료!', desc: '이제 AQM 사용 준비가 끝났습니다. 직접 이슈를 만들어 보세요!' },
+    });
+    return fallback[String(step)] || { title: '', desc: '' };
+  }
+
+  var titles = {
+    1: String(tkeys.step1Title || ''),
+    2: String(tkeys.step2Title || ''),
+    3: String(tkeys.step3Title || ''),
+    4: String(tkeys.step4Title || ''),
+  };
+  var descs = {
+    1: String(tkeys.step1Desc || ''),
+    2: String(tkeys.step2Desc || ''),
+    3: String(tkeys.step3Desc || ''),
+    4: String(tkeys.step4Desc || ''),
+  };
+  return { title: titles[/** @type {1|2|3|4} */ (step)] || '', desc: descs[/** @type {1|2|3|4} */ (step)] || '' };
+}
+
+/** @returns {string} */
+function renderStepDots() {
+  var step = getTutorialStep();
+  var dots = '';
+  for (var i = 1; i <= TUTORIAL_TOTAL_STEPS; i++) {
+    if (i <= step) {
+      dots += '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--tw-tutorial-primary,#a2c9ff);margin:0 3px;"></span>';
+    } else {
+      dots += '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;border:2px solid var(--tw-tutorial-outline,#8b919d);margin:0 3px;box-sizing:border-box;"></span>';
+    }
+  }
+  return dots;
+}
+
+/** @returns {string} */
+function getTutorialLangKey(/** @type {string} */ key) {
+  var lang = typeof currentLang !== 'undefined' ? currentLang : 'ko';
+  var tkeys = (typeof i18n !== 'undefined' && i18n[lang] && /** @type {any} */ (i18n[lang]).tutorial)
+    ? /** @type {any} */ (i18n[lang]).tutorial
+    : null;
+  if (!tkeys) {
+    var fallback = /** @type {Record<string,string>} */ ({ next: '다음', done: '시작하기', skip: '건너뛰기', createIssue: '이슈 만들기', stepOf: '/ ' });
+    return fallback[key] || key;
+  }
+  return String(tkeys[key] || key);
+}
+
+/** @returns {void} */
+function renderTutorialOverlay() {
+  var container = document.getElementById('tutorial-overlay');
+  if (!container) return;
+
+  var step = getTutorialStep();
+  var content = getTutorialContent(step);
+  var icon = TUTORIAL_ICONS[String(step)] || 'school';
+  var isLast = step === TUTORIAL_TOTAL_STEPS;
+  var stepLabel = String(step) + ' ' + getTutorialLangKey('stepOf') + String(TUTORIAL_TOTAL_STEPS);
+  var actionBtnLabel = isLast ? getTutorialLangKey('done') : getTutorialLangKey('next');
+  var ctaHtml = isLast
+    ? '<button onclick="dismissTutorial(); if(typeof navigateTo===\'function\')navigateTo(\'new-issue\');" class="tutorial-cta-btn" style="margin-top:6px;padding:8px 16px;font-size:12px;border:1px solid rgba(162,201,255,0.4);border-radius:8px;background:transparent;color:#a2c9ff;cursor:pointer;">' + getTutorialLangKey('createIssue') + '</button>'
+    : '';
+
+  container.innerHTML = ''
+    + '<div id="tutorial-backdrop" onclick="dismissTutorial()" style="position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);"></div>'
+    + '<div id="tutorial-card" style="position:fixed;z-index:1001;top:50%;left:50%;transform:translate(-50%,-50%);width:min(calc(100vw - 2rem),440px);background:#1c2026;border-radius:16px;box-shadow:0 24px 48px -12px rgba(0,0,0,0.6);ring:1px solid rgba(255,255,255,0.1);padding:32px 28px 24px;font-family:Inter,sans-serif;animation:tutorialFadeIn 0.25s ease-out;">'
+    +   '<div style="display:flex;justify-content:flex-end;margin-bottom:4px;">'
+    +     '<button onclick="dismissTutorial()" style="background:none;border:none;color:#8b919d;cursor:pointer;font-size:13px;padding:0;">' + getTutorialLangKey('skip') + '</button>'
+    +   '</div>'
+    +   '<div style="display:flex;flex-direction:column;align-items:center;text-align:center;gap:16px;">'
+    +     '<div style="width:64px;height:64px;border-radius:50%;background:rgba(162,201,255,0.1);display:flex;align-items:center;justify-content:center;ring:1px solid rgba(162,201,255,0.15);">'
+    +       '<span class="material-symbols-outlined" style="font-size:32px;color:#a2c9ff;font-variation-settings:\'FILL\' 1;">' + icon + '</span>'
+    +     '</div>'
+    +     '<div>'
+    +       '<div style="font-size:11px;color:#8b919d;margin-bottom:6px;">' + stepLabel + '</div>'
+    +       '<h2 style="font-size:20px;font-weight:700;color:#dfe2eb;margin:0 0 10px;font-family:Space Grotesk,sans-serif;letter-spacing:-0.3px;">' + content.title + '</h2>'
+    +       '<p style="font-size:14px;line-height:1.6;color:#8b919d;margin:0;">' + content.desc + '</p>'
+    +     '</div>'
+    +     '<div style="display:flex;gap:4px;margin-top:4px;">' + renderStepDots() + '</div>'
+    +     '<div style="display:flex;flex-direction:column;align-items:center;gap:8px;width:100%;margin-top:8px;">'
+    +       '<button onclick="advanceTutorialStep()" style="width:100%;padding:12px;font-size:15px;font-weight:600;border:none;border-radius:10px;background:#a2c9ff;color:#00315c;cursor:pointer;transition:filter 0.15s;" onmouseover="this.style.filter=\'brightness(1.1)\'" onmouseout="this.style.filter=\'\'"> ' + actionBtnLabel + '</button>'
+    +       ctaHtml
+    +     '</div>'
+    +   '</div>'
+    + '</div>'
+    + '<style>@keyframes tutorialFadeIn{from{opacity:0;transform:translate(-50%,-50%) scale(0.95)}to{opacity:1;transform:translate(-50%,-50%) scale(1)}}</style>';
+}
+
+/** @returns {void} */
+function advanceTutorialStep() {
+  var step = getTutorialStep();
+  if (step >= TUTORIAL_TOTAL_STEPS) {
+    dismissTutorial();
+    return;
+  }
+  setTutorialStep(step + 1);
+  renderTutorialOverlay();
+}
+
+/** @returns {void} */
+function dismissTutorial() {
+  markTutorialViewed();
+  var container = document.getElementById('tutorial-overlay');
+  if (container) container.innerHTML = '';
+}
+
+/** @returns {void} */
+function initTutorial() {
+  if (isTutorialViewed()) return;
+  setTutorialStep(1);
+  renderTutorialOverlay();
+}
+
+window.initTutorial = initTutorial;
+window.advanceTutorialStep = advanceTutorialStep;
+window.dismissTutorial = dismissTutorial;
+window.renderTutorialOverlay = renderTutorialOverlay;

--- a/src/server/public/views/_layout-footer.html
+++ b/src/server/public/views/_layout-footer.html
@@ -17,6 +17,7 @@
 <script src="js/doctor.js"></script>
 <script src="js/new-issue.js"></script>
 <script src="js/setup.js"></script>
+<script src="js/tutorial.js"></script>
 <script src="js/app.js"></script>
 
 <!-- Confirm Modal -->

--- a/src/server/public/views/dashboard.html
+++ b/src/server/public/views/dashboard.html
@@ -90,3 +90,5 @@
       </div>
     </div>
   </div>
+
+  <div id="tutorial-overlay"></div>

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -327,6 +327,25 @@ export class AQDatabase {
       logger.info("Migration: added cache_hit_ratio column to jobs table");
     }
 
+    // cache_hit_ratio 백필: jobToDbJob 누락 버그로 null로 남은 기존 잡 재계산
+    const refreshedCols = this.db.pragma("table_info(jobs)") as Array<{ name: string }>;
+    const hasReadTokens = refreshedCols.some(col => col.name === "total_cache_read_input_tokens");
+    const hasInputTokens = refreshedCols.some(col => col.name === "total_input_tokens");
+    if (hasReadTokens && hasInputTokens) {
+      const backfill = this.db.prepare(`
+        UPDATE jobs
+        SET cache_hit_ratio = CAST(total_cache_read_input_tokens AS REAL)
+          / (total_input_tokens + total_cache_read_input_tokens)
+        WHERE cache_hit_ratio IS NULL
+          AND total_cache_read_input_tokens IS NOT NULL
+          AND total_input_tokens IS NOT NULL
+          AND (total_input_tokens + total_cache_read_input_tokens) > 0
+      `).run();
+      if (backfill.changes > 0) {
+        logger.info(`Migration: backfilled cache_hit_ratio for ${backfill.changes} jobs`);
+      }
+    }
+
     // jobs 테이블에 cost_breakdown 컬럼 추가 (기존 DB 마이그레이션)
     const hasCostBreakdown = jobColumns.some(col => col.name === "cost_breakdown");
     if (!hasCostBreakdown) {

--- a/src/update/self-updater.ts
+++ b/src/update/self-updater.ts
@@ -96,9 +96,10 @@ export class SelfUpdater {
   }
 
   /**
-   * Performs git pull to update to latest commits
+   * Performs git pull to update to latest commits.
+   * @param remoteHash - When provided, verifies HEAD matches this hash after pull.
    */
-  async pullUpdates(): Promise<void> {
+  async pullUpdates(remoteHash?: string): Promise<void> {
     logger.info("업데이트 적용 중 — git pull 실행...");
 
     const pullResult = await runCli(
@@ -107,7 +108,33 @@ export class SelfUpdater {
       { cwd: this.options.cwd }
     );
     if (pullResult.exitCode !== 0) {
-      throw new Error(`git pull 실패: ${pullResult.stderr}`);
+      const stderr = pullResult.stderr;
+      let detail = stderr;
+      if (stderr.includes("CONFLICT")) {
+        detail = `머지 충돌 발생\n${stderr}`;
+      } else if (stderr.includes("Could not resolve host")) {
+        detail = `네트워크 오류 (호스트 연결 실패)\n${stderr}`;
+      } else if (stderr.includes("Authentication failed")) {
+        detail = `인증 실패\n${stderr}`;
+      }
+      throw new Error(`git pull 실패: ${detail}`);
+    }
+
+    if (remoteHash !== undefined) {
+      const headResult = await runCli(
+        this.gitConfig.gitPath,
+        ["rev-parse", "HEAD"],
+        { cwd: this.options.cwd }
+      );
+      if (headResult.exitCode !== 0) {
+        throw new Error(`pull 후 HEAD 확인 실패: ${headResult.stderr}`);
+      }
+      const actualHead = headResult.stdout.trim();
+      if (actualHead !== remoteHash) {
+        throw new Error(
+          `git pull 성공했으나 HEAD가 원격과 동기화되지 않음 (HEAD: ${actualHead.substring(0, 8)}, 원격: ${remoteHash.substring(0, 8)})`
+        );
+      }
     }
 
     logger.info("git pull 완료");
@@ -175,7 +202,7 @@ export class SelfUpdater {
 
     logger.info(`새 업데이트 발견 — ${updateInfo.currentHash.substring(0, 8)} -> ${updateInfo.remoteHash.substring(0, 8)}`);
 
-    await this.pullUpdates();
+    await this.pullUpdates(updateInfo.remoteHash);
 
     if (this.shouldRunNpmCi(updateInfo)) {
       await this.runNpmCi();

--- a/tests/github/pr-creator.test.ts
+++ b/tests/github/pr-creator.test.ts
@@ -488,6 +488,56 @@ describe("enableAutoMerge", () => {
   });
 });
 
+describe("createDraftPR cache stats template variables", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("should pass cacheHitRatio as percent (100% case) to pr-body template stats", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/20", stderr: "", exitCode: 0 });
+    const ctxWithUsage = {
+      ...ctx,
+      totalUsage: {
+        input_tokens: 0,
+        output_tokens: 500,
+        cache_read_input_tokens: 1000,
+      },
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    // cache_read / (input + cache_read) = 1000/1000 = 1.0 → "100.0%"
+    expect(stats.cacheHitRatio).toBe("100.0%");
+    expect(stats.cacheSavedTokens).toBe(1000);
+  });
+
+  it("should pass cacheHitRatio as percent (75% mid-value case) to pr-body template stats", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/22", stderr: "", exitCode: 0 });
+    const ctxWithUsage = {
+      ...ctx,
+      totalUsage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 3000,
+      },
+    };
+    await createDraftPR(prConfig, ghConfig, ctxWithUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    // 3000 / (1000 + 3000) = 0.75 → "75.0%"
+    expect(stats.cacheHitRatio).toBe("75.0%");
+    expect(stats.cacheSavedTokens).toBe(3000);
+  });
+
+  it("should default cacheHitRatio to '0.0%' and cacheSavedTokens to 0 when totalUsage is absent", async () => {
+    mockRunCli.mockResolvedValue({ stdout: "https://github.com/test/repo/pull/21", stderr: "", exitCode: 0 });
+    const ctxWithoutUsage = { ...ctx, totalUsage: undefined };
+    await createDraftPR(prConfig, ghConfig, ctxWithoutUsage, { cwd: "/tmp", promptsDir: "/prompts" });
+    const templateVars = mockRenderTemplate.mock.calls[1][1] as Record<string, unknown>;
+    const stats = templateVars.stats as Record<string, unknown>;
+    expect(stats.cacheHitRatio).toBe("0.0%");
+    expect(stats.cacheSavedTokens).toBe(0);
+  });
+});
+
 describe("addIssueComment", () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/tests/pipeline/orchestrator.test.ts
+++ b/tests/pipeline/orchestrator.test.ts
@@ -253,23 +253,8 @@ describe("runPipeline", () => {
     expect(pushOrder).toBeLessThan(prOrder);
   });
 
-  it("should close issue after PR creation", async () => {
+  it("should NOT close issue after draft PR creation (#801)", async () => {
     setupSuccessMocks();
-    await runPipeline({
-      issueNumber: 42,
-      repo: "test/repo",
-      config: makeConfig(),
-      projectRoot: "/tmp/project",
-    });
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", expect.objectContaining({
-      ghPath: expect.any(String),
-      dryRun: false,
-    }));
-  });
-
-  it("should continue pipeline even if issue close fails", async () => {
-    setupSuccessMocks();
-    mockCloseIssue.mockResolvedValue(false);
     const result = await runPipeline({
       issueNumber: 42,
       repo: "test/repo",
@@ -277,14 +262,9 @@ describe("runPipeline", () => {
       projectRoot: "/tmp/project",
     });
     expect(result.success).toBe(true);
-    expect(result.state).toBe("DONE");
-    // Verify closeIssue was called with correct parameters even though it returned false
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", expect.objectContaining({
-      ghPath: expect.any(String),
-      dryRun: false,
-    }));
-    // Pipeline should still produce a PR URL despite issue close failure
     expect(result.prUrl).toBe("https://github.com/test/repo/pull/1");
+    // Draft PR 생성 시점에는 이슈를 닫지 않는다. PR 머지 시점에만 닫혀야 한다.
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 
   describe("review fix loop", () => {

--- a/tests/pipeline/pipeline-publish.test.ts
+++ b/tests/pipeline/pipeline-publish.test.ts
@@ -241,7 +241,8 @@ describe("pushAndCreatePR", () => {
       "squash",
       { ghPath: "gh", dryRun: false, isDraft: true, deleteBranch: false }
     );
-    expect(mockCloseIssue).toHaveBeenCalledWith(42, "test/repo", { ghPath: "gh", dryRun: false });
+    // #801: draft PR 생성 시점에 closeIssue를 호출하면 이슈가 위양성 close됨
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 
   it("should handle safety validation failure", async () => {
@@ -352,16 +353,6 @@ describe("pushAndCreatePR", () => {
 
     expect(result.success).toBe(true);
     expect(context.jl?.log).toHaveBeenCalledWith("Auto-merge 활성화 실패 (경고만, 계속 진행)");
-  });
-
-  it("should continue when issue close fails", async () => {
-    const context = makePublishContext();
-    mockCloseIssue.mockRejectedValue(new Error("Issue close failed"));
-
-    const result = await pushAndCreatePR(context);
-
-    expect(result.success).toBe(true);
-    expect(context.jl?.log).toHaveBeenCalledWith("이슈 닫기 실패 (경고만, 계속 진행)");
   });
 
   it("should skip push in dry run mode", async () => {
@@ -487,6 +478,15 @@ describe("pushAndCreatePR", () => {
 
     expect(result.success).toBe(true);
     expect(context.jl?.log).toHaveBeenCalledWith("의존성 코멘트 추가 실패 (경고만, 계속 진행)");
+  });
+
+  it("should NOT call closeIssue after draft PR creation (#801 regression guard)", async () => {
+    const context = makePublishContext();
+
+    const result = await pushAndCreatePR(context);
+
+    expect(result.success).toBe(true);
+    expect(mockCloseIssue).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/pipeline/reporting/result-reporter.test.ts
+++ b/tests/pipeline/reporting/result-reporter.test.ts
@@ -4,7 +4,8 @@ vi.mock("../../../src/utils/logger.js", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 
-import { formatResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import { formatResult, printResult } from "../../../src/pipeline/reporting/result-reporter.js";
+import type { PipelineReport } from "../../../src/pipeline/reporting/result-reporter.js";
 import type { Plan, PhaseResult } from "../../../src/types/pipeline.js";
 
 function makePlan(overrides: Partial<Plan> = {}): Plan {
@@ -68,5 +69,80 @@ describe("formatResult usedModel field", () => {
     const report = formatResult(42, "test/repo", plan, results, Date.now() - 3000);
     expect(report.phases[0].usedModel).toBeUndefined();
     expect(report.phases[1].usedModel).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+describe("formatResult cacheHitRatio", () => {
+  it("calculates cacheHitRatio from totalUsage when cache tokens are present", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const totalUsage = { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 };
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000, undefined, totalUsage);
+    expect(report.totalUsage).toEqual(totalUsage);
+    expect(report.cacheHitRatio).toBeCloseTo(0.75, 5);
+  });
+
+  it("leaves cacheHitRatio undefined when totalUsage is not provided", () => {
+    const results: PhaseResult[] = [
+      { phaseIndex: 0, phaseName: "Phase 1", success: true, durationMs: 1000 },
+    ];
+    const report = formatResult(42, "test/repo", makePlan(), results, Date.now() - 1000);
+    expect(report.totalUsage).toBeUndefined();
+    expect(report.cacheHitRatio).toBeUndefined();
+  });
+});
+
+describe("printResult cache line", () => {
+  it("outputs '캐시 히트율' line with percentage and saved tokens when cache tokens are present", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 1000, output_tokens: 500, cache_read_input_tokens: 3000 },
+      cacheHitRatio: 0.75,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("캐시 히트율: 75.0%, 절감 토큰: 3000");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when totalUsage is absent", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
+  });
+
+  it("does not output '캐시 히트율' line when input + cache_read denominator is zero", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const report: PipelineReport = {
+      issueNumber: 42,
+      repo: "test/repo",
+      success: true,
+      plan: { title: "Test Plan", phaseCount: 1 },
+      phases: [],
+      totalDurationMs: 1000,
+      totalUsage: { input_tokens: 0, output_tokens: 0 },
+      cacheHitRatio: 0,
+    };
+    printResult(report);
+    const output = consoleSpy.mock.calls.flat().join("\n");
+    expect(output).not.toContain("캐시 히트율");
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/queue/job-store.test.ts
+++ b/tests/queue/job-store.test.ts
@@ -1575,4 +1575,21 @@ describe("JobStore", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("cacheHitRatio persistence", () => {
+    it("should persist cacheHitRatio when setCosts is applied", () => {
+      const job = store.create(100, "test/repo");
+      const usage = {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 900
+      };
+
+      store.update(job.id, { totalCostUsd: 0.1, totalUsage: usage, cacheHitRatio: 0.9 });
+
+      const reloaded = store.get(job.id);
+      expect(reloaded?.cacheHitRatio).toBeCloseTo(0.9, 2);
+    });
+  });
 });

--- a/tests/update/self-updater.test.ts
+++ b/tests/update/self-updater.test.ts
@@ -152,10 +152,43 @@ describe("SelfUpdater", () => {
       expect(mockRunCli).toHaveBeenCalledWith("git", ["pull", "origin", "main"], { cwd: "/test/project" });
     });
 
-    it("should throw error when git pull fails", async () => {
-      mockRunCli.mockResolvedValueOnce({ stdout: "", stderr: "merge conflict", exitCode: 1 });
+    it("should throw error when git pull fails with generic error", async () => {
+      mockRunCli.mockResolvedValueOnce({ stdout: "", stderr: "some generic error", exitCode: 1 });
 
-      await expect(selfUpdater.pullUpdates()).rejects.toThrow("git pull 실패: merge conflict");
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("git pull 실패: some generic error");
+    });
+
+    it("should throw merge conflict error when CONFLICT keyword in stderr", async () => {
+      mockRunCli.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "CONFLICT (content): Merge conflict in src/foo.ts",
+        exitCode: 1,
+      });
+
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("머지 충돌 발생");
+    });
+
+    it("should throw network error when host resolution fails", async () => {
+      mockRunCli.mockResolvedValueOnce({
+        stdout: "",
+        stderr: "fatal: Could not resolve host: github.com",
+        exitCode: 128,
+      });
+
+      await expect(selfUpdater.pullUpdates()).rejects.toThrow("네트워크 오류 (호스트 연결 실패)");
+    });
+
+    it("should throw when HEAD does not match remoteHash after pull", async () => {
+      const remoteHash = "def456ghi789";
+      const unexpectedHead = "zzz999yyy888";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${unexpectedHead}\n`, stderr: "", exitCode: 0 }); // git rev-parse HEAD
+
+      await expect(selfUpdater.pullUpdates(remoteHash)).rejects.toThrow(
+        "git pull 성공했으나 HEAD가 원격과 동기화되지 않음"
+      );
     });
   });
 
@@ -236,6 +269,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "package-lock.json\n", stderr: "", exitCode: 0 }) // diff package-lock
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "added 150 packages\n", stderr: "", exitCode: 0 }) // npm ci
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // npm run build
 
@@ -257,6 +291,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock (no changes)
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }); // npm run build
 
       const result = await selfUpdater.performSelfUpdate();
@@ -280,6 +315,66 @@ describe("SelfUpdater", () => {
       await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("git pull 실패: merge conflict");
     });
 
+    it("should throw conflict error with context when CONFLICT keyword in stderr", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "CONFLICT (content): Merge conflict in src/foo.ts", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("머지 충돌 발생");
+    });
+
+    it("should throw network error with context when host resolution fails", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "fatal: Could not resolve host: github.com", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("네트워크 오류 (호스트 연결 실패)");
+    });
+
+    it("should throw auth error with context when authentication fails", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "", stderr: "fatal: Authentication failed for 'https://github.com/repo'", exitCode: 1 }); // git pull
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("인증 실패");
+    });
+
+    it("should throw when HEAD does not match remoteHash after pull", async () => {
+      const currentHash = "abc123def456";
+      const remoteHash = "def456ghi789";
+      const unexpectedHead = "zzz999yyy888";
+
+      mockRunCli
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // git fetch
+        .mockResolvedValueOnce({ stdout: `${currentHash}\n`, stderr: "", exitCode: 0 }) // current HEAD
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
+        .mockResolvedValueOnce({ stdout: "", stderr: "", exitCode: 0 }) // diff package-lock
+        .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${unexpectedHead}\n`, stderr: "", exitCode: 0 }); // git rev-parse HEAD (post-pull)
+
+      await expect(selfUpdater.performSelfUpdate()).rejects.toThrow(
+        "git pull 성공했으나 HEAD가 원격과 동기화되지 않음"
+      );
+    });
+
     it("should propagate error when npm ci fails", async () => {
       const currentHash = "abc123def456";
       const remoteHash = "def456ghi789";
@@ -290,6 +385,7 @@ describe("SelfUpdater", () => {
         .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // remote HEAD
         .mockResolvedValueOnce({ stdout: "package-lock.json\n", stderr: "", exitCode: 0 }) // diff package-lock
         .mockResolvedValueOnce({ stdout: "Updated\n", stderr: "", exitCode: 0 }) // git pull
+        .mockResolvedValueOnce({ stdout: `${remoteHash}\n`, stderr: "", exitCode: 0 }) // git rev-parse HEAD (post-pull)
         .mockResolvedValueOnce({ stdout: "", stderr: "install failed", exitCode: 1 }); // npm ci
 
       await expect(selfUpdater.performSelfUpdate()).rejects.toThrow("npm ci 실패: install failed");


### PR DESCRIPTION
## Summary

v0.8.7 릴리스 — Plan B 최종 트랙(B6 첫 이슈 튜토리얼) 완결 + AQM 자체 신뢰성 버그 fix 묶음.

## 포함된 변경

### 기능
- **#790 Plan B B6** — 첫 이슈 튜토리얼 (Setup Wizard 완료 후 대시보드 진입 시 4스텝 오버레이, ko/en i18n)
- **#799 (#795 일부)** — PR body에 캐시 히트율 표시 + `result-reporter` 캐시 줄 출력

### 버그 수정
- **#794 (#791)** — `aqm update` false-success 버그: git pull 실패·HEAD 불일치 감지
- **#798 (#796)** — `jobs.cache_hit_ratio`가 항상 null로 저장되던 버그 (`update()` 재조립 + `jobToDbJob` 누락). 기존 잡 backfill 마이그레이션 포함
- **#802 (#801)** — draft PR 생성 직후 `closeIssue()` 호출로 이슈가 위양성 close되던 버그 제거

### 인프라
- **#793 (#792)** — 릴리스/핫픽스 PR에서 `package.json` / `package-lock.json` 버전 일치 검증 CI job 추가 (v0.8.4→0.8.6 version 누락 사고 재발 방지)

### 버전
- `package.json` 0.8.6 → **0.8.7**
- `package-lock.json` 동기화

## 후속 이슈 (수동 전용)

- **#800** — Plan Generator JSON 파싱 실패 복구 로직 (AQM 자체 버그, 본 릴리스에는 미포함)

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 전체 3383 pass
- [ ] 머지 후 태그 & `aqm update`로 버전 0.8.7 반영 확인
- [ ] 다음 이슈 처리 시: draft PR 생성되어도 이슈 여전히 OPEN, `jobs.cache_hit_ratio` null 아님, 튜토리얼 재로그인 시 미노출