### PR TITLE
refactor(learning): PatternStore 단일 인스턴스 팩토리 (Plan C #C3)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import { cleanOldWorktrees } from "./git/worktree-cleaner.js";
 import { runDoctor } from "./setup/doctor.js";
 import { JobLogger } from "./queue/job-logger.js";
 import { IssuePoller } from "./polling/issue-poller.js";
-import { PatternStore } from "./learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "./learning/pattern-store.js";
 import { SelfUpdater } from "./update/self-updater.js";
 import { ConfigWatcher } from "./config/config-watcher.js";
 import { AutomationScheduler } from "./automation/scheduler.js";
@@ -486,7 +486,7 @@ export async function startCommand(args: CliArgs): Promise<void> {
     );
   }
 
-  const patternStore = new PatternStore(dataDir);
+  const patternStore = getPatternStore(dataDir);
   const dashboardRoutes = createDashboardRoutes(store, queue, configWatcher, apiKey, host, effectiveConfig.general.dashboardAuth, wslReadOnly, patternStore, aqRoot);
   const healthRoutes = createHealthRoutes(queue, poller);
 
@@ -695,7 +695,7 @@ export async function planCommand(args: CliArgs): Promise<void> {
 export async function statsCommand(args: CliArgs): Promise<void> {
   const aqRoot = args.config ? resolve(args.config, "..") : process.cwd();
   const dataDir = resolve(aqRoot, "data");
-  const patternStore = new PatternStore(dataDir);
+  const patternStore = getPatternStore(dataDir);
   const jobStore = new JobStore(dataDir);
 
   const stats = patternStore.getStats(args.repo);

--- a/src/learning/pattern-store.ts
+++ b/src/learning/pattern-store.ts
@@ -107,6 +107,31 @@ export class PatternStore {
   }
 }
 
+const patternStoreCache = new Map<string, PatternStore>();
+
+/**
+ * 같은 dataDir에 대해 프로세스 수명 동안 단일 PatternStore 인스턴스를 반환한다.
+ *
+ * pipeline-phases / pipeline-publish / core-loop 등에서 각자 `new PatternStore()`를 생성하던
+ * 5곳을 이 팩토리로 일원화해, 같은 파일을 가리키는 중복 인스턴스와 불필요한 `mkdirSync` 재호출을
+ * 제거한다. 현재 모든 메서드가 동기 + write 경로가 단순한 read-modify-write라 단일 프로세스 내
+ * race는 발생하지 않지만, 향후 async/캐싱 도입 시 단일 인스턴스 전제를 깔아두기 위함.
+ */
+export function getPatternStore(dataDir: string): PatternStore {
+  const key = resolve(dataDir);
+  let instance = patternStoreCache.get(key);
+  if (!instance) {
+    instance = new PatternStore(dataDir);
+    patternStoreCache.set(key, instance);
+  }
+  return instance;
+}
+
+/** 테스트용 캐시 초기화. 프로덕션 코드에서는 사용하지 않음. */
+export function __resetPatternStoreCacheForTests(): void {
+  patternStoreCache.clear();
+}
+
 function resolutionHint(category: string): string {
   switch (category) {
     case "TS_ERROR":

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -10,7 +10,7 @@ import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { resolveRetryBudget } from "../execution/retry-config.js";
 import type { JobLogger } from "../../queue/job-logger.js";
-import { PatternStore } from "../../learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PLAN_GENERATED, phaseStart } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
 import { createWorktree, removeWorktree } from "../../git/worktree-manager.js";
@@ -304,7 +304,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
   let pastFailures = "";
   if (ctx.dataDir) {
     try {
-      const patternStore = new PatternStore(ctx.dataDir);
+      const patternStore = getPatternStore(ctx.dataDir);
       const recentFailures = patternStore.getRecentFailures(repoFull, 5);
       pastFailures = patternStore.formatForPrompt(recentFailures);
     } catch (patternError: unknown) {

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { runCoreLoop } from "../core/core-loop.js";
 import { getModePreset, getExecutionModePreset, detectExecutionModeFromLabels } from "../../config/mode-presets.js";
 import { resolveProject } from "../../config/project-resolver.js";
-import { PatternStore } from "../../learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "../../learning/pattern-store.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { handleCoreLoopFailure } from "../errors/pipeline-error-handler.js";
@@ -310,7 +310,7 @@ export async function executeCoreLoopPhase(
 
   const [owner, name] = repo.split("/");
   const projectConfig = { ...config, commands: project.commands, safety: project.safety };
-  const patternStore = new PatternStore(dataDir);
+  const patternStore = getPatternStore(dataDir);
   const preset = getModePreset(mode);
   const executionMode = detectExecutionModeFromLabels(issue.labels, "standard");
   const executionModePreset = getExecutionModePreset(executionMode);

--- a/src/pipeline/phases/pipeline-publish.ts
+++ b/src/pipeline/phases/pipeline-publish.ts
@@ -11,7 +11,7 @@ import { getLogger } from "../../utils/logger.js";
 import type { PublishPhaseContext, CleanupContext, FailureHandlerContext } from "../../types/pipeline.js";
 import type { SenderPermission } from "../../github/issue-fetcher.js";
 import { removeCheckpoint } from "../errors/checkpoint.js";
-import { PatternStore } from "../../learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PR_CREATED } from "../reporting/progress-tracker.js";
 import { saveResult } from "../setup/pipeline-validation.js";
 
@@ -275,7 +275,7 @@ export async function cleanupOnSuccess(context: CleanupContext): Promise<void> {
 
   // Record success pattern
   try {
-    const patternStore = new PatternStore(dataDir);
+    const patternStore = getPatternStore(dataDir);
     patternStore.add({
       issueNumber,
       repo,

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -16,7 +16,7 @@ import { createHealthRoutes } from "../src/server/health.js";
 import { cleanupStalePid, writePidFile, readPidFile, removePidFile } from "../src/server/pid-manager.js";
 import { ConfigWatcher } from "../src/config/config-watcher.js";
 import { loadCheckpoint } from "../src/pipeline/errors/checkpoint.js";
-import { PatternStore } from "../src/learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "../src/learning/pattern-store.js";
 import { cleanOldWorktrees } from "../src/git/worktree-cleaner.js";
 import { listTriggerIssues, generateExecutionPlan, printExecutionPlan } from "../src/pipeline/automation/issue-orchestrator.js";
 import { killAllActiveProcesses } from "../src/claude/claude-runner.js";
@@ -81,6 +81,13 @@ vi.mock("../src/config/config-watcher.js", () => ({
 }));
 vi.mock("../src/learning/pattern-store.js", () => ({
   PatternStore: vi.fn(),
+  getPatternStore: vi.fn(() => ({
+    add: vi.fn(),
+    list: vi.fn(() => []),
+    getRecentFailures: vi.fn(() => []),
+    getStats: vi.fn(() => ({ total: 0, successes: 0, failures: 0, byCategory: {} })),
+    formatForPrompt: vi.fn(() => ""),
+  })),
 }));
 vi.mock("../src/git/worktree-cleaner.js", () => ({
   cleanOldWorktrees: vi.fn(),
@@ -1106,10 +1113,10 @@ describe("statsCommand", () => {
   });
 
   it("빈 데이터 시 success rate N/A 출력", async () => {
-    vi.mocked(PatternStore).mockImplementation(() => ({
+    vi.mocked(getPatternStore).mockReturnValue({
       getStats: vi.fn().mockReturnValue({ total: 0, successes: 0, failures: 0, byCategory: {} }),
       list: vi.fn().mockReturnValue([]),
-    } as unknown as PatternStore));
+    } as unknown as PatternStore);
     vi.mocked(JobStore).mockImplementation(() => ({
       getCostStats: vi.fn().mockReturnValue({ totalCostUsd: 0, avgCostUsd: 0, jobCount: 0, topExpensiveJobs: [] }),
     } as unknown as JobStore));
@@ -1122,7 +1129,7 @@ describe("statsCommand", () => {
   });
 
   it("실패 패턴·비용 통계 출력", async () => {
-    vi.mocked(PatternStore).mockImplementation(() => ({
+    vi.mocked(getPatternStore).mockReturnValue({
       getStats: vi.fn().mockReturnValue({
         total: 10,
         successes: 7,
@@ -1132,7 +1139,7 @@ describe("statsCommand", () => {
       list: vi.fn().mockReturnValue([
         { timestamp: Date.now(), issueNumber: 5, repo: "owner/repo", errorCategory: "TYPE_ERROR", errorMessage: "타입 오류", phaseName: "implement" },
       ]),
-    } as unknown as PatternStore));
+    } as unknown as PatternStore);
     vi.mocked(JobStore).mockImplementation(() => ({
       getCostStats: vi.fn().mockReturnValue({
         totalCostUsd: 1.5,
@@ -1157,10 +1164,10 @@ describe("statsCommand", () => {
     const mockList = vi.fn().mockReturnValue([]);
     const mockGetCostStats = vi.fn().mockReturnValue({ totalCostUsd: 0, avgCostUsd: 0, jobCount: 0, topExpensiveJobs: [] });
 
-    vi.mocked(PatternStore).mockImplementation(() => ({
+    vi.mocked(getPatternStore).mockReturnValue({
       getStats: mockGetStats,
       list: mockList,
-    } as unknown as PatternStore));
+    } as unknown as PatternStore);
     vi.mocked(JobStore).mockImplementation(() => ({
       getCostStats: mockGetCostStats,
     } as unknown as JobStore));

--- a/tests/pipeline/core-loop.test.ts
+++ b/tests/pipeline/core-loop.test.ts
@@ -25,6 +25,10 @@ vi.mock("../../src/learning/pattern-store.js", () => ({
     getRecentFailures: vi.fn().mockReturnValue([]),
     formatForPrompt: vi.fn().mockReturnValue(""),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    getRecentFailures: vi.fn().mockReturnValue([]),
+    formatForPrompt: vi.fn().mockReturnValue(""),
+  })),
 }));
 vi.mock("../../src/utils/logger.js", () => ({
   getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),

--- a/tests/pipeline/core/orchestrator-phaseresults.test.ts
+++ b/tests/pipeline/core/orchestrator-phaseresults.test.ts
@@ -65,6 +65,10 @@ vi.mock("../../../src/learning/pattern-store.js", () => ({
     getRecentFailures: vi.fn().mockReturnValue([]),
     formatForPrompt: vi.fn().mockReturnValue(""),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    getRecentFailures: vi.fn().mockReturnValue([]),
+    formatForPrompt: vi.fn().mockReturnValue(""),
+  })),
 }));
 vi.mock("../../../src/pipeline/errors/pipeline-error-handler.js", () => ({
   handleCoreLoopFailure: vi.fn(),

--- a/tests/pipeline/errors/pipeline-error-handler.test.ts
+++ b/tests/pipeline/errors/pipeline-error-handler.test.ts
@@ -23,6 +23,9 @@ vi.mock("../../../src/learning/pattern-store.js", () => ({
   PatternStore: vi.fn().mockImplementation(() => ({
     add: vi.fn(),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+  })),
 }));
 
 vi.mock("../../../src/utils/logger.js", () => ({

--- a/tests/pipeline/execution/retry-budget.test.ts
+++ b/tests/pipeline/execution/retry-budget.test.ts
@@ -37,6 +37,10 @@ vi.mock("../../../src/learning/pattern-store.js", () => ({
     getRecentFailures: vi.fn().mockReturnValue([]),
     formatForPrompt: vi.fn().mockReturnValue(""),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    getRecentFailures: vi.fn().mockReturnValue([]),
+    formatForPrompt: vi.fn().mockReturnValue(""),
+  })),
 }));
 vi.mock("../../../src/prompt/template-renderer.js", () => ({
   buildBaseLayer: vi.fn().mockReturnValue({

--- a/tests/pipeline/pipeline-error-handler.test.ts
+++ b/tests/pipeline/pipeline-error-handler.test.ts
@@ -20,6 +20,9 @@ vi.mock("../../src/learning/pattern-store.js", () => ({
   PatternStore: vi.fn().mockImplementation(() => ({
     add: vi.fn(),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+  })),
 }));
 
 vi.mock("../../src/utils/logger.js", () => ({

--- a/tests/pipeline/pipeline-publish.test.ts
+++ b/tests/pipeline/pipeline-publish.test.ts
@@ -46,6 +46,9 @@ vi.mock("../../src/learning/pattern-store.js", () => ({
   PatternStore: vi.fn().mockImplementation(() => ({
     add: vi.fn(),
   })),
+  getPatternStore: vi.fn().mockImplementation(() => ({
+    add: vi.fn(),
+  })),
 }));
 vi.mock("../../src/pipeline/reporting/progress-tracker.js", () => ({
   PROGRESS_PR_CREATED: 90,
@@ -69,7 +72,7 @@ import { rollbackToCheckpoint } from "../../src/safety/rollback-manager.js";
 import { runCli } from "../../src/utils/cli-runner.js";
 import { formatResult, printResult } from "../../src/pipeline/reporting/result-reporter.js";
 import { removeCheckpoint } from "../../src/pipeline/errors/checkpoint.js";
-import { PatternStore } from "../../src/learning/pattern-store.js";
+import { PatternStore, getPatternStore } from "../../src/learning/pattern-store.js";
 import type { PublishPhaseContext, CleanupContext, FailureHandlerContext } from "../../src/types/pipeline.js";
 import { DEFAULT_CONFIG } from "../../src/config/defaults.js";
 
@@ -90,6 +93,7 @@ const mockFormatResult = vi.mocked(formatResult);
 const mockPrintResult = vi.mocked(printResult);
 const mockRemoveCheckpoint = vi.mocked(removeCheckpoint);
 const mockPatternStore = vi.mocked(PatternStore);
+const mockGetPatternStore = vi.mocked(getPatternStore);
 
 function makePublishContext(): PublishPhaseContext {
   return {
@@ -543,11 +547,11 @@ describe("cleanupOnSuccess", () => {
   it("should record success pattern", async () => {
     const context = makeCleanupContext();
     const mockAddFn = vi.fn();
-    mockPatternStore.mockImplementation(() => ({ add: mockAddFn }) as any);
+    mockGetPatternStore.mockReturnValue({ add: mockAddFn } as unknown as PatternStore);
 
     await cleanupOnSuccess(context);
 
-    expect(mockPatternStore).toHaveBeenCalledWith("/tmp/data");
+    expect(mockGetPatternStore).toHaveBeenCalledWith("/tmp/data");
     expect(mockAddFn).toHaveBeenCalledWith({
       issueNumber: 42,
       repo: "test/repo",

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -103,6 +103,7 @@ vi.mock("../../src/prompt/template-renderer.js", () => ({
 
 vi.mock("../../src/learning/pattern-store.js", () => ({
   PatternStore: vi.fn(),
+  getPatternStore: vi.fn(),
 }));
 
 // ── helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Plan C #C3 — PatternStore DI-only 스코프. 5곳 산재된 `new PatternStore(dataDir)`를 `getPatternStore(dataDir)` 팩토리로 일원화.

## Changes

- `src/learning/pattern-store.ts`
  - `getPatternStore(dataDir)` 팩토리 추가 — 모듈 레벨 Map 캐시로 dataDir당 단일 인스턴스
  - `__resetPatternStoreCacheForTests()` 테스트 헬퍼
- 5개 호출부 교체: `cli.ts` (start/stats), `pipeline-phases.ts`, `pipeline-publish.ts`, `core-loop.ts`
- 8개 `vi.mock` 블록에 `getPatternStore` 추가, statsCommand·pipeline-publish 테스트 4건 업데이트

## 플랜 원안 대비 축소

**Mutex/async 전환 제외.** 플랜은 "병렬 파이프라인 데이터 손실"을 근거로 Mutex 추가를 요구했지만:

- PatternStore의 모든 메서드가 sync (read + modify + write 모두 node sync API)
- 이벤트 루프 yield 지점 0 → 단일 프로세스 내 race 불가
- Mutex를 추가해도 실제 차단할 race가 없음

향후 async/파일 핸들 공유/external store 도입 시 재평가. 현재는 DI/singleton만으로 가치 충분.

## Test plan

- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3342 pass / 7 skipped (13 files touched)
- [ ] 실 파이프라인 dogfooding (별도 세션)

## Breaking

없음. 외부 API 무변경. 기존 `new PatternStore(dataDir)` 테스트 호환 유지.