### PR TITLE
refactor(queue): StuckJobMonitor 추출 (Plan C #C10 Phase 1)

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -3,12 +3,11 @@ import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
 import { areDependenciesMet } from "./dependency-resolver.js";
-import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
-import { checkJobStuck } from "./stuck-detector.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
+import { StuckJobMonitor } from "./stuck-monitor.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -97,7 +96,7 @@ export class JobQueue {
   private concurrency: number;
   private handler: JobHandler;
   private cancelled: Set<string> = new Set();
-  private stuckChecker: ReturnType<typeof setInterval> | undefined;
+  private readonly stuckMonitor: StuckJobMonitor;
   private stuckTimeoutMs: number;
   private stuckThresholds?: StuckThresholdConfig;
   private shuttingDown: boolean = false;
@@ -163,63 +162,26 @@ export class JobQueue {
     // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
     this.cleanupService = new JobCleanupService(process.cwd());
 
-    // Periodically check for stuck jobs
-    this.stuckChecker = setInterval(() => this.checkStuckJobs(), STUCK_CHECK_INTERVAL_MS);
-  }
-
-  private checkStuckJobs(): void {
-    const thresholds: StuckThresholdConfig = this.stuckThresholds ?? {
-      defaultMs: this.stuckTimeoutMs,
-      planGenerationMs: this.stuckTimeoutMs,
-      implementationMs: this.stuckTimeoutMs,
-      reviewMs: this.stuckTimeoutMs,
-      verificationMs: this.stuckTimeoutMs,
-      publishMs: this.stuckTimeoutMs,
-      activityThresholdMs: 5 * 60 * 1000,
-    };
-
-    const processAlive = isClaudeProcessAlive();
-    const lastActivityMs = getLastActivityMs();
-
-    for (const jobId of this.running) {
-      const storeJob = this.store.get(jobId);
-      if (!storeJob) continue;
-
-      const job = convertStoreJobToJob(storeJob);
-      const result = checkJobStuck(job, thresholds, { processAlive, lastActivityMs });
-
-      logger.debug(
-        `StuckCheck job=${jobId} step=${job.currentStep ?? "-"} category=${result.category} ` +
-        `elapsed=${result.elapsedMs}ms threshold=${result.thresholdMs}ms isStuck=${result.isStuck} reason=${result.reason}`
-      );
-
-      if (!result.isStuck && result.reason !== "임계값 이내") {
-        // Threshold exceeded but still working — extend lastUpdatedAt
-        if (result.reason.startsWith("Claude 활동 중")) {
-          logger.info(
-            `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과, ${result.reason} — 대기 연장`
-          );
-        } else {
-          logger.debug(
-            `Job ${jobId} (${result.category}): ${result.reason} — 대기 연장`
-          );
-        }
-        this.store.update(jobId, { lastUpdatedAt: new Date().toISOString() });
-      } else if (result.isStuck) {
-        logger.error(
-          `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과 — ${result.reason}`
-        );
+    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
+    this.stuckMonitor = new StuckJobMonitor({
+      store: this.store,
+      stuckTimeoutMs: this.stuckTimeoutMs,
+      stuckThresholds: this.stuckThresholds,
+      checkIntervalMs: STUCK_CHECK_INTERVAL_MS,
+      getRunningJobIds: () => this.running,
+      toJob: convertStoreJobToJob,
+      onStuckDetected: (jobId, reason) => {
         this.store.update(jobId, {
           status: "failure",
           completedAt: new Date().toISOString(),
-          error: result.reason,
+          error: reason,
         });
         this.stuckAborted.add(jobId);
         this.running.delete(jobId);
         setTimeout(() => this.processNext(), 0);
-      }
-      // result.reason === "임계값 이내": threshold not yet exceeded, no action needed
-    }
+      },
+    });
+    this.stuckMonitor.start();
   }
 
   /**
@@ -239,10 +201,7 @@ export class JobQueue {
    */
   shutdown(timeoutMs: number = 30000): Promise<void> {
     this.shuttingDown = true;
-    if (this.stuckChecker !== undefined) {
-      clearInterval(this.stuckChecker);
-      this.stuckChecker = undefined;
-    }
+    this.stuckMonitor.stop();
     if (this.running.size === 0) {
       return Promise.resolve();
     }

--- a/src/queue/stuck-monitor.ts
+++ b/src/queue/stuck-monitor.ts
@@ -1,0 +1,109 @@
+import type { JobStore } from "./job-store.js";
+import type { StuckThresholdConfig } from "../types/config.js";
+import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
+import { checkJobStuck } from "./stuck-detector.js";
+import { Job } from "../types/pipeline.js";
+import { getLogger } from "../utils/logger.js";
+
+const logger = getLogger();
+
+/**
+ * 주기적으로 stuck 잡을 탐지해 콜백을 호출한다 (Plan C #C10 — Phase 1).
+ *
+ * 이전: `JobQueue.checkStuckJobs` private 메서드. running Set / stuckAborted Set /
+ *      store / processNext에 깊이 얽혀 있었다.
+ * 이후: 본 모니터가 store + 외부 콜백 두 가지 의존성만 갖고, JobQueue는 콜백에서
+ *      자체 상태(running/stuckAborted)를 mutate한다.
+ */
+export interface StuckJobMonitorOptions {
+  store: JobStore;
+  stuckTimeoutMs: number;
+  stuckThresholds?: StuckThresholdConfig;
+  /** 현재 실행 중인 잡 ID iterable. 매 체크마다 호출되어 최신 상태를 가져온다. */
+  getRunningJobIds: () => Iterable<string>;
+  /** StoreJob → Job 변환기. JobQueue 내부 변환 헬퍼를 그대로 주입. */
+  toJob: (storeJob: import("./job-store.js").Job) => Job;
+  /** stuck으로 판정됐을 때 호출. JobQueue에서 store update + running 제거 + processNext schedule을 처리한다. */
+  onStuckDetected: (jobId: string, reason: string) => void;
+  /** 체크 주기. 기본 60초. */
+  checkIntervalMs?: number;
+}
+
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 1000;
+const DEFAULT_ACTIVITY_THRESHOLD_MS = 5 * 60 * 1000;
+
+export class StuckJobMonitor {
+  private interval?: ReturnType<typeof setInterval>;
+
+  constructor(private readonly opts: StuckJobMonitorOptions) {}
+
+  start(): void {
+    this.stop();
+    this.interval = setInterval(
+      () => this.checkStuckJobs(),
+      this.opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS
+    );
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+  }
+
+  /**
+   * 외부에서 명시적으로 한 차례 stuck 점검을 트리거한다 (테스트/긴급 점검).
+   */
+  runOnce(): void {
+    this.checkStuckJobs();
+  }
+
+  private checkStuckJobs(): void {
+    const thresholds: StuckThresholdConfig = this.opts.stuckThresholds ?? {
+      defaultMs: this.opts.stuckTimeoutMs,
+      planGenerationMs: this.opts.stuckTimeoutMs,
+      implementationMs: this.opts.stuckTimeoutMs,
+      reviewMs: this.opts.stuckTimeoutMs,
+      verificationMs: this.opts.stuckTimeoutMs,
+      publishMs: this.opts.stuckTimeoutMs,
+      activityThresholdMs: DEFAULT_ACTIVITY_THRESHOLD_MS,
+    };
+
+    const processAlive = isClaudeProcessAlive();
+    const lastActivityMs = getLastActivityMs();
+
+    for (const jobId of this.opts.getRunningJobIds()) {
+      const storeJob = this.opts.store.get(jobId);
+      if (!storeJob) continue;
+
+      const job = this.opts.toJob(storeJob);
+      const result = checkJobStuck(job, thresholds, { processAlive, lastActivityMs });
+
+      logger.debug(
+        `StuckCheck job=${jobId} step=${job.currentStep ?? "-"} category=${result.category} ` +
+        `elapsed=${result.elapsedMs}ms threshold=${result.thresholdMs}ms isStuck=${result.isStuck} reason=${result.reason}`
+      );
+
+      if (!result.isStuck && result.reason !== "임계값 이내") {
+        // 임계값은 초과했지만 아직 진행 중 — lastUpdatedAt 갱신으로 대기 연장
+        if (result.reason.startsWith("Claude 활동 중")) {
+          logger.info(
+            `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과, ${result.reason} — 대기 연장`
+          );
+        } else {
+          logger.debug(
+            `Job ${jobId} (${result.category}): ${result.reason} — 대기 연장`
+          );
+        }
+        this.opts.store.update(jobId, { lastUpdatedAt: new Date().toISOString() });
+      } else if (result.isStuck) {
+        logger.error(
+          `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과 — ${result.reason}`
+        );
+        this.opts.onStuckDetected(jobId, result.reason);
+      }
+      // result.reason === "임계값 이내": 임계값 미달, 액션 없음
+    }
+  }
+}

--- a/tests/queue/stuck-monitor.test.ts
+++ b/tests/queue/stuck-monitor.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const claudeMocks = vi.hoisted(() => ({
+  isClaudeProcessAlive: vi.fn(() => false),
+  getLastActivityMs: vi.fn(() => Date.now()),
+}));
+
+const stuckDetectorMock = vi.hoisted(() => ({
+  checkJobStuck: vi.fn(),
+}));
+
+vi.mock("../../src/claude/claude-runner.js", () => claudeMocks);
+vi.mock("../../src/queue/stuck-detector.js", () => stuckDetectorMock);
+
+import { StuckJobMonitor } from "../../src/queue/stuck-monitor.js";
+import type { Job as StoreJob, JobStore } from "../../src/queue/job-store.js";
+import type { Job } from "../../src/types/pipeline.js";
+
+function makeStore(getResult: StoreJob | undefined = undefined): JobStore {
+  return {
+    get: vi.fn(() => getResult),
+    update: vi.fn(),
+  } as unknown as JobStore;
+}
+
+function makeStoreJob(id: string): StoreJob {
+  return {
+    id,
+    issueNumber: 1,
+    repo: "a/b",
+    status: "running",
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    logs: [],
+    currentStep: null,
+  } as unknown as StoreJob;
+}
+
+describe("StuckJobMonitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    claudeMocks.isClaudeProcessAlive.mockReturnValue(false);
+    claudeMocks.getLastActivityMs.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start/stop은 setInterval을 토글한다", () => {
+    const monitor = new StuckJobMonitor({
+      store: makeStore(),
+      stuckTimeoutMs: 1000,
+      checkIntervalMs: 100,
+      getRunningJobIds: () => [],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.start();
+    vi.advanceTimersByTime(250);
+    monitor.stop();
+    vi.advanceTimersByTime(500);
+    // 정상 동작 — 에러 없음
+    expect(true).toBe(true);
+  });
+
+  it("stuck 판정 시 onStuckDetected 콜백 호출", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: true,
+      reason: "타임아웃",
+      category: "default",
+      elapsedMs: 600_000,
+      thresholdMs: 300_000,
+    });
+    const storeJob = makeStoreJob("job-1");
+    const store = makeStore(storeJob);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-1"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(onStuckDetected).toHaveBeenCalledWith("job-1", "타임아웃");
+  });
+
+  it("stuck 아님 + threshold 초과 시 lastUpdatedAt 갱신", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "Claude 활동 중",
+      category: "default",
+      elapsedMs: 600_000,
+      thresholdMs: 300_000,
+    });
+    const storeJob = makeStoreJob("job-2");
+    const store = makeStore(storeJob);
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-2"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.runOnce();
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-2",
+      expect.objectContaining({ lastUpdatedAt: expect.any(String) })
+    );
+  });
+
+  it("threshold 이내 reason은 액션 없음", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "임계값 이내",
+      category: "default",
+      elapsedMs: 100,
+      thresholdMs: 1000,
+    });
+    const storeJob = makeStoreJob("job-3");
+    const store = makeStore(storeJob);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-3"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(store.update).not.toHaveBeenCalled();
+    expect(onStuckDetected).not.toHaveBeenCalled();
+  });
+
+  it("store.get이 undefined 반환하면 해당 잡은 스킵", () => {
+    const store = makeStore(undefined);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["ghost"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(stuckDetectorMock.checkJobStuck).not.toHaveBeenCalled();
+    expect(onStuckDetected).not.toHaveBeenCalled();
+  });
+
+  it("interval 발화 시 checkJobStuck 호출", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "임계값 이내",
+      category: "default",
+      elapsedMs: 0,
+      thresholdMs: 1000,
+    });
+    const store = makeStore(makeStoreJob("job-tick"));
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      checkIntervalMs: 50,
+      getRunningJobIds: () => ["job-tick"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.start();
+    vi.advanceTimersByTime(170); // 50/100/150 = 3회
+    monitor.stop();
+
+    expect(stuckDetectorMock.checkJobStuck).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

Plan C #C10 — **Phase 1**. `JobQueue.checkStuckJobs`(70여 줄)와 `stuckChecker` setInterval을 독립 클래스 `StuckJobMonitor`로 분리. JobQueue는 자체 상태(running/stuckAborted) mutation만 책임지고, stuck 탐지 루프는 모니터가 담당한다.

워크플랜 #C10 풀 스코프(JobScheduler / JobLifecycle 추가 추출)는 후속 PR로 분할 — 본 PR은 가장 자기완결적인 stuck 탐지를 먼저 떼낸다.

## Changes

- **`src/queue/stuck-monitor.ts` (신규, 109줄)**
  - `StuckJobMonitor` 클래스
  - `start()` / `stop()` / `runOnce()` — interval 기반 stuck 탐지 루프
  - 옵션: `store`, `stuckTimeoutMs`, `stuckThresholds`, `checkIntervalMs`
  - 콜백: `getRunningJobIds`, `toJob`, `onStuckDetected(jobId, reason)` — JobQueue의 자체 상태 mutate를 위해
- **`src/queue/job-queue.ts` (864 → 823, -41줄)**
  - `checkStuckJobs` private 메서드 제거
  - `stuckChecker` 필드 → `stuckMonitor: StuckJobMonitor`
  - `claude-runner` (isClaudeProcessAlive/getLastActivityMs), `stuck-detector` (checkJobStuck) 직접 import 제거 (모니터로 이전)
  - 생성자에서 `new StuckJobMonitor({...}).start()` 즉시 활성화
  - `shutdown()`: `clearInterval(stuckChecker)` → `stuckMonitor.stop()`

## Test plan

- [x] `npx tsc --noEmit` — 0 error
- [x] `npm run lint` — 0 error
- [x] `npm test` — 158 files / 3385 pass / 7 skipped
- [x] 신규 단위 테스트 6건: start/stop interval, stuck 판정 콜백, threshold 초과 lastUpdatedAt 갱신, threshold 이내 액션 없음, ghost job 스킵, interval 발화 횟수
- [x] `tests/queue/job-queue.test.ts` 67건 회귀 0

## Breaking

없음. 외부 시그니처 무변경. Stuck 탐지 동작 동일 (콜백 패턴으로만 재구성).

## 후속

- **#C10 Phase 2**: `JobLifecycle` (executeJob + 결과 처리) 추출
- **#C10 Phase 3**: `JobScheduler` (priority/round-robin/processNext) 추출 + 생성자 옵션 객체화
- 모두 완료 시 JobQueue를 thin Facade(~200줄)로 축소 + `process.cwd()` fallback 100% 근절

## depends

- #C6 (`JobCleanupService` 패턴) — ✅ 8d13554