### PR TITLE
release: v0.8.9 — 반응형 UI 복원 + Plan 실패 자동 디버그 덤프

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ AGENTS.md
 .codeium/
 .continue/
 .windsurf/
+responsive-check/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/src/pipeline/phases/plan-generator.ts
+++ b/src/pipeline/phases/plan-generator.ts
@@ -1,5 +1,5 @@
-import { resolve } from "path";
-import { readFileSync, existsSync } from "fs";
+import { resolve, join } from "path";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import * as ts from "typescript";
 import { renderTemplate, loadTemplate, buildDynamicSection, extractDesignReferences, TemplateVariables } from "../../prompt/template-renderer.js";
 import { detectCircularDependencies, validatePhaseDependencies } from "../execution/phase-scheduler.js";
@@ -51,6 +51,7 @@ export type PlanTemplateData = PlanTemplateBaseData | PlanTemplateRetryData;
 import { notifyPlanRetryContext } from "../../notification/notifier.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
+import { AQM_HOME } from "../../config/project-resolver.js";
 import { DEFAULT_PLAN_MAX_RETRIES } from "../execution/retry-config.js";
 import { analyzeTokenUsage, truncateRepoStructure, truncateToTokenBudget } from "../../review/token-estimator.js";
 
@@ -314,6 +315,17 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       errorCategory = "UNKNOWN";
       errorMessage = getErrorMessage(parseError);
       logger.error(`Plan JSON parsing failed (attempt ${attempt}): ${errorMessage}. Claude output: ${result.output.slice(0, 500)}`);
+
+      try {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const logsDir = join(AQM_HOME, 'logs');
+        mkdirSync(logsDir, { recursive: true });
+        const dumpPath = join(logsDir, `plan-fail-${ctx.issue.number}-${timestamp}.txt`);
+        writeFileSync(dumpPath, result.output, 'utf-8');
+        logger.warn(`Plan 원본 응답 저장됨: ${dumpPath}`);
+      } catch (dumpError: unknown) {
+        logger.warn(`Failed to dump plan response: ${getErrorMessage(dumpError)}`);
+      }
 
       // 히스토리 기록
       retryContext.generationHistory.push({

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -399,7 +399,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 
 <div class="flex min-h-[calc(100vh-64px)]">
 <!-- SideNavBar -->
-<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d]">
+<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d] overflow-y-auto">
   <div class="mb-4 px-2">
     <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase"></div>
   </div>
