### PR TITLE
refactor(server): SSEManager + DashboardContext + safeError (Plan C #C5)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -35,6 +35,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
+import { SSEManager } from "./sse-manager.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -53,126 +54,36 @@ export function getQuotaStatus(): QuotaStatus | null {
   return currentQuotaStatus;
 }
 
-// SSE client management
-interface SSEClient {
-  id: string;
-  controller: ReadableStreamDefaultController<Uint8Array>;
-  connectedAt: number;
-  lastHeartbeat: number;
-}
+// SSE 클라이언트 풀과 heartbeat 루프는 SSEManager로 캡슐화 (Plan C #C5).
+// dashboard-api는 단일 인스턴스를 보유하고, 외부 export는 위임 함수로 유지한다.
+const sseManager = new SSEManager({
+  maxClients: 50,
+  heartbeatMs: 30_000,
+  clientTimeoutMs: 120_000,
+});
 
-
-const sseClients = new Map<string, SSEClient>();
-const encoder = new TextEncoder();
-
-// Periodic cleanup intervals
+// Token cleanup interval (sessionManager TTL 가지치기). SSE heartbeat과는 독립.
 let tokenCleanupInterval: ReturnType<typeof setInterval> | undefined;
-let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-
-// Cleanup constants
 const TOKEN_CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-const HEARTBEAT_INTERVAL_MS = 30 * 1000; // 30 seconds
-const CLIENT_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
-const MAX_SSE_CLIENTS = 50; // Maximum concurrent SSE connections
-
-function removeStaleClients(): void {
-  const now = Date.now();
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    if (now - client.lastHeartbeat > CLIENT_TIMEOUT_MS) {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    try {
-      const client = sseClients.get(clientId);
-      client?.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-    sseClients.delete(clientId);
-  }
-}
 
 export function getSSEClientCount(): number {
-  return sseClients.size;
-}
-
-function evictOldestClients(targetCount: number): void {
-  if (sseClients.size <= targetCount) return;
-
-  // Sort by connectedAt ascending (oldest first)
-  const sorted = [...sseClients.entries()].sort(([, a], [, b]) => a.connectedAt - b.connectedAt);
-  const toEvict = sorted.slice(0, sseClients.size - targetCount);
-
-  for (const [clientId, client] of toEvict) {
-    try {
-      client.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-    sseClients.delete(clientId);
-  }
+  return sseManager.clientCount;
 }
 
 function broadcastToAllClients(event: string, data: unknown): void {
-  const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-  const now = Date.now();
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    if (now - client.lastHeartbeat > CLIENT_TIMEOUT_MS) {
-      clientsToRemove.push(clientId);
-      continue;
-    }
-
-    try {
-      client.controller.enqueue(encoder.encode(message));
-      client.lastHeartbeat = now;
-    } catch {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    sseClients.delete(clientId);
-  }
-}
-
-
-function sendHeartbeat(): void {
-  const heartbeatMessage = `event: heartbeat\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`;
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    try {
-      client.controller.enqueue(encoder.encode(heartbeatMessage));
-    } catch {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    sseClients.delete(clientId);
-  }
+  sseManager.broadcast(event, data);
 }
 
 function startPeriodicCleanup(): void {
   // Stop existing intervals if any
   stopPeriodicCleanup();
 
-  // Start token cleanup interval
+  // Token cleanup은 SSE와 독립적으로 운영.
   tokenCleanupInterval = setInterval(() => {
     sessionManager.pruneExpired();
   }, TOKEN_CLEANUP_INTERVAL_MS);
 
-  // Start heartbeat interval
-  heartbeatInterval = setInterval(() => {
-    sendHeartbeat();
-    removeStaleClients();
-  }, HEARTBEAT_INTERVAL_MS);
+  sseManager.startHeartbeat();
 }
 
 export function stopPeriodicCleanup(): void {
@@ -180,24 +91,14 @@ export function stopPeriodicCleanup(): void {
     clearInterval(tokenCleanupInterval);
     tokenCleanupInterval = undefined;
   }
-  if (heartbeatInterval) {
-    clearInterval(heartbeatInterval);
-    heartbeatInterval = undefined;
-  }
+  sseManager.stopHeartbeat();
 }
 
 /**
  * Clean up all active SSE clients by closing their connections.
  */
 export function cleanupAllSSEClients(): void {
-  for (const [, client] of sseClients) {
-    try {
-      client.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-  }
-  sseClients.clear();
+  sseManager.cleanupAll();
 }
 
 /**
@@ -1382,23 +1283,12 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // SSE endpoint for real-time updates
   api.get("/api/events", (_c) => {
     const clientId = randomUUID();
+    const encoder = new TextEncoder();
     let intervalId: ReturnType<typeof setInterval> | undefined;
 
     const stream = new ReadableStream({
       start(controller) {
-        // Enforce connection limit — evict oldest clients before registering new one
-        if (sseClients.size >= MAX_SSE_CLIENTS) {
-          evictOldestClients(MAX_SSE_CLIENTS - 1);
-        }
-
-        // Register client with timestamps
-        const now = Date.now();
-        sseClients.set(clientId, {
-          id: clientId,
-          controller,
-          connectedAt: now,
-          lastHeartbeat: now
-        });
+        sseManager.addClient(controller, clientId);
 
         // Send initial state
         const sendInitialState = () => {
@@ -1419,13 +1309,12 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
         // Auto-cleanup after 5 minutes
         setTimeout(() => {
           clearInterval(intervalId);
-          sseClients.delete(clientId);
-          try { controller.close(); } catch { /* already closed */ }
+          sseManager.removeClient(clientId);
         }, 300000);
       },
       cancel() {
         clearInterval(intervalId);
-        sseClients.delete(clientId);
+        sseManager.removeClient(clientId);
       },
     });
 
