### PR TITLE
feat(ui): 대시보드/automations 반응형 복원 — lg:(1024) 경계 좌우분할 + 사이드바 스크롤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ AGENTS.md
 .codeium/
 .continue/
 .windsurf/
+responsive-check/

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -399,7 +399,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 
 <div class="flex min-h-[calc(100vh-64px)]">
 <!-- SideNavBar -->
-<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d]">
+<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d] overflow-y-auto">
   <div class="mb-4 px-2">
     <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase"></div>
   </div>
@@ -524,9 +524,9 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     </div>
 
     <!-- Dashboard Layout Grid -->
-    <div class="grid grid-cols-12 gap-8">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
       <!-- Left: Job List Column -->
-      <div class="col-span-4 space-y-4">
+      <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
         <div id="job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-350px)] pr-2 custom-scrollbar">
           <!-- Jobs rendered here dynamically -->
         </div>
@@ -544,7 +544,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
       </div>
 
       <!-- Right: Job Details Column -->
-      <div class="col-span-8">
+      <div class="col-span-1 lg:col-span-8 min-w-0">
         <div id="job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
           <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
         </div>
@@ -680,9 +680,9 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 
     <!-- List View -->
     <div id="automations-list-view">
-      <div class="grid grid-cols-12 gap-8">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <!-- Left: Job List Column -->
-        <div class="col-span-4 space-y-4">
+        <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
           <div id="automations-job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-300px)] pr-2 custom-scrollbar">
             <!-- Jobs rendered here dynamically -->
           </div>
@@ -693,7 +693,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
           </div>
         </div>
         <!-- Right: Job Detail Column -->
-        <div class="col-span-8">
+        <div class="col-span-1 lg:col-span-8 min-w-0">
           <div id="automations-job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
             <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
           </div>

--- a/src/server/public/js/render-jobs.js
+++ b/src/server/public/js/render-jobs.js
@@ -128,13 +128,13 @@ function renderJobDetail(job) {
   }
 
   // Header
-  var html = '<div class="flex justify-between items-start">';
-  html += '<div>';
-  html += '<div class="flex items-center gap-3 mb-2">';
-  html += '<h1 class="text-2xl font-headline font-bold">#' + job.issueNumber + ' ' + esc(job.repo) + '</h1>';
+  var html = '<div class="flex flex-wrap justify-between items-start gap-4">';
+  html += '<div class="min-w-0">';
+  html += '<div class="flex flex-wrap items-center gap-3 mb-2">';
+  html += '<h1 class="text-2xl font-headline font-bold break-words">#' + job.issueNumber + ' ' + esc(job.repo) + '</h1>';
   html += statusBadge;
   html += '</div>';
-  html += '<div class="flex items-center gap-6 text-sm text-outline font-medium">';
+  html += '<div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-outline font-medium">';
   if (dur) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">schedule</span> <span data-dur="' + esc(job.id) + '">' + dur + '</span></span>';
   var costHtml = fmtCost(job.totalCostUsd);
   if (costHtml) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">payments</span> ' + costHtml + '</span>';
@@ -144,7 +144,7 @@ function renderJobDetail(job) {
   html += '</div></div>';
 
   // Action buttons
-  html += '<div class="flex gap-3">';
+  html += '<div class="flex flex-wrap gap-3 shrink-0">';
   if (job.phaseResults && job.phaseResults.length > 0) {
     html += '<button onclick="openTimelineModal(currentJobs.find(function(j){return j.id===\'' + esc(job.id) + '\'})||{})" class="px-4 py-2 bg-surface-container-high text-primary text-sm font-bold rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors flex items-center gap-1.5 whitespace-nowrap"><span class="material-symbols-outlined text-sm">timeline</span> 타임라인</button>';
   }

--- a/src/server/public/views/_layout-sidebar.html
+++ b/src/server/public/views/_layout-sidebar.html
@@ -1,6 +1,6 @@
 <div class="flex min-h-[calc(100vh-64px)]">
 <!-- SideNavBar -->
-<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d]">
+<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d] overflow-y-auto">
   <div class="mb-4 px-2">
     <div class="flex items-center gap-2">
       <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase flex-1"></div>

