### PR TITLE
release: v0.8.8 — Plan Generator JSON 파싱 truncation 복구

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/src/claude/claude-runner.ts
+++ b/src/claude/claude-runner.ts
@@ -381,6 +381,8 @@ export function extractJson<T = unknown>(text: string): T {
     let depth = 0;
     let inString = false;
     let escape = false;
+    // Top-level(깊이 1) 경계 위치 — truncation 복구 시 잘라낼 안전 지점
+    let lastTopLevelComma = -1;
 
     for (let i = firstBrace; i < text.length; i++) {
       const ch = text[i];
@@ -409,6 +411,31 @@ export function extractJson<T = unknown>(text: string): T {
           } catch {
             // continue searching
           }
+        }
+      }
+      else if (ch === "," && depth === 1) {
+        lastTopLevelComma = i;
+      }
+    }
+
+    // 4. Recovery: Claude 응답이 token 한계로 중간 절단된 경우 자동 복구
+    //    - 마지막이 문자열 내부면 `"`로 닫고, 남은 open brace 깊이만큼 `}` 추가
+    //    - 1차 복구 실패 시 마지막 top-level 쉼표 직전까지만 유지 후 `}` 추가
+    if (depth > 0) {
+      const base = text.slice(firstBrace);
+      const closers = "}".repeat(depth);
+      const firstAttempt = (inString ? base + '"' : base) + closers;
+      try {
+        return JSON.parse(firstAttempt) as T;
+      } catch {
+        // fallback
+      }
+      if (lastTopLevelComma !== -1) {
+        const truncated = text.slice(firstBrace, lastTopLevelComma) + "}";
+        try {
+          return JSON.parse(truncated) as T;
+        } catch {
+          // fallback
         }
       }
     }

--- a/tests/claude/claude-runner.test.ts
+++ b/tests/claude/claude-runner.test.ts
@@ -34,6 +34,28 @@ describe("extractJson", () => {
     const result = extractJson(json);
     expect(result).toEqual({ outer: { inner: { deep: true } } });
   });
+
+  describe("truncation recovery (#800)", () => {
+    it("should recover JSON truncated inside a string value", () => {
+      // 실제 실패 패턴: problemDefinition 중간에서 잘림
+      const truncated = '{"mode":"code","issueNumber":791,"problemDefinition":"aqm update 실행 시 git';
+      const result = extractJson<{ mode: string; problemDefinition: string }>(truncated);
+      expect(result.mode).toBe("code");
+      expect(result.problemDefinition.startsWith("aqm update")).toBe(true);
+    });
+
+    it("should recover JSON truncated with nested object unclosed", () => {
+      const truncated = '{"mode":"code","title":"t","nested":{"a":1,"b":';
+      // nested가 incomplete면 top-level comma 앞까지 잘라내서 복구
+      const result = extractJson<{ mode: string; title: string }>(truncated);
+      expect(result.mode).toBe("code");
+      expect(result.title).toBe("t");
+    });
+
+    it("should still throw when no recoverable JSON exists", () => {
+      expect(() => extractJson("not even a brace")).toThrow();
+    });
+  });
 });
 
 describe("ClaudeRunOptions", () => {


### PR DESCRIPTION
## Summary

v0.8.8 릴리스 — AQM Plan Generator JSON 파싱 실패 방지 핫픽스.

## 포함된 변경

### 버그 수정
- **#800 부분 해결 (#804)** — `extractJson()`에 truncation 복구 로직 추가. Claude 응답이 token 한계로 중간 절단돼도 방어적으로 `"` + `}` 보강하여 파싱 성공시킴. #791/#792/#795/#796 초기 시도 실패 패턴 방지.

### 버전
- `package.json` 0.8.7 → **0.8.8**

## 배경

v0.8.7 세션 중 이슈 본문이 길 때(한글 문장 + 백틱 + → 화살표) AQM Plan 생성이 반복 실패했음. 원인은 Claude 응답 JSON이 `problemDefinition` 중간에서 절단되어 `JSON.parse()` throw. `extractJson()`이 불완전 JSON을 복구하도록 강화.

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run tests/claude/claude-runner.test.ts` — 21 pass (truncation 복구 3건 포함)
- [ ] 머지 후: `aqm update`로 v0.8.8 반영
- [ ] 과거 실패 패턴(한글 긴 문장 + 특수문자)의 이슈 생성해서 AQM 처리 성공 여부 실사용 확인