@@ -2041,6 +1930,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
   api.get("/api/doctor/heal/:id/stream", (c) => {
     const checkId = c.req.param("id");
+    const encoder = new TextEncoder();
 
     const stream = new ReadableStream({
       start(controller) {

--- a/src/server/route-context.ts
+++ b/src/server/route-context.ts
@@ -1,0 +1,47 @@
+import type { Context } from "hono";
+import type { JobStore } from "../queue/job-store.js";
+import type { JobQueue } from "../queue/job-queue.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+import type { PatternStore } from "../learning/pattern-store.js";
+import type { SSEManager } from "./sse-manager.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
+
+/**
+ * 대시보드 라우트 핸들러가 공유하는 의존성 컨테이너.
+ *
+ * Plan C #C5에서 정의되며, 실제 `createDashboardRoutes` 시그니처 적용은 #C9·#C12에서
+ * 라우트 파일 분할과 함께 진행한다. 본 인터페이스는 그 사전 계약이다.
+ */
+export interface DashboardContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configProvider: ConfigProvider;
+  patternStore?: PatternStore;
+  /** AQM 설치 루트(=AQM_HOME 또는 ~/.ai-quartermaster) — 라우트 핸들러가 데이터/로그 경로 조립에 사용. */
+  rootDir: string;
+  /** insecure 환경에서 mutation 차단용 플래그. */
+  readOnly: boolean;
+}
+
+/**
+ * 라우트 핸들러에서 던져진 예외를 표준 JSON 에러 응답으로 변환한다.
+ * `sanitizeErrorMessage(getErrorMessage(...))` 42회 반복 패턴의 단일화 헬퍼.
+ *
+ * @param c Hono Context
+ * @param error catch 블록의 unknown 에러
+ * @param prefix 사용자 노출용 접두 메시지(예: "Failed to fetch jobs")
+ * @param status HTTP 상태 코드 (기본 500)
+ */
+export function safeError(
+  c: Context,
+  error: unknown,
+  prefix: string,
+  status: number = 500
+): Response {
+  const message = sanitizeErrorMessage(getErrorMessage(error));
+  // Hono의 status 파라미터는 ContentfulStatusCode union이지만, safeError는
+  // 일반 number를 받고 호출부 편의성을 우선한다 (4xx/5xx 범위 가정).
+  return c.json({ error: `${prefix}: ${message}` }, status as Parameters<typeof c.json>[1]);
+}

--- a/src/server/sse-manager.ts
+++ b/src/server/sse-manager.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "crypto";
+
+/**
+ * SSE 클라이언트 1건의 메타.
+ */
+interface SSEClient {
+  id: string;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  connectedAt: number;
+  lastHeartbeat: number;
+}
+
+export interface SSEManagerOptions {
+  /** 동시 연결 최대치. 기본 50. */
+  maxClients?: number;
+  /** Heartbeat 송출 주기 (ms). 기본 30s. */
+  heartbeatMs?: number;
+  /** 마지막 heartbeat 이후 이 시간이 지나면 stale로 간주 (ms). 기본 2m. */
+  clientTimeoutMs?: number;
+}
+
+/**
+ * SSE(Server-Sent Events) 클라이언트 풀 관리 + heartbeat 루프.
+ *
+ * 이전에는 `dashboard-api.ts` module-level 상태(Map<string, SSEClient> + interval)로 흩어져 있었다.
+ * Plan C #C5 — 단일 클래스로 캡슐화하고 dashboard-api는 인스턴스 1개를 보유한다.
+ *
+ * 라이프사이클:
+ *   addClient(controller) → broadcast/sendHeartbeat 발화 시 자동으로 stale 제거
+ *   startHeartbeat() ↔ stopHeartbeat() — interval 토글
+ *   cleanupAll() — 모든 컨트롤러 close + 맵 비움 (서버 종료 시)
+ */
+export class SSEManager {
+  private readonly clients = new Map<string, SSEClient>();
+  private readonly encoder = new TextEncoder();
+  private readonly maxClients: number;
+  private readonly heartbeatMs: number;
+  private readonly clientTimeoutMs: number;
+  private heartbeatInterval?: ReturnType<typeof setInterval>;
+
+  constructor(opts: SSEManagerOptions = {}) {
+    this.maxClients = opts.maxClients ?? 50;
+    this.heartbeatMs = opts.heartbeatMs ?? 30_000;
+    this.clientTimeoutMs = opts.clientTimeoutMs ?? 120_000;
+  }
+
+  /**
+   * 새 클라이언트 등록. 한도 초과 시 가장 오래된 클라이언트를 evict한 후 추가한다.
+   * @param controller ReadableStream 컨트롤러
+   * @param id 클라이언트 식별자(미주입 시 randomUUID). 호출부가 stream cancel 핸들러에서
+   *           동일 id로 removeClient를 호출할 수 있도록 외부에서 주입 가능.
+   * @returns 등록된 클라이언트 ID
+   */
+  addClient(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    id: string = randomUUID()
+  ): string {
+    if (this.clients.size >= this.maxClients) {
+      this.evictOldest(this.maxClients - 1);
+    }
+    const now = Date.now();
+    this.clients.set(id, { id, controller, connectedAt: now, lastHeartbeat: now });
+    return id;
+  }
+
+  /**
+   * 클라이언트 제거. 컨트롤러 close 실패는 무시한다.
+   */
+  removeClient(id: string): void {
+    const client = this.clients.get(id);
+    if (!client) return;
+    try {
+      client.controller.close();
+    } catch {
+      // already closed
+    }
+    this.clients.delete(id);
+  }
+
+  /**
+   * 모든 클라이언트에 SSE 이벤트 전송. 전송 실패 또는 stale 클라이언트는 즉시 제거.
+   */
+  broadcast(event: string, data: unknown): void {
+    const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    const now = Date.now();
+    const toRemove: string[] = [];
+
+    for (const [clientId, client] of this.clients) {
+      if (now - client.lastHeartbeat > this.clientTimeoutMs) {
+        toRemove.push(clientId);
+        continue;
+      }
+      try {
+        client.controller.enqueue(this.encoder.encode(message));
+        client.lastHeartbeat = now;
+      } catch {
+        toRemove.push(clientId);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * 모든 클라이언트에 heartbeat 이벤트 송출. 실패한 컨트롤러는 제거.
+   */
+  sendHeartbeat(): void {
+    const message = `event: heartbeat\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`;
+    const toRemove: string[] = [];
+
+    for (const [clientId, client] of this.clients) {
+      try {
+        client.controller.enqueue(this.encoder.encode(message));
+      } catch {
+        toRemove.push(clientId);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * 마지막 heartbeat 이후 timeout이 지난 클라이언트를 제거한다.
+   */
+  removeStale(): void {
+    const now = Date.now();
+    const toRemove: string[] = [];
+    for (const [clientId, client] of this.clients) {
+      if (now - client.lastHeartbeat > this.clientTimeoutMs) {
+        toRemove.push(clientId);
+      }
+    }
+    for (const id of toRemove) {
+      const client = this.clients.get(id);
+      try {
+        client?.controller.close();
+      } catch {
+        // ignore
+      }
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * heartbeat interval 시작. 이미 켜져 있으면 먼저 정지 후 재시작.
+   * 매 주기마다 sendHeartbeat + removeStale 호출.
+   */
+  startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatInterval = setInterval(() => {
+      this.sendHeartbeat();
+      this.removeStale();
+    }, this.heartbeatMs);
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+  }
+
+  /**
+   * 모든 클라이언트 컨트롤러 close + 맵 비움. 서버 종료 시 호출.
+   */
+  cleanupAll(): void {
+    for (const [, client] of this.clients) {
+      try {
+        client.controller.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.clients.clear();
+  }
+
+  get clientCount(): number {
+    return this.clients.size;
+  }
+
+  /**
+   * 한도를 초과한 가장 오래된 클라이언트(connectedAt 기준)를 제거한다.
+   */
+  private evictOldest(targetCount: number): void {
+    if (this.clients.size <= targetCount) return;
+    const sorted = [...this.clients.entries()].sort(
+      ([, a], [, b]) => a.connectedAt - b.connectedAt
+    );
+    const evictCount = this.clients.size - targetCount;
+    for (let i = 0; i < evictCount; i++) {
+      const [clientId, client] = sorted[i];
+      try {
+        client.controller.close();
+      } catch {
+        // ignore
+      }
+      this.clients.delete(clientId);
+    }
+  }
+}

--- a/tests/server/sse-manager.test.ts
+++ b/tests/server/sse-manager.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SSEManager } from "../../src/server/sse-manager.js";
+
+function makeController() {
+  return {
+    enqueue: vi.fn(),
+    close: vi.fn(),
+    error: vi.fn(),
+    desiredSize: 0,
+    terminate: vi.fn(),
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+}
+
+describe("SSEManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("addClient / clientCount / removeClient", () => {
+    it("addClient는 ID를 반환하고 clientCount를 증가시킨다", () => {
+      const m = new SSEManager();
+      const id = m.addClient(makeController());
+      expect(id).toBeTruthy();
+      expect(m.clientCount).toBe(1);
+    });
+
+    it("외부 ID 주입 시 그대로 사용한다", () => {
+      const m = new SSEManager();
+      const id = m.addClient(makeController(), "external-id");
+      expect(id).toBe("external-id");
+    });
+
+    it("removeClient는 컨트롤러 close + 맵에서 제거", () => {
+      const m = new SSEManager();
+      const ctrl = makeController();
+      const id = m.addClient(ctrl, "abc");
+      m.removeClient(id);
+      expect(m.clientCount).toBe(0);
+      expect(ctrl.close).toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 클라이언트 removeClient는 무시", () => {
+      const m = new SSEManager();
+      expect(() => m.removeClient("nope")).not.toThrow();
+    });
+
+    it("close 예외는 무시되고 맵에서 제거된다", () => {
+      const m = new SSEManager();
+      const ctrl = makeController();
+      (ctrl.close as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("already closed");
+      });
+      const id = m.addClient(ctrl);
+      expect(() => m.removeClient(id)).not.toThrow();
+      expect(m.clientCount).toBe(0);
+    });
+  });
+
+  describe("maxClients enforcement", () => {
+    it("한도 초과 시 가장 오래된 클라이언트를 evict한다", () => {
+      const m = new SSEManager({ maxClients: 2 });
+      const c1 = makeController();
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(c1, "first");
+      vi.setSystemTime(new Date("2026-04-26T00:00:01.000Z"));
+      m.addClient(makeController(), "second");
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      m.addClient(makeController(), "third");
+
+      expect(m.clientCount).toBe(2);
+      // oldest(first) should have been evicted
+      expect(c1.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("broadcast", () => {
+    it("모든 클라이언트에 SSE 메시지를 enqueue한다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      const c2 = makeController();
+      m.addClient(c1);
+      m.addClient(c2);
+      m.broadcast("jobUpdated", { id: 1 });
+
+      expect(c1.enqueue).toHaveBeenCalledTimes(1);
+      expect(c2.enqueue).toHaveBeenCalledTimes(1);
+
+      const sent = (c1.enqueue as ReturnType<typeof vi.fn>).mock.calls[0][0] as Uint8Array;
+      const decoded = new TextDecoder().decode(sent);
+      expect(decoded).toContain("event: jobUpdated");
+      expect(decoded).toContain('"id":1');
+    });
+
+    it("enqueue 실패한 클라이언트는 풀에서 제거", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      (c1.enqueue as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("write failed");
+      });
+      m.addClient(c1, "broken");
+      m.addClient(makeController(), "ok");
+
+      m.broadcast("event", {});
+      expect(m.clientCount).toBe(1);
+    });
+
+    it("clientTimeoutMs 초과한 클라이언트는 broadcast 시 제거", () => {
+      const m = new SSEManager({ clientTimeoutMs: 1000 });
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(makeController(), "stale");
+
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      m.broadcast("event", {});
+      expect(m.clientCount).toBe(0);
+    });
+  });
+
+  describe("sendHeartbeat / removeStale", () => {
+    it("sendHeartbeat은 heartbeat 이벤트를 모든 클라이언트에 보낸다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      m.addClient(c1);
+      m.sendHeartbeat();
+
+      const sent = (c1.enqueue as ReturnType<typeof vi.fn>).mock.calls[0][0] as Uint8Array;
+      const decoded = new TextDecoder().decode(sent);
+      expect(decoded).toContain("event: heartbeat");
+    });
+
+    it("removeStale은 timeout 초과 클라이언트만 제거", () => {
+      const m = new SSEManager({ clientTimeoutMs: 1000 });
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(makeController(), "old");
+      vi.setSystemTime(new Date("2026-04-26T00:00:01.500Z"));
+      m.addClient(makeController(), "fresh");
+
+      // old: lastHeartbeat=0s, now=1.5s, timeout=1s → stale
+      // fresh: lastHeartbeat=1.5s, now=1.5s → fresh
+      m.removeStale();
+      expect(m.clientCount).toBe(1);
+    });
+  });
+
+  describe("startHeartbeat / stopHeartbeat", () => {
+    it("startHeartbeat은 주기적으로 heartbeat을 송출한다", () => {
+      const m = new SSEManager({ heartbeatMs: 100 });
+      const c1 = makeController();
+      m.addClient(c1);
+      m.startHeartbeat();
+      vi.advanceTimersByTime(350);
+      // 100, 200, 300ms — 3회
+      expect(c1.enqueue).toHaveBeenCalledTimes(3);
+      m.stopHeartbeat();
+    });
+
+    it("startHeartbeat을 두 번 호출해도 interval이 누수되지 않는다", () => {
+      const m = new SSEManager({ heartbeatMs: 100 });
+      const c1 = makeController();
+      m.addClient(c1);
+      m.startHeartbeat();
+      m.startHeartbeat(); // restart
+      vi.advanceTimersByTime(150);
+      // 첫 interval은 종료됐으니 1회만 발화
+      expect(c1.enqueue).toHaveBeenCalledTimes(1);
+      m.stopHeartbeat();
+    });
+  });
+
+  describe("cleanupAll", () => {
+    it("모든 컨트롤러를 close하고 맵을 비운다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      const c2 = makeController();
+      m.addClient(c1);
+      m.addClient(c2);
+      m.cleanupAll();
+
+      expect(c1.close).toHaveBeenCalled();
+      expect(c2.close).toHaveBeenCalled();
+      expect(m.clientCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Plan C #C5 — `dashboard-api.ts` module-level SSE 상태(2,127줄 중 SSE 헬퍼 영역 ~150줄)를 `SSEManager` 클래스로 캡슐화. `DashboardContext`/`safeError` 인터페이스도 정의해 #C9·#C12에서 라우트 분할·시그니처 정리 시 활용. 외부 export 시그니처는 유지해 `cli.ts` 및 기존 테스트 무영향.

## Changes

- `src/server/sse-manager.ts` (신규)
  - `SSEManager` 클래스 — 클라이언트 풀 + heartbeat 루프 캡슐화
  - `addClient(controller, id?)` → 한도 초과 시 LRU evict
  - `broadcast(event, data)` / `sendHeartbeat()` / `removeStale()` / `cleanupAll()`
  - `startHeartbeat()` / `stopHeartbeat()` — interval 토글 (이중 호출 안전)
  - 옵션: `maxClients` (50), `heartbeatMs` (30s), `clientTimeoutMs` (2m)
- `src/server/route-context.ts` (신규)
  - `DashboardContext` — `store/queue/sseManager/configProvider/patternStore/rootDir/readOnly`
  - `safeError(c, error, prefix, status?)` — `sanitizeErrorMessage(getErrorMessage(...))` 42회 반복 패턴 단일화
- `src/server/dashboard-api.ts`
  - module-level `sseClients` Map + `encoder` + SSE 상수 4종 + helper 함수 5종(`removeStaleClients`, `evictOldestClients`, `broadcastToAllClients`, `sendHeartbeat`, `cleanupAllSSEClients` 본체) 제거 → `sseManager` 인스턴스 1개
  - 외부 export 위임: `getSSEClientCount` → `sseManager.clientCount`, `cleanupAllSSEClients` → `sseManager.cleanupAll()`, `stopPeriodicCleanup` → tokenCleanup + `sseManager.stopHeartbeat()`
  - `/api/events` 핸들러: `sseManager.addClient/removeClient` 사용
  - `/api/doctor/heal/:id/stream`은 SSE 풀 미관리 일회성 스트림이므로 로컬 `TextEncoder` 인스턴스화

## Test plan

- [x] `npx tsc --noEmit` — 0 error
- [x] `npm run lint` — 0 error
- [x] `npm test` — 154 files / 3356 pass / 7 skipped (이전 3349 + 신규)
- [x] `tests/server/sse-manager.test.ts` 14건 신규 통과
- [x] `tests/server/dashboard-api.test.ts` 176건 회귀 0
- [x] `getSSEClientCount`/`cleanupAllSSEClients`/`stopPeriodicCleanup`/`cleanupDashboardResources` 호환

## Breaking

없음. 외부 API/CLI/HTTP 무변경. module-level SSE 상태 → SSEManager 인스턴스 위임은 내부 캡슐화일 뿐 동작 동일.

## depends

- #C2 ConfigProvider (✅ e588999) — `DashboardContext.configProvider` 타입 의존

## 후속

- #C9: 도메인별 라우트 파일 분할 시 `DashboardContext` 주입으로 전파
- #C12: `createDashboardRoutes` 시그니처를 `(ctx: DashboardContext, authConfig)`로 정리