### PR TITLE
refactor(pipeline): runPhaseWithTracking + CoreLoopPhaseContext (Plan C #C8)

### DIFF
--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -69,20 +69,19 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     checkpointFn({ plan: undefined, phaseResults: [...accumulatedPhaseResults] });
 
     // Phase 3: Core Loop Execution (Plan generation + Phase execution)
-    const coreResult = await executeCoreLoopPhase(
+    const coreResult = await executeCoreLoopPhase({
       input,
       runtime,
       issue,
-      setupResult.project,
+      project: setupResult.project,
       config,
-      setupResult.promptsDir,
-      setupResult.dataDir,
+      promptsDir: setupResult.promptsDir,
+      dataDir: setupResult.dataDir,
       envResult,
-      setupResult.timer,
+      timer: setupResult.timer,
       mode,
-      hookRegistry,
-      hookExecutor
-    );
+      hooks: { registry: hookRegistry, executor: hookExecutor },
+    });
 
     checkpointFn({ plan: coreResult.coreResult.plan, phaseResults: [...accumulatedPhaseResults, ...coreResult.coreResult.phaseResults] });
 

--- a/src/pipeline/phases/phase-tracker.ts
+++ b/src/pipeline/phases/phase-tracker.ts
@@ -1,0 +1,100 @@
+import type { Clock } from "../../utils/clock.js";
+import { systemClock } from "../../utils/clock.js";
+import type { PhaseResult } from "../../types/pipeline.js";
+import type { OrchestratorInput, PipelineRuntime } from "../core/pipeline-context.js";
+import type { GitHubIssue } from "../../github/issue-fetcher.js";
+import type { ResolvedProject } from "../../config/project-resolver.js";
+import type { AQConfig, PipelineMode } from "../../types/config.js";
+import type { PipelineTimer } from "../../safety/timeout-manager.js";
+import type { HookRegistry } from "../../hooks/hook-registry.js";
+import type { HookExecutor } from "../../hooks/hook-executor.js";
+import type { EnvironmentSetupResult } from "./pipeline-phases.js";
+import {
+  makePseudoPhaseSuccess,
+  makePseudoPhaseFailure,
+  type PseudoPhaseName,
+} from "../reporting/phase-result-helper.js";
+
+/**
+ * core-loop phase 실행 시 필요한 의존성을 묶은 context 객체.
+ * 파라미터 폭주(`executeCoreLoopPhase` 12개)를 단일 객체로 정리한다.
+ */
+export interface CoreLoopPhaseContext {
+  input: OrchestratorInput;
+  runtime: PipelineRuntime;
+  issue: GitHubIssue;
+  project: ResolvedProject;
+  config: AQConfig;
+  promptsDir: string;
+  dataDir: string;
+  envResult: EnvironmentSetupResult;
+  timer: PipelineTimer;
+  mode: PipelineMode;
+  hooks?: { registry: HookRegistry; executor: HookExecutor };
+  clock?: Clock;
+}
+
+export interface PhaseTrackingResult<T> {
+  result: T;
+  durationMs: number;
+  startedAt: string;
+  completedAt: string;
+}
+
+interface TrackablePhaseResult {
+  success: boolean;
+  error?: string;
+  costUsd?: number;
+}
+
+/**
+ * pseudo-phase의 측정·기록 패턴을 단일화한다.
+ *
+ * `runner`를 실행하면서 시작/종료 시각·소요시간을 측정하고, `accumulated`가 주어지면
+ * 결과의 `success` 값에 따라 PhaseResult를 누적 배열에 push한다. runner 내부 예외는
+ * 호출부가 처리하도록 그대로 throw한다 (성공/실패 분기는 결과 객체의 `success`를 통해 표현).
+ *
+ * @param phaseName pseudo-phase 식별자 (`makePseudoPhase*` 키와 동일)
+ * @param runner 측정 대상 비동기 작업
+ * @param accumulated 누적 PhaseResult 배열 (선택)
+ * @param clock 시간 주입 (테스트용, 생략 시 systemClock)
+ */
+export async function runPhaseWithTracking<T extends TrackablePhaseResult>(
+  phaseName: PseudoPhaseName,
+  runner: () => Promise<T>,
+  accumulated?: PhaseResult[],
+  clock: Clock = systemClock
+): Promise<PhaseTrackingResult<T>> {
+  const startedAt = clock.nowIso();
+  const startMs = clock.nowMs();
+  const result = await runner();
+  const durationMs = clock.nowMs() - startMs;
+  const completedAt = clock.nowIso();
+
+  if (accumulated) {
+    if (result.success) {
+      accumulated.push(
+        makePseudoPhaseSuccess(phaseName, durationMs, {
+          startedAt,
+          completedAt,
+          costUsd: result.costUsd,
+        })
+      );
+    } else {
+      accumulated.push(
+        makePseudoPhaseFailure(
+          phaseName,
+          durationMs,
+          result.error ?? `${phaseName} failed`,
+          {
+            startedAt,
+            completedAt,
+            costUsd: result.costUsd,
+          }
+        )
+      );
+    }
+  }
+
+  return { result, durationMs, startedAt, completedAt };
+}

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -24,6 +24,7 @@ import {
   PROGRESS_DONE
 } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
+import type { CoreLoopPhaseContext } from "./phase-tracker.js";
 import type { AQConfig, PipelineMode, ExecutionMode, GitConfig } from "../../types/config.js";
 import type { SenderPermission } from "../../github/issue-fetcher.js";
 import type { PipelineState, PhaseResult } from "../../types/pipeline.js";
@@ -289,19 +290,11 @@ export async function executeEnvironmentSetup(
  * Execute core loop phase: Plan generation and phase execution
  */
 export async function executeCoreLoopPhase(
-  input: OrchestratorInput,
-  runtime: PipelineRuntime,
-  issue: GitHubIssue,
-  project: ResolvedProject,
-  config: AQConfig,
-  promptsDir: string,
-  dataDir: string,
-  envResult: EnvironmentSetupResult,
-  timer: PipelineTimer,
-  mode: PipelineMode,
-  hookRegistry?: HookRegistry,
-  hookExecutor?: HookExecutor
+  ctx: CoreLoopPhaseContext
 ): Promise<CoreLoopExecutionResult> {
+  const { input, runtime, issue, project, config, promptsDir, dataDir, envResult, timer, mode, hooks } = ctx;
+  const hookRegistry = hooks?.registry;
+  const hookExecutor = hooks?.executor;
   const { repo } = input;
   const jl = input.jobLogger;
 

--- a/tests/pipeline/phases/phase-tracker.test.ts
+++ b/tests/pipeline/phases/phase-tracker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { runPhaseWithTracking } from "../../../src/pipeline/phases/phase-tracker.js";
+import { createFixedClock } from "../../../src/utils/clock.js";
+import type { PhaseResult } from "../../../src/types/pipeline.js";
+
+describe("runPhaseWithTracking", () => {
+  it("runner 성공 시 PhaseTrackingResult를 반환한다", async () => {
+    const clock = createFixedClock("2026-04-26T00:00:00.000Z");
+    const tracking = await runPhaseWithTracking(
+      "review:code",
+      async () => ({ success: true, costUsd: 0.5 }),
+      undefined,
+      clock
+    );
+
+    expect(tracking.result.success).toBe(true);
+    expect(tracking.startedAt).toBe("2026-04-26T00:00:00.000Z");
+    expect(tracking.completedAt).toBe("2026-04-26T00:00:00.000Z");
+    expect(tracking.durationMs).toBe(0);
+  });
+
+  it("성공한 runner의 PhaseResult를 누적 배열에 push한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "review:code",
+      async () => ({ success: true, costUsd: 1.23 }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated).toHaveLength(1);
+    expect(accumulated[0]).toMatchObject({
+      phaseName: "review:code",
+      success: true,
+      costUsd: 1.23,
+      startedAt: "2026-04-26T00:00:00.000Z",
+      completedAt: "2026-04-26T00:00:00.000Z",
+    });
+  });
+
+  it("실패한 runner의 PhaseResult를 failure로 push한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "validation:check",
+      async () => ({ success: false, error: "boom", costUsd: 0.1 }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated).toHaveLength(1);
+    expect(accumulated[0]).toMatchObject({
+      phaseName: "validation:check",
+      success: false,
+      error: "boom",
+      costUsd: 0.1,
+    });
+  });
+
+  it("error 미제공 시 기본 메시지를 사용한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "publish:pr",
+      async () => ({ success: false }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated[0].error).toBe("publish:pr failed");
+  });
+
+  it("accumulated 미주입 시 push하지 않는다", async () => {
+    const tracking = await runPhaseWithTracking(
+      "review:simplify",
+      async () => ({ success: true }),
+      undefined,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+    expect(tracking.result.success).toBe(true);
+  });
+
+  it("runner 예외는 그대로 throw된다 (push 없음)", async () => {
+    const accumulated: PhaseResult[] = [];
+    await expect(
+      runPhaseWithTracking(
+        "review:code",
+        async () => {
+          throw new Error("runner crashed");
+        },
+        accumulated
+      )
+    ).rejects.toThrow("runner crashed");
+    expect(accumulated).toHaveLength(0);
+  });
+
+  it("durationMs는 nowMs 진행에 따라 측정된다", async () => {
+    let ms = 1000;
+    const advancingClock = {
+      nowIso: () => new Date(ms).toISOString(),
+      nowMs: () => {
+        const cur = ms;
+        ms += 250;
+        return cur;
+      },
+    };
+    const tracking = await runPhaseWithTracking(
+      "setup:worktree",
+      async () => ({ success: true }),
+      undefined,
+      advancingClock
+    );
+    // startMs=1000 → completedMs=1250 → duration 250
+    expect(tracking.durationMs).toBe(250);
+  });
+});


### PR DESCRIPTION
## Summary

Plan C #C8 — pseudo-phase 측정·기록의 30줄 반복 패턴을 `runPhaseWithTracking` 헬퍼로 추출하고, `executeCoreLoopPhase` 12개 파라미터를 `CoreLoopPhaseContext`로 묶는다. 헬퍼 적용(post-processing 4 phase 치환)은 #C11에서 후속 진행.

## Changes

- `src/pipeline/phases/phase-tracker.ts` (신규)
  - `runPhaseWithTracking<T>(phaseName, runner, accumulated?, clock?)` 제너릭 헬퍼 — startedAt/durationMs/completedAt 측정 + accumulated 배열에 PhaseResult push
  - `CoreLoopPhaseContext` 인터페이스 — input/runtime/issue/project/config/promptsDir/dataDir/envResult/timer/mode/hooks/clock
- `src/pipeline/phases/pipeline-phases.ts`
  - `executeCoreLoopPhase` 시그니처: 파라미터 12개 → `ctx: CoreLoopPhaseContext`
  - 함수 본문 destructuring으로 변경, 동작 동일
- `src/pipeline/core/orchestrator.ts`
  - 호출부를 객체 리터럴 전달로 갱신 (`hooks: { registry, executor }`)
- `tests/pipeline/phases/phase-tracker.test.ts` (신규, 7 tests)
  - 성공/실패 push, 기본 에러 메시지, accumulated 미주입, 예외 전파, durationMs 측정, Clock 주입

## Test plan

- [x] `npx tsc --noEmit` — 0 error
- [x] `npm run lint` — 0 error
- [x] `npm test` — 154 files / 3349 pass / 7 skipped
- [x] 단위 테스트 7건 추가 통과

## Breaking

내부만. `executeCoreLoopPhase` 시그니처 변경 — 호출부는 `orchestrator.ts` 1곳이며 동시 갱신. 외부 CLI/HTTP API 무변경.

## depends

- #C1 Clock (✅ fddc281)