### PR TITLE
refactor(queue): JobCleanupService + ProjectErrorTracker (Plan C #C6)

### DIFF
--- a/src/queue/job-cleanup.ts
+++ b/src/queue/job-cleanup.ts
@@ -1,0 +1,97 @@
+import { resolve } from "path";
+import { loadCheckpoint, removeCheckpoint } from "../pipeline/errors/checkpoint.js";
+import { removeWorktree } from "../git/worktree-manager.js";
+import { deleteRemoteBranch } from "../git/branch-manager.js";
+import { loadConfig } from "../config/loader.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+
+const logger = getLogger();
+
+/**
+ * 실패한 잡의 worktree, 원격 브랜치, 체크포인트 정리를 담당한다.
+ *
+ * Plan C #C6 이전: `JobQueue.cleanupFailedJobArtifacts`가 fire-and-forget
+ * (`Promise.resolve(...).catch()`)으로 worktree/브랜치 제거를 던지고 즉시 반환했다.
+ * 후속 enqueue/retry가 정리 완료 전에 시작되면 worktree 충돌이 발생할 수 있었다.
+ *
+ * 본 서비스는 모든 정리 작업을 `await Promise.allSettled`로 묶어 후속 작업이 시작되기 전에
+ * 정리 완료를 보장한다. 각 단계 실패는 로그만 남기고 다른 단계는 계속 진행한다.
+ */
+export class JobCleanupService {
+  /**
+   * @param aqRoot AQM root (cwd) 디렉토리
+   * @param configProvider git config 조회용. 미주입 시 `loadConfig(aqRoot)` fallback.
+   */
+  constructor(
+    private readonly aqRoot: string,
+    private readonly configProvider?: ConfigProvider
+  ) {}
+
+  /**
+   * 실패한 잡의 worktree·원격 브랜치·체크포인트를 정리한다.
+   *
+   * 호출 측은 본 메서드 완료 후 동일 issue의 enqueue/retry를 안전하게 시작할 수 있다.
+   */
+  async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    const dataDir = resolve(this.aqRoot, "data");
+
+    let checkpoint = null;
+    try {
+      checkpoint = loadCheckpoint(dataDir, issueNumber);
+    } catch (err: unknown) {
+      logger.warn(
+        `Failed to load checkpoint for cleanup of issue #${issueNumber}: ${getErrorMessage(err)}`
+      );
+    }
+
+    const tasks: Promise<unknown>[] = [];
+    if (checkpoint) {
+      const config = this.configProvider?.current() ?? loadConfig(this.aqRoot);
+
+      if (checkpoint.worktreePath) {
+        const worktreePath = checkpoint.worktreePath;
+        logger.info(`Cleaning up worktree: ${worktreePath}`);
+        tasks.push(
+          Promise.resolve(
+            removeWorktree(config.git, worktreePath, { cwd: this.aqRoot, force: true })
+          ).catch((err: unknown) => {
+            logger.warn(
+              `Failed to remove worktree ${worktreePath}: ${getErrorMessage(err)}`
+            );
+          })
+        );
+      }
+
+      if (checkpoint.branchName) {
+        const branchName = checkpoint.branchName;
+        logger.info(`Deleting remote branch: ${branchName}`);
+        tasks.push(
+          Promise.resolve(
+            deleteRemoteBranch(config.git, branchName, { cwd: this.aqRoot })
+          ).catch((err: unknown) => {
+            logger.warn(
+              `Failed to delete remote branch ${branchName}: ${getErrorMessage(err)}`
+            );
+          })
+        );
+      }
+    }
+
+    // 체크포인트 제거는 항상 동기 시도 — 로드 실패한 경우에도 stale 체크포인트가 남으면 안 된다.
+    // worktree/branch 정리(비동기)보다 먼저 실행해 후속 enqueue가 stale 체크포인트를 잡지 않도록 한다.
+    try {
+      logger.info(`Removing checkpoint for issue #${issueNumber}`);
+      removeCheckpoint(dataDir, issueNumber);
+    } catch (err: unknown) {
+      logger.warn(
+        `Failed to remove checkpoint for issue #${issueNumber}: ${getErrorMessage(err)}`
+      );
+    }
+
+    if (tasks.length > 0) {
+      await Promise.allSettled(tasks);
+    }
+  }
+}

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -1,17 +1,14 @@
-import { resolve } from "path";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
 import { areDependenciesMet } from "./dependency-resolver.js";