@@ -524,9 +524,9 @@ if (localStorage.getItem('aqm-theme') === 'light') {
     </div>
 
     <!-- Dashboard Layout Grid -->
-    <div class="grid grid-cols-12 gap-8">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
       <!-- Left: Job List Column -->
-      <div class="col-span-4 space-y-4">
+      <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
         <div id="job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-350px)] pr-2 custom-scrollbar">
           <!-- Jobs rendered here dynamically -->
         </div>
@@ -544,7 +544,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
       </div>
 
       <!-- Right: Job Details Column -->
-      <div class="col-span-8">
+      <div class="col-span-1 lg:col-span-8 min-w-0">
         <div id="job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
           <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
         </div>
@@ -680,9 +680,9 @@ if (localStorage.getItem('aqm-theme') === 'light') {
 
     <!-- List View -->
     <div id="automations-list-view">
-      <div class="grid grid-cols-12 gap-8">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <!-- Left: Job List Column -->
-        <div class="col-span-4 space-y-4">
+        <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
           <div id="automations-job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-300px)] pr-2 custom-scrollbar">
             <!-- Jobs rendered here dynamically -->
           </div>
@@ -693,7 +693,7 @@ if (localStorage.getItem('aqm-theme') === 'light') {
           </div>
         </div>
         <!-- Right: Job Detail Column -->
-        <div class="col-span-8">
+        <div class="col-span-1 lg:col-span-8 min-w-0">
           <div id="automations-job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
             <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
           </div>

--- a/src/server/public/js/render-jobs.js
+++ b/src/server/public/js/render-jobs.js
@@ -128,13 +128,13 @@ function renderJobDetail(job) {
   }
 
   // Header
-  var html = '<div class="flex justify-between items-start">';
-  html += '<div>';
-  html += '<div class="flex items-center gap-3 mb-2">';
-  html += '<h1 class="text-2xl font-headline font-bold">#' + job.issueNumber + ' ' + esc(job.repo) + '</h1>';
+  var html = '<div class="flex flex-wrap justify-between items-start gap-4">';
+  html += '<div class="min-w-0">';
+  html += '<div class="flex flex-wrap items-center gap-3 mb-2">';
+  html += '<h1 class="text-2xl font-headline font-bold break-words">#' + job.issueNumber + ' ' + esc(job.repo) + '</h1>';
   html += statusBadge;
   html += '</div>';
-  html += '<div class="flex items-center gap-6 text-sm text-outline font-medium">';
+  html += '<div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-outline font-medium">';
   if (dur) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">schedule</span> <span data-dur="' + esc(job.id) + '">' + dur + '</span></span>';
   var costHtml = fmtCost(job.totalCostUsd);
   if (costHtml) html += '<span class="flex items-center gap-1.5"><span class="material-symbols-outlined text-sm">payments</span> ' + costHtml + '</span>';
@@ -144,7 +144,7 @@ function renderJobDetail(job) {
   html += '</div></div>';
 
   // Action buttons
-  html += '<div class="flex gap-3">';
+  html += '<div class="flex flex-wrap gap-3 shrink-0">';
   if (job.phaseResults && job.phaseResults.length > 0) {
     html += '<button onclick="openTimelineModal(currentJobs.find(function(j){return j.id===\'' + esc(job.id) + '\'})||{})" class="px-4 py-2 bg-surface-container-high text-primary text-sm font-bold rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors flex items-center gap-1.5 whitespace-nowrap"><span class="material-symbols-outlined text-sm">timeline</span> 타임라인</button>';
   }

--- a/src/server/public/views/_layout-sidebar.html
+++ b/src/server/public/views/_layout-sidebar.html
@@ -1,6 +1,6 @@
 <div class="flex min-h-[calc(100vh-64px)]">
 <!-- SideNavBar -->
-<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d]">
+<aside class="w-[280px] h-screen fixed left-0 top-16 bottom-0 flex flex-col p-4 z-40 bg-[#161b22] dark:bg-[#161b22] border-r border-[#30363d] overflow-y-auto">
   <div class="mb-4 px-2">
     <div class="flex items-center gap-2">
       <div id="claude-profile-label" class="text-sm font-headline font-bold text-primary tracking-wide uppercase flex-1"></div>

--- a/src/server/public/views/automations.html
+++ b/src/server/public/views/automations.html
@@ -25,9 +25,9 @@
 
     <!-- List View -->
     <div id="automations-list-view">
-      <div class="grid grid-cols-12 gap-8">
+      <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
         <!-- Left: Job List Column -->
-        <div class="col-span-4 space-y-4">
+        <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
           <div id="automations-job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-300px)] pr-2 custom-scrollbar">
             <!-- Jobs rendered here dynamically -->
           </div>
@@ -38,7 +38,7 @@
           </div>
         </div>
         <!-- Right: Job Detail Column -->
-        <div class="col-span-8">
+        <div class="col-span-1 lg:col-span-8 min-w-0">
           <div id="automations-job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
             <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
           </div>

--- a/src/server/public/views/dashboard.html
+++ b/src/server/public/views/dashboard.html
@@ -63,9 +63,9 @@
     </div>
 
     <!-- Dashboard Layout Grid -->
-    <div class="grid grid-cols-12 gap-8">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
       <!-- Left: Job List Column -->
-      <div class="col-span-4 space-y-4">
+      <div class="col-span-1 lg:col-span-4 min-w-0 space-y-4">
         <div id="job-list" class="space-y-3 overflow-y-auto max-h-[calc(100vh-350px)] pr-2 custom-scrollbar">
           <!-- Jobs rendered here dynamically -->
         </div>
@@ -79,7 +79,7 @@
       </div>
 
       <!-- Right: Job Details Column -->
-      <div class="col-span-8">
+      <div class="col-span-1 lg:col-span-8 min-w-0">
         <div id="job-detail" class="bg-surface-container p-8 rounded-2xl ring-1 ring-outline-variant/20 flex flex-col gap-8 min-h-[400px]">
           <div class="flex items-center justify-center h-full min-h-[300px] text-outline text-sm">작업을 선택하세요</div>
         </div>


### PR DESCRIPTION
## Summary

v0.8.9 릴리스 — 대시보드 반응형 복원 + AQM Plan 생성 실패 자동 진단 개선.

## 포함

### UI
- **#808 (#아직-issue-없음)** — 대시보드/automations 반응형 복원. \`lg:\`(1024) 경계 좌우 분할, 그 이하 세로 stack. 사이드바 세로 좁은 해상도에서 스크롤. detail 헤더 flex-wrap. 이전 @media 강제 오버라이드 방식과 달리 Tailwind 표준 유틸리티로 재구현.

### 진단 / 자가 복원
- **#807 (#806)** — Plan JSON 파싱 실패 시 Claude 원본 응답을 \`~/.ai-quartermaster/logs/plan-fail-{issueNumber}-{timestamp}.txt\`로 자동 덤프. best-effort, 기존 throw 동작 유지. #800(extractJson 복구) + 본 덤프로 실패 원인 추적 용이.

### 버전
- \`package.json\` 0.8.8 → **0.8.9**

## Test plan

- [x] Playwright 각 해상도 실측 (1080x640, 1080x1400, 1280, 1440)
- [x] \`npx tsc --noEmit\` / \`npx vitest run\` 통과
- [ ] 머지 후 \`aqm update\` → 세로 회전 모니터에서 타임라인/삭제 버튼 정상 표시 확인
- [ ] 다음 AQM 처리 시 plan-fail-*.txt 파일이 (파싱 실패 발생 시) 생성되는지