--- a/src/server/public/views/automations.html
+++ b/src/server/public/views/automations.html
@@ -25,9 +25,9 @@
 
     <!-- List View -->
     <div id="automations-list-view">
-      <div class="grid grid-cols-12 gap-8">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <!-- Left: Job List Column -->
-        <div class="col-span-4 space-y-4">
+        <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
           <div id="automations-job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-300px)] pr-2 custom-scrollbar">
             <!-- Jobs rendered here dynamically -->
           </div>
@@ -38,7 +38,7 @@
           </div>
         </div>
         <!-- Right: Job Detail Column -->
-        <div class="col-span-8">
+        <div class="col-span-1 lg:col-span-8 min-w-0">
           <div id="automations-job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
             <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
           </div>

--- a/src/server/public/views/dashboard.html
+++ b/src/server/public/views/dashboard.html
@@ -63,9 +63,9 @@
     </div>
 
     <!-- Dashboard Layout Grid -->
-    <div class="grid grid-cols-12 gap-8">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
       <!-- Left: Job List Column -->
-      <div class="col-span-4 space-y-4">
+      <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
         <div id="job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-350px)] pr-2 custom-scrollbar">
           <!-- Jobs rendered here dynamically -->
         </div>
@@ -79,7 +79,7 @@
       </div>
 
       <!-- Right: Job Details Column -->
-      <div class="col-span-8">
+      <div class="col-span-1 lg:col-span-8 min-w-0">
         <div id="job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
           <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
         </div>


### PR DESCRIPTION
## Summary

좁은 폭(모니터 세로 회전 1080 portrait 등)과 좁은 높이(1080x640 등)에서 대시보드 UI가 깨지던 문제 해결.

## 문제

- **너비 1024~1279 구간**: detail 패널의 타임라인/삭제 버튼이 우측 viewport 바깥으로 잘림
- **높이 640 이하**: 사이드바 메뉴 하단(설정/초기 설정) 잘려 접근 불가
- **원인**: 과거 \`@media (max-width:1080px)\` + \`!important\` 강제 오버라이드 방식이 깨져 \`max-width:0px\`로 비활성화된 채 방치됨

## 수정

이전 방식(@media + !important 강제 오버라이드) 대신 **Tailwind 표준 유틸리티로 재구현**:

- \`views/dashboard.html\` / \`views/automations.html\`:
  - \`grid-cols-12\` → \`grid-cols-1 lg:grid-cols-12\`
  - \`col-span-4/8\` → \`col-span-1 lg:col-span-4/8 min-w-0\` (CSS Grid 셀이 content에 따라 확장되는 문제 방지)
- \`views/_layout-sidebar.html\`: \`overflow-y-auto\` 추가 (세로 좁은 해상도 메뉴 스크롤)
- \`js/render-jobs.js\` \`renderJobDetail\`:
  - 헤더 컨테이너: \`flex\` → \`flex flex-wrap ... gap-4\`
  - 제목 블록: \`min-w-0\` + \`flex-wrap\` + h1에 \`break-words\`
  - 메타 행: \`flex-wrap\` + \`gap-x-6 gap-y-2\`
  - 액션 버튼: \`flex-wrap shrink-0\`
- \`index.html\`: 런타임 미사용이지만 일관성 위해 동일 sync
- \`.gitignore\`: \`responsive-check/\` 스크린샷 artifact 제외

## 검증 (Playwright 실측)

| 해상도 | 결과 |
|---|---|
| 1080x1400 (portrait) | 제목/배지/메타/버튼 flex-wrap으로 세로 정렬 |
| 1080x640 (1080/3 height) | 사이드바 스크롤로 전 메뉴 접근 가능 |
| 1440x900 | 기존과 동일 |
| 1280x800 | 정상 |

## 주의

설치 경로(\`~/.ai-quartermaster/\`)에는 이미 파일이 sync되어 현재 서버에 반영된 상태. 공식 배포는 develop → main 다음 릴리스에.

## Test plan

- [x] Playwright 각 해상도 스크린샷 검증
- [ ] 머지 후 사용자님 실제 환경(1080 portrait)에서 타임라인/삭제 버튼 정상 표시 확인