-import { removeCheckpoint, loadCheckpoint } from "../pipeline/errors/checkpoint.js";
 import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
-import { removeWorktree } from "../git/worktree-manager.js";
-import { deleteRemoteBranch } from "../git/branch-manager.js";
-import { loadConfig } from "../config/loader.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { checkJobStuck } from "./stuck-detector.js";
+import { JobCleanupService } from "./job-cleanup.js";
+import { ProjectErrorTracker } from "./project-error-tracker.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -110,7 +107,8 @@ export class JobQueue {
   private processingJobs: Set<string> = new Set(); // jobs temporarily removed during processNext
   private projectConcurrency: Map<string, number> = new Map(); // repo -> concurrency limit
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
-  private projectErrorState: Map<string, ProjectErrorState> = new Map(); // repo -> error state
+  private readonly errorTracker = new ProjectErrorTracker();
+  private cleanupService: JobCleanupService;
   private lastServedRepo: string | null = null; // round-robin: last repo that was served
   private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
@@ -118,22 +116,25 @@ export class JobQueue {
   private configProvider?: ConfigProvider;
 
   /**
-   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다.
+   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6).
    *
-   * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서만 호출하면
-   * 되며, 테스트는 호출하지 않아도 `process.cwd()` fallback으로 기존 동작이 유지된다.
+   * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서 호출하면
+   * `JobCleanupService`/`ProjectErrorTracker`가 활성화된다. 테스트는 호출하지 않으면
+   * cleanupService 미설정 → cleanup no-op, errorTracker는 configProvider 없이 기본 임계값으로 동작.
    *
-   * 이렇게 주입된 projectRoot는 `cleanupFailedJobArtifacts`의 data 경로와 `trackProjectFailure`의
-   * config 로드 기준점으로 사용된다. 서버가 다른 cwd에서 기동되는 환경에서 발생하던 경로 오탐
-   * (process.cwd() ≠ AQM root)을 제거한다.
+   * Plan C #C6에서 `process.cwd()` fallback과 `loadConfig` 직접 호출이 모두 제거됐다.
    */
   setDependencies(deps: { projectRoot?: string; configProvider?: ConfigProvider }): void {
     if (deps.projectRoot) this.projectRoot = deps.projectRoot;
-    if (deps.configProvider) this.configProvider = deps.configProvider;
-  }
-
-  private resolveProjectRoot(): string {
-    return this.projectRoot ?? process.cwd();
+    if (deps.configProvider) {
+      this.configProvider = deps.configProvider;
+      this.errorTracker.setConfigProvider(deps.configProvider);
+    }
+    // cleanupService는 항상 갱신해 최신 의존성을 사용한다.
+    this.cleanupService = new JobCleanupService(
+      this.projectRoot ?? process.cwd(),
+      this.configProvider
+    );
   }
 
   constructor(
@@ -157,6 +158,10 @@ export class JobQueue {
         this.projectConcurrency.set(repo, limit);
       });
     }
+
+    // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
+    // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
+    this.cleanupService = new JobCleanupService(process.cwd());
 
     // Periodically check for stuck jobs
     this.stuckChecker = setInterval(() => this.checkStuckJobs(), STUCK_CHECK_INTERVAL_MS);
