### PR TITLE
refactor(queue): JobLifecycle 추출 (Plan C #C10 Phase 2)

### DIFF
--- a/src/queue/job-lifecycle.ts
+++ b/src/queue/job-lifecycle.ts
@@ -1,0 +1,134 @@
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { JobStore } from "./job-store.js";
+import type { Job, DiagnosisReport, UserSummary } from "../types/pipeline.js";
+import type { ProjectErrorTracker } from "./project-error-tracker.js";
+import type { TaskFactory } from "../tasks/task-factory.js";
+import type { AQMTask } from "../tasks/aqm-task.js";
+
+const logger = getLogger();
+
+export type JobHandler = (
+  job: Job
+) => Promise<{
+  prUrl?: string;
+  error?: string;
+  diagnosis?: DiagnosisReport;
+  userSummary?: UserSummary;
+}>;
+
+/**
+ * 잡 한 건의 실행/결과 처리 책임 (Plan C #C10 — Phase 2).
+ *
+ * 이전: `JobQueue.executeJob` private 메서드. handler 호출, store 갱신, project error
+ *      tracking, stuckAborted/cancelled 세트 정리, finally 단계의 running/repo 카운터
+ *      해제까지 한 메서드에서 담당했다.
+ * 이후: 본 클래스가 실행 흐름과 결과 분기만 담당한다. 공유 상태(running/runningByRepo
+ *      카운터, processNext 호출)는 `onJobFinished` 콜백을 통해 JobQueue가 책임진다.
+ */
+export interface JobLifecycleDeps {
+  store: JobStore;
+  handler: JobHandler;
+  taskFactory?: TaskFactory;
+  errorTracker: ProjectErrorTracker;
+  /** JobQueue가 소유하는 active task 추적 Map. cancel()이 동일 Map을 참조한다. */
+  activeTasks: Map<string, AQMTask>;
+  /** StuckJobMonitor 콜백/JobLifecycle 사이에서 공유되는 stuck-abort 플래그. */
+  stuckAborted: Set<string>;
+  /** JobQueue.cancel과 공유되는 cancel 플래그. */
+  cancelled: Set<string>;
+  /**
+   * 잡 종료 시(성공/실패/취소/예외 모두 포함) 호출. JobQueue가 running.delete +
+   * removeJobFromRepo + processNext schedule을 처리한다.
+   */
+  onJobFinished: (jobId: string, repo: string) => void;
+}
+
+export class JobLifecycle {
+  constructor(private readonly deps: JobLifecycleDeps) {}
+
+  async execute(job: Job): Promise<void> {
+    try {
+      // Stuck monitor가 이미 abort 신호를 보낸 잡은 handler를 돌리지 않는다.
+      if (this.deps.stuckAborted.has(job.id)) {
+        this.deps.stuckAborted.delete(job.id);
+        return;
+      }
+
+      let result: {
+        prUrl?: string;
+        error?: string;
+        diagnosis?: DiagnosisReport;
+        userSummary?: UserSummary;
+      };
+
+      if (this.deps.taskFactory) {
+        const task = this.deps.taskFactory.createTask(job);
+        this.deps.activeTasks.set(job.id, task);
+        try {
+          result = await (
+            task as unknown as {
+              run(): Promise<{ prUrl?: string; error?: string }>;
+            }
+          ).run();
+        } finally {
+          this.deps.activeTasks.delete(job.id);
+        }
+      } else {
+        result = await this.deps.handler(job);
+      }
+
+      // handler 실행 도중 stuck checker가 발화했을 수 있다 — 결과 적용 전 재확인.
+      const wasStuckAborted = this.deps.stuckAborted.has(job.id);
+      if (wasStuckAborted) {
+        this.deps.stuckAborted.delete(job.id);
+        logger.warn(
+          `Job ${job.id} handler completed after stuck-abort — updating status but not tracking project metrics`
+        );
+      }
+
+      if (this.deps.cancelled.has(job.id)) {
+        this.deps.cancelled.delete(job.id);
+        // cancel()이 이미 cancelled 상태로 update했으므로 추가 처리 없음.
+      } else if (result.error) {
+        this.deps.store.update(job.id, {
+          status: "failure",
+          completedAt: new Date().toISOString(),
+          error: result.error,
+          ...(result.diagnosis ? { diagnosis: result.diagnosis } : {}),
+          ...(result.userSummary ? { userSummary: result.userSummary } : {}),
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackFailure(job.repo);
+        }
+      } else if (result.prUrl) {
+        this.deps.store.update(job.id, {
+          status: "success",
+          completedAt: new Date().toISOString(),
+          prUrl: result.prUrl,
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackSuccess(job.repo);
+        }
+      } else {
+        this.deps.store.update(job.id, {
+          status: "failure",
+          completedAt: new Date().toISOString(),
+          error: "Pipeline completed but no PR was created",
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackFailure(job.repo);
+        }
+      }
+    } catch (error: unknown) {
+      this.deps.store.update(job.id, {
+        status: "failure",
+        completedAt: new Date().toISOString(),
+        error: getErrorMessage(error),
+      });
+      this.deps.errorTracker.trackFailure(job.repo);
+    } finally {
+      this.deps.onJobFinished(job.id, job.repo);
+    }
+  }
+}

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -8,6 +8,7 @@ import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
 import { StuckJobMonitor } from "./stuck-monitor.js";
+import { JobLifecycle } from "./job-lifecycle.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -108,6 +109,7 @@ export class JobQueue {
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
   private readonly errorTracker = new ProjectErrorTracker();
   private cleanupService: JobCleanupService;
+  private readonly lifecycle: JobLifecycle;
   private lastServedRepo: string | null = null; // round-robin: last repo that was served
   private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
@@ -161,6 +163,23 @@ export class JobQueue {
     // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
     // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
     this.cleanupService = new JobCleanupService(process.cwd());
+
+    // 잡 실행/결과 처리는 JobLifecycle에 위임 (Plan C #C10 Phase 2)
+    this.lifecycle = new JobLifecycle({
+      store: this.store,
+      handler: this.handler,
+      taskFactory: this.taskFactory,
+      errorTracker: this.errorTracker,
+      activeTasks: this.activeTasks,
+      stuckAborted: this.stuckAborted,
+      cancelled: this.cancelled,
+      onJobFinished: (jobId, repo) => {
+        this.running.delete(jobId);
+        this.removeJobFromRepo(jobId, repo);
+        // Process next in queue (defer via setImmediate to avoid deep call stacks)
+        setImmediate(() => this.processNext());
+      },
+    });
 
     // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
     this.stuckMonitor = new StuckJobMonitor({
@@ -503,20 +522,6 @@ export class JobQueue {
   }
 
   /**
-   * Tracks a project failure and potentially pauses the project.
-   */
-  private trackProjectFailure(repo: string): void {
-    this.errorTracker.trackFailure(repo);
-  }
-
-  /**
-   * Tracks a project success and resets failure count.
-   */
-  private trackProjectSuccess(repo: string): void {
-    this.errorTracker.trackSuccess(repo);
-  }
-
-  /**
    * Gets the highest priority job from the pending queue and removes it.
    * Priority order: high (0) > normal (1) > low (2)
    * Within same priority: FIFO (earliest createdAt first)
@@ -721,7 +726,7 @@ export class JobQueue {
         logger.info(`Job started: ${jobId}`);
 
         // Run async - don't await, let it run in background
-        this.executeJob(convertStoreJobToJob(job)).catch((err: unknown) => {
+        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
           logger.error(`Job ${jobId} unexpected error: ${getErrorMessage(err)}`);
         });
       }
@@ -740,84 +745,4 @@ export class JobQueue {
     }
   }
 
-  private async executeJob(job: Job): Promise<void> {
-    try {
-      // Check if already aborted before running handler
-      if (this.stuckAborted.has(job.id)) {
-        this.stuckAborted.delete(job.id);
-        return;
-      }
-
-      let result: { prUrl?: string; error?: string; diagnosis?: DiagnosisReport; userSummary?: UserSummary };
-
-      if (this.taskFactory) {
-        // TaskFactory 경로: AQMTask 생성 후 run() 호출
-        const task = this.taskFactory.createTask(job);
-        this.activeTasks.set(job.id, task);
-        try {
-          result = await (task as unknown as { run(): Promise<{ prUrl?: string; error?: string }> }).run();
-        } finally {
-          this.activeTasks.delete(job.id);
-        }
-      } else {
-        result = await this.handler(job);
-      }
-
-      // Re-check after handler completes — stuck checker may have fired during execution
-      const wasStuckAborted = this.stuckAborted.has(job.id);
-      if (wasStuckAborted) {
-        this.stuckAborted.delete(job.id);
-        logger.warn(`Job ${job.id} handler completed after stuck-abort — updating status but not tracking project metrics`);
-      }
-
-      if (this.cancelled.has(job.id)) {
-        this.cancelled.delete(job.id);
-        // Already marked cancelled
-      } else if (result.error) {
-        this.store.update(job.id, {
-          status: "failure",
-          completedAt: new Date().toISOString(),
-          error: result.error,
-          ...(result.diagnosis ? { diagnosis: result.diagnosis } : {}),
-          ...(result.userSummary ? { userSummary: result.userSummary } : {}),
-        });
-        // Don't track project failure if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectFailure(job.repo);
-        }
-      } else if (result.prUrl) {
-        this.store.update(job.id, {
-          status: "success",
-          completedAt: new Date().toISOString(),
-          prUrl: result.prUrl,
-        });
-        // Don't track project success if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectSuccess(job.repo);
-        }
-      } else {
-        this.store.update(job.id, {
-          status: "failure",
-          completedAt: new Date().toISOString(),
-          error: "Pipeline completed but no PR was created",
-        });
-        // Don't track project failure if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectFailure(job.repo);
-        }
-      }
-    } catch (error: unknown) {
-      this.store.update(job.id, {
-        status: "failure",
-        completedAt: new Date().toISOString(),
-        error: getErrorMessage(error),
-      });
-      this.trackProjectFailure(job.repo);
-    } finally {
-      this.running.delete(job.id);
-      this.removeJobFromRepo(job.id, job.repo);
-      // Process next in queue (defer via setImmediate to avoid deep call stacks)
-      setImmediate(() => this.processNext());
-    }
-  }
 }

--- a/tests/queue/job-lifecycle.test.ts
+++ b/tests/queue/job-lifecycle.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JobLifecycle, type JobHandler } from "../../src/queue/job-lifecycle.js";
+import type { JobStore } from "../../src/queue/job-store.js";
+import type { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+import type { TaskFactory } from "../../src/tasks/task-factory.js";
+import type { AQMTask } from "../../src/tasks/aqm-task.js";
+import type { Job } from "../../src/types/pipeline.js";
+
+function makeStore(): JobStore {
+  return {
+    update: vi.fn(),
+  } as unknown as JobStore;
+}
+
+function makeTracker(): ProjectErrorTracker {
+  return {
+    trackFailure: vi.fn(),
+    trackSuccess: vi.fn(),
+  } as unknown as ProjectErrorTracker;
+}
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    issueNumber: 1,
+    repo: "a/b",
+    status: "running",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastUpdatedAt: "2025-01-01T00:00:00.000Z",
+    startedAt: "2025-01-01T00:00:00.000Z",
+    logs: [],
+    currentStep: null,
+    ...overrides,
+  } as unknown as Job;
+}
+
+describe("JobLifecycle", () => {
+  let store: JobStore;
+  let errorTracker: ProjectErrorTracker;
+  let activeTasks: Map<string, AQMTask>;
+  let stuckAborted: Set<string>;
+  let cancelled: Set<string>;
+  let onJobFinished: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = makeStore();
+    errorTracker = makeTracker();
+    activeTasks = new Map();
+    stuckAborted = new Set();
+    cancelled = new Set();
+    onJobFinished = vi.fn();
+  });
+
+  function makeLifecycle(handler: JobHandler, taskFactory?: TaskFactory) {
+    return new JobLifecycle({
+      store,
+      handler,
+      taskFactory,
+      errorTracker,
+      activeTasks,
+      stuckAborted,
+      cancelled,
+      onJobFinished,
+    });
+  }
+
+  it("성공 결과(prUrl)는 success로 update + trackSuccess", async () => {
+    const handler: JobHandler = vi.fn(async () => ({ prUrl: "https://github.com/x/y/pull/1" }));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(handler).toHaveBeenCalled();
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "success", prUrl: "https://github.com/x/y/pull/1" })
+    );
+    expect(errorTracker.trackSuccess).toHaveBeenCalledWith("a/b");
+    expect(errorTracker.trackFailure).not.toHaveBeenCalled();
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("error 결과는 failure로 update + trackFailure + diagnosis/userSummary 전파", async () => {
+    const handler: JobHandler = vi.fn(async () => ({
+      error: "boom",
+      diagnosis: { rootCause: "x" } as never,
+      userSummary: { headline: "y" } as never,
+    }));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        status: "failure",
+        error: "boom",
+        diagnosis: { rootCause: "x" },
+        userSummary: { headline: "y" },
+      })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("prUrl도 error도 없으면 'no PR was created' 실패", async () => {
+    const handler: JobHandler = vi.fn(async () => ({}));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        status: "failure",
+        error: "Pipeline completed but no PR was created",
+      })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+  });
+
+  it("실행 시작 시 stuckAborted면 handler 호출하지 않고 종료(onJobFinished는 호출됨)", async () => {
+    stuckAborted.add("job-1");
+    const handler: JobHandler = vi.fn();
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(store.update).not.toHaveBeenCalled();
+    expect(stuckAborted.has("job-1")).toBe(false); // 플래그 클리어
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("handler 도중 stuckAborted 발화 시 status update는 하되 trackFailure 스킵", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      stuckAborted.add("job-1");
+      return { error: "boom" };
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "boom" })
+    );
+    expect(errorTracker.trackFailure).not.toHaveBeenCalled();
+    expect(stuckAborted.has("job-1")).toBe(false);
+  });
+
+  it("cancelled 플래그 set 상태에서 handler가 끝나면 store update 스킵 + 플래그 클리어", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      cancelled.add("job-1");
+      return { prUrl: "ignored" };
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).not.toHaveBeenCalled();
+    expect(cancelled.has("job-1")).toBe(false);
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("handler 예외 발생 시 failure로 update + trackFailure + onJobFinished 보장", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      throw new Error("kaboom");
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "kaboom" })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("taskFactory 경로: createTask로 만든 task.run()을 호출하고 activeTasks에 추가/제거", async () => {
+    const runMock = vi.fn(async () => ({ prUrl: "https://x" }));
+    const killMock = vi.fn();
+    const fakeTask = { run: runMock, kill: killMock } as unknown as AQMTask;
+    const taskFactory = {
+      createTask: vi.fn(() => fakeTask),
+    } as unknown as TaskFactory;
+
+    const handler: JobHandler = vi.fn();
+    const lifecycle = makeLifecycle(handler, taskFactory);
+
+    const finishedActiveTasks: Map<string, AQMTask>[] = [];
+    onJobFinished.mockImplementation(() => {
+      finishedActiveTasks.push(new Map(activeTasks));
+    });
+
+    await lifecycle.execute(makeJob());
+
+    expect(taskFactory.createTask).toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(activeTasks.has("job-1")).toBe(false); // run 후 제거
+    // onJobFinished 시점에도 이미 빠져 있어야 함
+    expect(finishedActiveTasks[0]?.has("job-1")).toBe(false);
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "success", prUrl: "https://x" })
+    );
+  });
+
+  it("taskFactory.run()이 throw해도 activeTasks 정리 + onJobFinished 호출", async () => {
+    const runMock = vi.fn(async () => {
+      throw new Error("task-boom");
+    });
+    const fakeTask = { run: runMock, kill: vi.fn() } as unknown as AQMTask;
+    const taskFactory = {
+      createTask: vi.fn(() => fakeTask),
+    } as unknown as TaskFactory;
+
+    const lifecycle = makeLifecycle(vi.fn(), taskFactory);
+
+    await lifecycle.execute(makeJob());
+
+    expect(activeTasks.has("job-1")).toBe(false);
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "task-boom" })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+});


### PR DESCRIPTION
## Summary
- `executeJob` + 결과 처리 책임을 신규 `JobLifecycle` 클래스로 추출
- 공유 상태(running/runningByRepo/processNext)는 `onJobFinished` 콜백으로 분리
- `trackProjectFailure/Success` 사적 wrapper 제거 → errorTracker 직접 호출
- `job-queue.ts` 823 → 748줄 (-75)

## 변경 파일
- 신규: `src/queue/job-lifecycle.ts` (134줄)
- 신규: `tests/queue/job-lifecycle.test.ts` (9 tests)
- 수정: `src/queue/job-queue.ts` (-75)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3394 passed / 7 skipped / 0 failed
- [x] `npm run lint` — clean
- [x] `tests/queue/job-lifecycle.test.ts` 9 tests (성공/실패/예외/stuck/cancel/taskFactory)
- [x] `tests/queue/job-queue.test.ts` 67 tests 회귀 통과

## Plan C 진행
- Phase 1 (StuckJobMonitor): #817 merged
- Phase 2 (JobLifecycle): **본 PR**
- Phase 3 (JobScheduler): 후속 PR 예정 — pending/running/round-robin 추출 + 생성자 옵션 객체화 + process.cwd() fallback 0건 달성