### PR TITLE
fix(claude): extractJson에 truncation 복구 로직 추가 (#800 부분 해결)

### DIFF
--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -381,6 +381,8 @@ export function extractJson<T = unknown>(text: string): T {
     let depth = 0;
     let inString = false;
     let escape = false;
+    // Top-level(깊이 1) 경계 위치 — truncation 복구 시 잘라낼 안전 지점
+    let lastTopLevelComma = -1;
 
     for (let i = firstBrace; i < text.length; i++) {
       const ch = text[i];
@@ -409,6 +411,31 @@ export function extractJson<T = unknown>(text: string): T {
           } catch {
             // continue searching
           }
+        }
+      }
+      else if (ch === "," && depth === 1) {
+        lastTopLevelComma = i;
+      }
+    }
+
+    // 4. Recovery: Claude 응답이 token 한계로 중간 절단된 경우 자동 복구
+    //    - 마지막이 문자열 내부면 `"`로 닫고, 남은 open brace 깊이만큼 `}` 추가
+    //    - 1차 복구 실패 시 마지막 top-level 쉼표 직전까지만 유지 후 `}` 추가
+    if (depth > 0) {
+      const base = text.slice(firstBrace);
+      const closers = "}".repeat(depth);
+      const firstAttempt = (inString ? base + '"' : base) + closers;
+      try {
+        return JSON.parse(firstAttempt) as T;
+      } catch {
+        // fallback
+      }
+      if (lastTopLevelComma !== -1) {
+        const truncated = text.slice(firstBrace, lastTopLevelComma) + "}";
+        try {
+          return JSON.parse(truncated) as T;
+        } catch {
+          // fallback
         }
       }
     }

--- a/tests/claude/claude-runner.test.ts
+++ b/tests/claude/claude-runner.test.ts
@@ -34,6 +34,28 @@ describe("extractJson", () => {
     const result = extractJson(json);
     expect(result).toEqual({ outer: { inner: { deep: true } } });
   });
+
+  describe("truncation recovery (#800)", () => {
+    it("should recover JSON truncated inside a string value", () => {
+      // 실제 실패 패턴: problemDefinition 중간에서 잘림
+      const truncated = '{"mode":"code","issueNumber":791,"problemDefinition":"aqm update 실행 시 git';
+      const result = extractJson<{ mode: string; problemDefinition: string }>(truncated);
+      expect(result.mode).toBe("code");
+      expect(result.problemDefinition.startsWith("aqm update")).toBe(true);
+    });
+
+    it("should recover JSON truncated with nested object unclosed", () => {
+      const truncated = '{"mode":"code","title":"t","nested":{"a":1,"b":';
+      // nested가 incomplete면 top-level comma 앞까지 잘라내서 복구
+      const result = extractJson<{ mode: string; title: string }>(truncated);
+      expect(result.mode).toBe("code");
+      expect(result.title).toBe("t");
+    });
+
+    it("should still throw when no recoverable JSON exists", () => {
+      expect(() => extractJson("not even a brace")).toThrow();
+    });
+  });
 });
 
 describe("ClaudeRunOptions", () => {


### PR DESCRIPTION
## Summary

Claude 응답이 `max_tokens` 한계로 중간 절단될 때 `extractJson()`이 throw하지 않고 복구 시도하도록 개선.

## 관측 증상

2026-04-19 세션에서 #791/#792/#795/#796 초기 시도 전부 동일 실패:
```
Plan generation failed: JSON 파싱 실패 (2회 시도). Claude 응답: {"mode":"code","issueNumber":791,...,"problemDefinition":"aqm update 실행 시 git...
```
응답이 `problemDefinition` 중간에서 잘림 → JSON.parse 실패 → retry도 같은 결과.

## 수정 내용

`src/claude/claude-runner.ts` `extractJson()`:
1. 기존 3단계 파싱 실패 후 추가 4단계: **truncation 복구**
2. 마지막이 문자열 내부면 `"` 추가 + 남은 depth만큼 `}` 추가 → 1차 파싱 시도
3. 실패 시 마지막 top-level `,` 직전까지 잘라내고 `}` 추가 → 2차 파싱 시도
4. 그래도 실패하면 기존처럼 throw

## 관련 이슈

- `fix(claude): Plan Generator JSON 파싱 실패 복구 로직 — 수동 전용` (GitHub #800)
- `extractJson` 강화만 적용. 프롬프트/스키마 변경은 본 PR 범위 외

## 범위

- 파일 2개 (구현 + 테스트)
- 테스트 3건 추가: truncation 복구 2건 + 회귀 1건
- 전체 21 tests pass

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run tests/claude/claude-runner.test.ts` — 21 pass
- [ ] 머지 후: 과거 실패 패턴과 유사한 테스트 이슈 생성 → AQM 처리 성공 여부 실사용 확인