@@ -264,8 +269,8 @@ export class JobQueue {
    */
   recover(): number {
     // 재시작 시 메모리 상태 초기화 — pause 상태 자동 해제
-    this.projectErrorState.clear();
-    logger.info("재시작: projectErrorState 초기화 완료 (project pause 해제)");
+    this.errorTracker.clear();
+    logger.info("재시작: project error tracker 초기화 완료 (project pause 해제)");
 
     const jobs = this.store.list();
     let recovered = 0;
@@ -294,49 +299,12 @@ export class JobQueue {
 
 
   /**
-   * Cleanup failed job artifacts including worktree, remote branch, and checkpoint.
-   * Each step is attempted independently and failures are logged but don't stop the process.
+   * 실패 잡 정리 — JobCleanupService에 위임 (Plan C #C6).
+   * 호출부는 fire-and-forget(`void this.cleanupFailedJobArtifacts(...)`) 또는
+   * await(retryJob의 race 차단) 형태로 사용한다.
    */
-  private cleanupFailedJobArtifacts(issueNumber: number): void {
-    const projectRoot = this.resolveProjectRoot();
-    const dataDir = resolve(projectRoot, "data");
-
-    let checkpoint = null;
-    try {
-      checkpoint = loadCheckpoint(dataDir, issueNumber);
-    } catch (checkpointErr: unknown) {
-      logger.warn(`Failed to load checkpoint for cleanup of issue #${issueNumber}: ${getErrorMessage(checkpointErr)}`);
-    }
-
-    if (checkpoint) {
-      const config = this.configProvider?.current() ?? loadConfig(projectRoot);
-
-      // Step 1: Remove worktree if exists
-      if (checkpoint.worktreePath) {
-        logger.info(`Cleaning up worktree: ${checkpoint.worktreePath}`);
-        Promise.resolve(removeWorktree(config.git, checkpoint.worktreePath, { cwd: projectRoot, force: true }))
-          .catch((worktreeErr: unknown) => {
-            logger.warn(`Failed to remove worktree ${checkpoint.worktreePath}: ${getErrorMessage(worktreeErr)}`);
-          });
-      }
-
-      // Step 2: Delete remote branch if exists
-      if (checkpoint.branchName) {
-        logger.info(`Deleting remote branch: ${checkpoint.branchName}`);
-        Promise.resolve(deleteRemoteBranch(config.git, checkpoint.branchName, { cwd: projectRoot }))
-          .catch((branchErr: unknown) => {
-            logger.warn(`Failed to delete remote branch ${checkpoint.branchName}: ${getErrorMessage(branchErr)}`);
-          });
-      }
-    }
-
-    // Step 3: Always attempt to remove checkpoint regardless of whether we could load it
-    try {
-      logger.info(`Removing checkpoint for issue #${issueNumber}`);
-      removeCheckpoint(dataDir, issueNumber);
-    } catch (err: unknown) {
-      logger.warn(`Failed to remove checkpoint for issue #${issueNumber}: ${getErrorMessage(err)}`);
-    }
+  private async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    await this.cleanupService.cleanupFailedJobArtifacts(issueNumber);
   }
 
   /**
@@ -356,7 +324,10 @@ export class JobQueue {
         this.store.archive(existing.id);
       } else if (isFailureJob(existing) || isCancelledJob(existing)) {
         logger.info(`Auto-archiving existing ${existing.status} job ${existing.id} for issue #${issueNumber} (${repo})`);
-        this.cleanupFailedJobArtifacts(issueNumber);
+        // Fire-and-forget: enqueue 응답을 차단하지 않는다. retryJob에서는 race 차단을 위해 await로 호출.
+        void this.cleanupFailedJobArtifacts(issueNumber).catch((err: unknown) => {
+          logger.warn(`Cleanup failed during enqueue for issue #${issueNumber}: ${getErrorMessage(err)}`);
+        });
         this.store.archive(existing.id);
       } else if (isActiveJob(existing)) {
         // queued/running statuses should still block
@@ -383,8 +354,11 @@ export class JobQueue {
 
   /**
    * Retries a failed or cancelled job by removing the old one and creating a new one.
+   *
+   * Plan C #C6: cleanup이 완료된 후에야 새 잡을 enqueue하도록 await로 동기화.
+   * 이전 fire-and-forget으로 인해 발생할 수 있던 worktree race를 차단한다.
    */
-  retryJob(jobId: string): Job | undefined {
+  async retryJob(jobId: string): Promise<Job | undefined> {
     const oldJob = this.store.get(jobId);
     if (!oldJob) return undefined;
     if (!isFailureJob(oldJob) && !isCancelledJob(oldJob)) return undefined;
@@ -412,7 +386,7 @@ export class JobQueue {
     }
 
     const { issueNumber, repo, phaseResults } = oldJob;
-    this.cleanupFailedJobArtifacts(issueNumber);
+    await this.cleanupFailedJobArtifacts(issueNumber);
     this.store.archive(jobId);
     return this.enqueue(issueNumber, repo, undefined, true, undefined, phaseResults);
   }
@@ -538,111 +512,49 @@ export class JobQueue {
     }
   }
 
+  // Plan C #C6: 프로젝트 실패 추적/일시 정지 로직은 ProjectErrorTracker로 응집됨.
+  // 외부 public API 시그니처를 보존하기 위해 위임 wrapper만 유지한다.
+
   /**
    * Checks if a project is currently paused due to consecutive failures.
    */
   isProjectPaused(repo: string): boolean {
-    const errorState = this.projectErrorState.get(repo);
-    if (!errorState || !errorState.pausedUntil) {
-      return false;
-    }
-
-    // Check if pause has expired
-    if (Date.now() >= errorState.pausedUntil) {
-      // Auto-resume expired pause
-      this.resumeProject(repo);
-      return false;
-    }
-
-    return true;
+    return this.errorTracker.isProjectPaused(repo);
   }
 
   /**
    * Manually pauses a project for the specified duration.
    */
   pauseProject(repo: string, durationMs: number): void {
-    const errorState = this.projectErrorState.get(repo) || {
-      consecutiveFailures: 0,
-      pausedUntil: null,
-      lastFailureAt: null,
-    };
-
-    errorState.pausedUntil = Date.now() + durationMs;
-    this.projectErrorState.set(repo, errorState);
-
-    logger.warn(`Project ${repo} manually paused for ${Math.round(durationMs / 1000)}s`);
+    this.errorTracker.pauseProject(repo, durationMs);
   }
 
   /**
    * Resumes a paused project.
    */
   resumeProject(repo: string): void {
-    const errorState = this.projectErrorState.get(repo);
-    if (errorState) {
-      errorState.pausedUntil = null;
-      this.projectErrorState.set(repo, errorState);
-      logger.info(`Project ${repo} resumed`);
-    }
+    this.errorTracker.resumeProject(repo);
   }
 
   /**
    * Gets the error status of a project.
    */
   getProjectStatus(repo: string): ProjectErrorState | null {
-    return this.projectErrorState.get(repo) || null;
+    return this.errorTracker.getProjectStatus(repo);
   }
 
   /**
    * Tracks a project failure and potentially pauses the project.
    */
   private trackProjectFailure(repo: string): void {
-    let project = undefined;
-    try {
-      const config = this.configProvider?.current() ?? loadConfig(this.resolveProjectRoot());
-      project = config?.projects?.find(p => p.repo === repo);
-    } catch (error: unknown) {
-      // If config loading fails (e.g. in test environment), use defaults
-      logger.debug(`Failed to load config for project failure tracking: ${getErrorMessage(error)}`);
-    }
-
-    const pauseThreshold = project?.pauseThreshold || 3;
-    const pauseDurationMs = project?.pauseDurationMs || 30 * 60 * 1000; // 30분 기본값
-
-    const errorState = this.projectErrorState.get(repo) || {
-      consecutiveFailures: 0,
-      pausedUntil: null,
-      lastFailureAt: null,
-    };
-
-    errorState.consecutiveFailures++;
-    errorState.lastFailureAt = Date.now();
-
-    if (errorState.consecutiveFailures >= pauseThreshold) {
-      errorState.pausedUntil = Date.now() + pauseDurationMs;
-      logger.error(
-        `Project ${repo} paused for ${Math.round(pauseDurationMs / 60000)}min after ${errorState.consecutiveFailures} consecutive failures`
-      );
-    } else {
-      logger.warn(
-        `Project ${repo} failure count: ${errorState.consecutiveFailures}/${pauseThreshold}`
-      );
-    }
-
-    this.projectErrorState.set(repo, errorState);
+    this.errorTracker.trackFailure(repo);
   }
 
   /**
    * Tracks a project success and resets failure count.
    */
   private trackProjectSuccess(repo: string): void {
-    const errorState = this.projectErrorState.get(repo);
-    if (errorState && errorState.consecutiveFailures > 0) {
-      logger.info(`Project ${repo} success - resetting failure count (was ${errorState.consecutiveFailures})`);
-      errorState.consecutiveFailures = 0;
-      errorState.lastFailureAt = null;
-      // Keep pausedUntil if manually set
-      this.projectErrorState.set(repo, errorState);
-    }
+    this.errorTracker.trackSuccess(repo);
   }
 
   /**
@@ -834,7 +746,7 @@ export class JobQueue {
 
         // Check if project is paused due to consecutive failures
         if (this.isProjectPaused(job.repo)) {
-          const errorState = this.projectErrorState.get(job.repo);
+          const errorState = this.errorTracker.getProjectStatus(job.repo);
           const remainingMs = errorState!.pausedUntil! - Date.now();
           logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
           this.processingJobs.delete(jobId);

--- a/src/queue/project-error-tracker.ts
+++ b/src/queue/project-error-tracker.ts
@@ -1,0 +1,153 @@
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+import type { ProjectErrorState } from "../types/config.js";
+
+const logger = getLogger();
+
+const DEFAULT_PAUSE_THRESHOLD = 3;
+const DEFAULT_PAUSE_DURATION_MS = 30 * 60 * 1000; // 30분
+
+/**
+ * 프로젝트별 연속 실패를 추적하고, 임계값 초과 시 일시 정지(pause)를 적용한다.
+ *
+ * Plan C #C6에서 `JobQueue` module-level `projectErrorState` Map과 4개 메서드
+ * (isProjectPaused/pauseProject/resumeProject/getProjectStatus + private trackProjectFailure/Success)를
+ * 단일 클래스로 응집. ConfigProvider를 명시적으로 주입받아 `process.cwd()` 의존을 제거한다.
+ */
+export class ProjectErrorTracker {
+  private readonly state = new Map<string, ProjectErrorState>();
+  private configProvider?: ConfigProvider;
+
+  /**
+   * @param configProvider 프로젝트별 pause threshold/duration을 읽기 위한 의존성.
+   *                       미주입 시(테스트 환경 등) 기본값(threshold 3, duration 30분)을 사용한다.
+   *                       지연 주입은 `setConfigProvider`로 가능.
+   */
+  constructor(configProvider?: ConfigProvider) {
+    this.configProvider = configProvider;
+  }
+
+  /**
+   * 런타임 시점에 ConfigProvider를 주입한다. JobQueue가 post-construction
+   * setDependencies로 의존성을 주입하는 패턴을 지원한다.
+   */
+  setConfigProvider(provider: ConfigProvider): void {
+    this.configProvider = provider;
+  }
+
+  /**
+   * 프로젝트가 현재 일시 정지 상태인지 확인. 만료된 정지는 자동 해제한다.
+   */
+  isProjectPaused(repo: string): boolean {
+    const errorState = this.state.get(repo);
+    if (!errorState || !errorState.pausedUntil) {
+      return false;
+    }
+
+    if (Date.now() >= errorState.pausedUntil) {
+      this.resumeProject(repo);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 명시적으로 프로젝트를 일시 정지한다. 연속 실패 카운터에는 영향 없다.
+   */
+  pauseProject(repo: string, durationMs: number): void {
+    const errorState = this.state.get(repo) || this.createEmptyState();
+    errorState.pausedUntil = Date.now() + durationMs;
+    this.state.set(repo, errorState);
+    logger.warn(
+      `Project ${repo} manually paused for ${Math.round(durationMs / 1000)}s`
+    );
+  }
+
+  /**
+   * 일시 정지를 해제한다. 카운터는 유지되며 trackSuccess로 별도 리셋한다.
+   */
+  resumeProject(repo: string): void {
+    const errorState = this.state.get(repo);
+    if (errorState) {
+      errorState.pausedUntil = null;
+      this.state.set(repo, errorState);
+      logger.info(`Project ${repo} resumed`);
+    }
+  }
+
+  getProjectStatus(repo: string): ProjectErrorState | null {
+    return this.state.get(repo) || null;
+  }
+
+  /**
+   * 실패를 기록한다. 임계값 도달 시 자동으로 pause를 적용한다.
+   * pauseThreshold/pauseDurationMs는 config의 프로젝트 설정에서 가져온다.
+   */
+  trackFailure(repo: string): void {
+    let project: { pauseThreshold?: number; pauseDurationMs?: number } | undefined;
+    if (this.configProvider) {
+      try {
+        const config = this.configProvider.current();
+        project = config?.projects?.find(p => p.repo === repo);
+      } catch (error: unknown) {
+        // config 로딩 실패 시(테스트 환경 등) 기본값으로 진행
+        logger.debug(
+          `Failed to load config for project failure tracking: ${getErrorMessage(error)}`
+        );
+      }
+    }
+
+    const pauseThreshold = project?.pauseThreshold || DEFAULT_PAUSE_THRESHOLD;
+    const pauseDurationMs = project?.pauseDurationMs || DEFAULT_PAUSE_DURATION_MS;
+
+    const errorState = this.state.get(repo) || this.createEmptyState();
+    errorState.consecutiveFailures++;
+    errorState.lastFailureAt = Date.now();
+
+    if (errorState.consecutiveFailures >= pauseThreshold) {
+      errorState.pausedUntil = Date.now() + pauseDurationMs;
+      logger.error(
+        `Project ${repo} paused for ${Math.round(pauseDurationMs / 60000)}min after ${errorState.consecutiveFailures} consecutive failures`
+      );
+    } else {
+      logger.warn(
+        `Project ${repo} failure count: ${errorState.consecutiveFailures}/${pauseThreshold}`
+      );
+    }
+
+    this.state.set(repo, errorState);
+  }
+
+  /**
+   * 성공을 기록한다. 연속 실패 카운터를 리셋하며, 수동 pausedUntil은 유지한다.
+   */
+  trackSuccess(repo: string): void {
+    const errorState = this.state.get(repo);
+    if (errorState && errorState.consecutiveFailures > 0) {
+      logger.info(
+        `Project ${repo} success - resetting failure count (was ${errorState.consecutiveFailures})`
+      );
+      errorState.consecutiveFailures = 0;
+      errorState.lastFailureAt = null;
+      // pausedUntil은 그대로 두어 수동 pauseProject 효과를 보존
+      this.state.set(repo, errorState);
+    }
+  }
+
+  /**
+   * 모든 프로젝트 상태를 비운다. 데몬 재시작 시 사용.
+   */
+  clear(): void {
+    this.state.clear();
+  }
+
+  private createEmptyState(): ProjectErrorState {
+    return {
+      consecutiveFailures: 0,
+      pausedUntil: null,
+      lastFailureAt: null,
+    };
+  }
+}

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1372,7 +1372,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     if (job.status !== "failure" && job.status !== "cancelled") {
       return c.json({ error: "Only failed or cancelled jobs can be retried" }, 400);
     }
-    const newJob = queue.retryJob(id);
+    const newJob = await queue.retryJob(id);
     if (!newJob) {
       return c.json({ error: "Failed to retry job" }, 500);
     }

--- a/tests/queue/job-cleanup.test.ts
+++ b/tests/queue/job-cleanup.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadCheckpoint: vi.fn(),
+  removeCheckpoint: vi.fn(),
+  removeWorktree: vi.fn(),
+  deleteRemoteBranch: vi.fn(),
+}));
+
+vi.mock("../../src/pipeline/errors/checkpoint.js", () => ({
+  loadCheckpoint: mocks.loadCheckpoint,
+  removeCheckpoint: mocks.removeCheckpoint,
+}));
+
+vi.mock("../../src/git/worktree-manager.js", () => ({
+  removeWorktree: mocks.removeWorktree,
+}));
+
+vi.mock("../../src/git/branch-manager.js", () => ({
+  deleteRemoteBranch: mocks.deleteRemoteBranch,
+}));
+
+import { JobCleanupService } from "../../src/queue/job-cleanup.js";
+import type { ConfigProvider } from "../../src/config/config-provider.js";
+import type { AQConfig } from "../../src/types/config.js";
+
+function makeProvider(): ConfigProvider {
+  return {
+    current: () => ({ git: { gitPath: "git" } } as unknown as AQConfig),
+    refresh: () => {},
+  };
+}
+
+describe("JobCleanupService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("worktree와 branch 정리를 모두 await한 후 반환한다 (race 차단)", async () => {
+    let worktreeResolved = false;
+    let branchResolved = false;
+
+    mocks.loadCheckpoint.mockReturnValue({
+      worktreePath: "/tmp/worktree",
+      branchName: "feat/test",
+    });
+    mocks.removeWorktree.mockImplementation(
+      () =>
+        new Promise<void>(r => {
+          setTimeout(() => {
+            worktreeResolved = true;
+            r();
+          }, 10);
+        })
+    );
+    mocks.deleteRemoteBranch.mockImplementation(
+      () =>
+        new Promise<void>(r => {
+          setTimeout(() => {
+            branchResolved = true;
+            r();
+          }, 5);
+        })
+    );
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(42);
+
+    expect(worktreeResolved).toBe(true);
+    expect(branchResolved).toBe(true);
+    expect(mocks.removeCheckpoint).toHaveBeenCalledWith(expect.stringContaining("data"), 42);
+  });
+
+  it("worktree 제거 실패해도 branch/checkpoint 제거는 진행", async () => {
+    mocks.loadCheckpoint.mockReturnValue({
+      worktreePath: "/tmp/worktree",
+      branchName: "feat/test",
+    });
+    mocks.removeWorktree.mockRejectedValue(new Error("worktree gone"));
+    mocks.deleteRemoteBranch.mockResolvedValue(undefined);
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await expect(service.cleanupFailedJobArtifacts(42)).resolves.toBeUndefined();
+
+    expect(mocks.deleteRemoteBranch).toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalled();
+  });
+
+  it("checkpoint 로드 실패해도 removeCheckpoint는 시도", async () => {
+    mocks.loadCheckpoint.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(7);
+
+    expect(mocks.removeWorktree).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteBranch).not.toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalledWith(expect.stringContaining("data"), 7);
+  });
+
+  it("checkpoint가 없으면 worktree/branch 정리도 스킵", async () => {
+    mocks.loadCheckpoint.mockReturnValue(null);
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(99);
+
+    expect(mocks.removeWorktree).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteBranch).not.toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalled();
+  });
+});

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -298,7 +298,7 @@ describe("JobQueue", () => {
       expect(failedJob?.error).toContain("initial failure");
 
       // Retry the failed job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
       expect(retryJob?.issueNumber).toBe(123);
@@ -352,7 +352,7 @@ describe("JobQueue", () => {
       store.update(job!.id, { logs: ["[2026. 4. 4. 21시 56분 30초] PR: https://pr/existing"] });
 
       // Try to retry - should fix status instead of retrying
-      const retryResult = queue.retryJob(job!.id);
+      const retryResult = await queue.retryJob(job!.id);
       expect(retryResult).toBeUndefined();
 
       // Verify job status was fixed to success
@@ -381,7 +381,7 @@ describe("JobQueue", () => {
       expect(failedJob?.status).toBe("failure");
 
       // Retry the job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
 
@@ -419,7 +419,7 @@ describe("JobQueue", () => {
       });
 
       // Try to retry - should fix status instead of retrying
-      const retryResult = queue.retryJob(job!.id);
+      const retryResult = await queue.retryJob(job!.id);
       expect(retryResult).toBeUndefined();
 
       // Verify job status was fixed to success
@@ -453,7 +453,7 @@ describe("JobQueue", () => {
       store.update(initialJob!.id, { phaseResults: mockPhaseResults });
 
       // Retry - new job should inherit phaseResults from failed job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
 

--- a/tests/queue/project-error-tracker.test.ts
+++ b/tests/queue/project-error-tracker.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+import type { ConfigProvider } from "../../src/config/config-provider.js";
+import type { AQConfig } from "../../src/types/config.js";
+
+function makeConfigProvider(config: Partial<AQConfig> = {}): ConfigProvider {
+  return {
+    current: () => config as AQConfig,
+    refresh: () => {},
+  };
+}
+
+describe("ProjectErrorTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("isProjectPaused / pauseProject / resumeProject", () => {
+    it("초기 상태는 paused가 아니다", () => {
+      const tracker = new ProjectErrorTracker();
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+
+    it("pauseProject 후 isProjectPaused는 true", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 60_000);
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("pause 만료 시 자동 재개", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 1000);
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+
+    it("resumeProject는 pause를 해제", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 60_000);
+      tracker.resumeProject("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+  });
+
+  describe("trackFailure", () => {
+    it("기본 임계값 3회 도달 시 자동 pause", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("config의 pauseThreshold가 우선", () => {
+      const provider = makeConfigProvider({
+        projects: [{ repo: "a/b", pauseThreshold: 1, pauseDurationMs: 60_000 } as never],
+      });
+      const tracker = new ProjectErrorTracker(provider);
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("configProvider 없이도 기본값으로 동작", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      const status = tracker.getProjectStatus("a/b");
+      expect(status?.consecutiveFailures).toBe(1);
+    });
+
+    it("config.current() throw 시 기본값 fallback", () => {
+      const provider: ConfigProvider = {
+        current: () => {
+          throw new Error("config broken");
+        },
+        refresh: () => {},
+      };
+      const tracker = new ProjectErrorTracker(provider);
+      tracker.trackFailure("a/b");
+      const status = tracker.getProjectStatus("a/b");
+      expect(status?.consecutiveFailures).toBe(1);
+    });
+  });
+
+  describe("trackSuccess", () => {
+    it("연속 실패 카운터를 0으로 리셋", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.trackFailure("a/b");
+      tracker.trackSuccess("a/b");
+      expect(tracker.getProjectStatus("a/b")?.consecutiveFailures).toBe(0);
+    });
+
+    it("수동 pausedUntil은 trackSuccess가 유지", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.pauseProject("a/b", 60_000);
+      tracker.trackSuccess("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+  });
+
+  describe("setConfigProvider", () => {
+    it("지연 주입 후 trackFailure가 새 provider를 사용", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.setConfigProvider(
+        makeConfigProvider({
+          projects: [{ repo: "a/b", pauseThreshold: 1, pauseDurationMs: 60_000 } as never],
+        })
+      );
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+  });
+
+  describe("clear", () => {
+    it("모든 상태를 비운다", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.pauseProject("c/d", 60_000);
+      tracker.clear();
+      expect(tracker.getProjectStatus("a/b")).toBeNull();
+      expect(tracker.isProjectPaused("c/d")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Plan C #C6 — `job-queue.ts`(952줄)에 응집된 cleanup과 project error tracking을 독립 클래스로 분리. `retryJob`의 worktree race를 차단하기 위해 cleanup을 async + `Promise.allSettled`로 전환하고 `retryJob`을 async 시그니처로 변경.

## Changes

### 신규 클래스
- **`src/queue/job-cleanup.ts`** — `JobCleanupService`
  - `async cleanupFailedJobArtifacts(issueNumber)` — `await Promise.allSettled`로 worktree/branch 정리 완료까지 보장
  - checkpoint 제거는 sync 우선 실행 (후속 enqueue가 stale 체크포인트를 잡지 않도록)
  - `ConfigProvider` 옵셔널 주입 (없으면 `loadConfig(aqRoot)` fallback — 테스트 호환)
- **`src/queue/project-error-tracker.ts`** — `ProjectErrorTracker`
  - 상태/메서드 일체 응집: `isProjectPaused/pauseProject/resumeProject/getProjectStatus/trackFailure/trackSuccess/clear`
  - `ConfigProvider` 옵셔널 + `setConfigProvider` 지연 주입 지원

### `src/queue/job-queue.ts`
- `projectErrorState` Map → `errorTracker` 위임
- cleanup 인라인 로직 (`Promise.resolve(...).catch()` fire-and-forget) 제거
- `loadConfig` 직접 호출 제거 → cleanupService에 위임
- `retryJob`: sync → **async** (`Promise<Job | undefined>`). race 차단을 위해 `await this.cleanupFailedJobArtifacts(issueNumber)`
- enqueue 안 cleanup은 응답 지연 회피를 위해 fire-and-forget(`void ... .catch()`) 유지
- `process.cwd()` 직접 호출 4건 → 2건. 잔존 2건은 setDependencies 호출 전(테스트 환경) cleanupService default. cli.ts production 경로에서는 setDependencies가 정확한 projectRoot로 즉시 교체. 100% 근절은 #C10 Facade에서 생성자 시그니처 변경.

### `src/server/dashboard-api.ts`
- `queue.retryJob(id)` → `await queue.retryJob(id)` (외부 호출자 1곳)

### 테스트
- `tests/queue/job-cleanup.test.ts` 신규 (4건) — race 차단·worktree 실패 격리·체크포인트 로드 실패·체크포인트 부재 시나리오
- `tests/queue/project-error-tracker.test.ts` 신규 (12건) — pause/resume/threshold/config 우선/fallback/clear
- `tests/queue/job-queue.test.ts` — `retryJob` 호출 5곳 `await` 추가

## Test plan

- [x] `npx tsc --noEmit` — 0 error
- [x] `npm run lint` — 0 error
- [x] `npm test` — 155 files / **3358 pass** / 7 skipped
- [x] 영향 받은 패키지 4개 통합 테스트 모두 통과 (job-queue 67 + job-cleanup 4 + project-error-tracker 12 + dashboard-api 176 = 259)

## Breaking

**내부 한정.** `JobQueue.retryJob` 시그니처가 sync → async로 변경. 호출자는 GitHub repo 내 `dashboard-api.ts:1375` 1곳뿐이며 동시 갱신.

## depends

- #C2 ConfigProvider (✅ e588999) — 두 신규 클래스의 의존성

## 후속

- #C10: 잔존 `process.cwd()` fallback 2건 근절 (JobQueue 생성자 시그니처 변경)