### PR TITLE
[AQ-#806] fix(logger): Plan 생성 실패 시 Claude 원본 응답을 디버그 파일로 저장

### DIFF
--- a/src/pipeline/phases/plan-generator.ts
+++ b/src/pipeline/phases/plan-generator.ts
@@ -1,5 +1,5 @@
-import { resolve } from "path";
-import { readFileSync, existsSync } from "fs";
+import { resolve, join } from "path";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import * as ts from "typescript";
 import { renderTemplate, loadTemplate, buildDynamicSection, extractDesignReferences, TemplateVariables } from "../../prompt/template-renderer.js";
 import { detectCircularDependencies, validatePhaseDependencies } from "../execution/phase-scheduler.js";
@@ -51,6 +51,7 @@ export type PlanTemplateData = PlanTemplateBaseData | PlanTemplateRetryData;
 import { notifyPlanRetryContext } from "../../notification/notifier.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
+import { AQM_HOME } from "../../config/project-resolver.js";
 import { DEFAULT_PLAN_MAX_RETRIES } from "../execution/retry-config.js";
 import { analyzeTokenUsage, truncateRepoStructure, truncateToTokenBudget } from "../../review/token-estimator.js";
 
@@ -314,6 +315,17 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       errorCategory = "UNKNOWN";
       errorMessage = getErrorMessage(parseError);
       logger.error(`Plan JSON parsing failed (attempt ${attempt}): ${errorMessage}. Claude output: ${result.output.slice(0, 500)}`);
+
+      try {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const logsDir = join(AQM_HOME, 'logs');
+        mkdirSync(logsDir, { recursive: true });
+        const dumpPath = join(logsDir, `plan-fail-${ctx.issue.number}-${timestamp}.txt`);
+        writeFileSync(dumpPath, result.output, 'utf-8');
+        logger.warn(`Plan 원본 응답 저장됨: ${dumpPath}`);
+      } catch (dumpError: unknown) {
+        logger.warn(`Failed to dump plan response: ${getErrorMessage(dumpError)}`);
+      }
 
       // 히스토리 기록
       retryContext.generationHistory.push({


### PR DESCRIPTION
## Summary

Resolves #806 — fix(logger): Plan 생성 실패 시 Claude 원본 응답을 디버그 파일로 저장

v0.8.8에서 extractJson() truncation 복구 로직(#800)을 추가했지만, 여전히 JSON 파싱 실패 케이스가 발생할 수 있다. 현재 plan-generator.ts의 catch 블록은 result.output을 최대 500자(로그) / 300자(throw) 까지만 노출하므로 사후 디버깅이 불가능하다. Claude 원본 응답 전체를 ~/.ai-quartermaster/logs/ 에 best-effort로 덤프해 사후 분석을 가능하게 만든다.

## Requirements

- JSON 파싱 실패 catch 블록에서 result.output 전체를 ~/.ai-quartermaster/logs/plan-fail-{issueNumber}-{timestamp}.txt 로 저장
- 저장된 파일 경로를 logger.warn으로 출력
- 파일 저장은 best-effort: writeFileSync 또는 mkdirSync 실패해도 파이프라인 흐름(throw, retry, history 기록)에 영향 없음
- 기존 예외 throw 동작 유지 — 마지막 시도 실패 시 동일한 메시지로 throw
- AQM_HOME(project-resolver.ts) 상수를 재사용해 base 경로 통일
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: plan-generator catch 블록에 raw response 덤프 추가 — SUCCESS (d24b579d)

## Risks

- 파일 시스템 쓰기 실패가 catch 블록을 다시 throw 하면 retry 로직이 깨질 수 있음 → 내부 try/catch로 격리 필수
- 다중 파이프라인 동시 실행 시 동일 issueNumber+timestamp 충돌 가능성 → timestamp에 ms + 무작위 suffix 또는 ISO ms 정밀도 사용
- logs 디렉토리 미존재 시 mkdirSync({recursive:true}) 필요
- 이슈 본문/Claude 응답에 토큰/시크릿이 포함될 수 있으나 기존 로그도 일부 노출하므로 동일 정책(추가 마스킹 없이 raw 저장) — 디버그 전용 디렉토리

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $1.0964 (review: $0.1179)
- **Phases**: 2/2 completed
- **Branch**: `aq/806-fix-logger-plan-claude` → `develop`
- **Tokens**: 59 input, 6251 output
- **Cache Hit**: 100.0% (절감 토큰: 757850)


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| plan-generator catch 블록에 raw response 덤프 추가 | $0.3493 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $0.3493 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #806