### PR TITLE
refactor(queue): JobScheduler 추출 + process.cwd() 0건 (Plan C #C10 Phase 3)

### DIFF
--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -2,13 +2,13 @@ import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
-import { areDependenciesMet } from "./dependency-resolver.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
 import { StuckJobMonitor } from "./stuck-monitor.js";
 import { JobLifecycle } from "./job-lifecycle.js";
+import { JobScheduler } from "./job-scheduler.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -91,39 +91,30 @@ function convertStoreJobToJob(storeJob: StoreJob): Job {
 const STUCK_CHECK_INTERVAL_MS = 60 * 1000; // check every minute
 
 export class JobQueue {
-  private pending: string[] = [];  // job IDs
-  private running: Set<string> = new Set();
   private store: JobStore;
-  private concurrency: number;
   private handler: JobHandler;
   private cancelled: Set<string> = new Set();
-  private readonly stuckMonitor: StuckJobMonitor;
-  private stuckTimeoutMs: number;
-  private stuckThresholds?: StuckThresholdConfig;
-  private shuttingDown: boolean = false;
   private stuckAborted: Set<string> = new Set();
-  private isProcessing: boolean = false;
-  private needsReprocess: boolean = false;
-  private processingJobs: Set<string> = new Set(); // jobs temporarily removed during processNext
-  private projectConcurrency: Map<string, number> = new Map(); // repo -> concurrency limit
-  private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
-  private readonly errorTracker = new ProjectErrorTracker();
-  private cleanupService: JobCleanupService;
-  private readonly lifecycle: JobLifecycle;
-  private lastServedRepo: string | null = null; // round-robin: last repo that was served
-  private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
+  private taskFactory?: TaskFactory;
+  private shuttingDown: boolean = false;
+  private readonly errorTracker = new ProjectErrorTracker();
+  private cleanupService?: JobCleanupService; // setDependencies 호출 후 활성화
+  private readonly scheduler: JobScheduler;
+  private readonly lifecycle: JobLifecycle;
+  private readonly stuckMonitor: StuckJobMonitor;
   private projectRoot?: string;
   private configProvider?: ConfigProvider;
 
   /**
-   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6).
+   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6/#C10).
    *
    * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서 호출하면
    * `JobCleanupService`/`ProjectErrorTracker`가 활성화된다. 테스트는 호출하지 않으면
    * cleanupService 미설정 → cleanup no-op, errorTracker는 configProvider 없이 기본 임계값으로 동작.
    *
-   * Plan C #C6에서 `process.cwd()` fallback과 `loadConfig` 직접 호출이 모두 제거됐다.
+   * Plan C #C10 Phase 3에서 `process.cwd()` fallback이 완전히 제거됐다. 호출하지 않으면
+   * cleanup이 그냥 동작하지 않으며, 어떤 디렉터리도 가정하지 않는다.
    */
   setDependencies(deps: { projectRoot?: string; configProvider?: ConfigProvider }): void {
     if (deps.projectRoot) this.projectRoot = deps.projectRoot;
@@ -131,11 +122,9 @@ export class JobQueue {
       this.configProvider = deps.configProvider;
       this.errorTracker.setConfigProvider(deps.configProvider);
     }
-    // cleanupService는 항상 갱신해 최신 의존성을 사용한다.
-    this.cleanupService = new JobCleanupService(
-      this.projectRoot ?? process.cwd(),
-      this.configProvider
-    );
+    if (this.projectRoot) {
+      this.cleanupService = new JobCleanupService(this.projectRoot, this.configProvider);
+    }
   }
 
   constructor(
@@ -148,21 +137,22 @@ export class JobQueue {
     stuckThresholds?: StuckThresholdConfig
   ) {
     this.store = store;
-    this.concurrency = concurrency;
     this.handler = handler;
-    this.stuckTimeoutMs = stuckTimeoutMs;
-    this.stuckThresholds = stuckThresholds;
     this.taskFactory = taskFactory;
 
-    if (projectConcurrency) {
-      Object.entries(projectConcurrency).forEach(([repo, limit]) => {
-        this.projectConcurrency.set(repo, limit);
-      });
-    }
-
-    // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
-    // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
-    this.cleanupService = new JobCleanupService(process.cwd());
+    // 스케줄링 책임은 JobScheduler에 위임 (Plan C #C10 Phase 3)
+    this.scheduler = new JobScheduler({
+      store: this.store,
+      errorTracker: this.errorTracker,
+      concurrency,
+      projectConcurrency,
+      cancelledRef: this.cancelled,
+      onStartJob: (job) => {
+        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
+          logger.error(`Job ${job.id} unexpected error: ${getErrorMessage(err)}`);
+        });
+      },
+    });
 
     // 잡 실행/결과 처리는 JobLifecycle에 위임 (Plan C #C10 Phase 2)
     this.lifecycle = new JobLifecycle({
@@ -174,20 +164,17 @@ export class JobQueue {
       stuckAborted: this.stuckAborted,
       cancelled: this.cancelled,
       onJobFinished: (jobId, repo) => {
-        this.running.delete(jobId);
-        this.removeJobFromRepo(jobId, repo);
-        // Process next in queue (defer via setImmediate to avoid deep call stacks)
-        setImmediate(() => this.processNext());
+        this.scheduler.markJobFinished(jobId, repo);
       },
     });
 
-    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
+    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10 Phase 1)
     this.stuckMonitor = new StuckJobMonitor({
       store: this.store,
-      stuckTimeoutMs: this.stuckTimeoutMs,
-      stuckThresholds: this.stuckThresholds,
+      stuckTimeoutMs,
+      stuckThresholds,
       checkIntervalMs: STUCK_CHECK_INTERVAL_MS,
-      getRunningJobIds: () => this.running,
+      getRunningJobIds: () => this.scheduler.getRunningIds(),
       toJob: convertStoreJobToJob,
       onStuckDetected: (jobId, reason) => {
         this.store.update(jobId, {
@@ -196,8 +183,7 @@ export class JobQueue {
           error: reason,
         });
         this.stuckAborted.add(jobId);
-        this.running.delete(jobId);
-        setTimeout(() => this.processNext(), 0);
+        this.scheduler.markStuckAborted(jobId);
       },
     });
     this.stuckMonitor.start();
@@ -207,7 +193,7 @@ export class JobQueue {
    * Marks a job as stuck-aborted so executeJob can detect it after the handler returns.
    */
   abortJob(jobId: string): boolean {
-    if (this.running.has(jobId)) {
+    if (this.scheduler.isRunning(jobId)) {
       this.stuckAborted.add(jobId);
       return true;
     }
@@ -221,20 +207,20 @@ export class JobQueue {
   shutdown(timeoutMs: number = 30000): Promise<void> {
     this.shuttingDown = true;
     this.stuckMonitor.stop();
-    if (this.running.size === 0) {
+    if (this.scheduler.runningCount === 0) {
       return Promise.resolve();
     }
     return new Promise((resolve) => {
       const start = Date.now();
       const check = setInterval(() => {
-        if (this.running.size === 0) {
+        if (this.scheduler.runningCount === 0) {
           clearInterval(check);
           resolve();
           return;
         }
         if (Date.now() - start >= timeoutMs) {
           clearInterval(check);
-          logger.warn(`Shutdown timeout: ${this.running.size} job(s) still running after ${timeoutMs / 1000}s`);
+          logger.warn(`Shutdown timeout: ${this.scheduler.runningCount} job(s) still running after ${timeoutMs / 1000}s`);
           resolve();
         }
       }, 1000);
@@ -257,11 +243,11 @@ export class JobQueue {
       if (isRunningJob(job)) {
         // Was running when server died — reset to queued
         this.store.update(job.id, { status: "queued", startedAt: undefined });
-        this.pending.push(job.id);
+        this.scheduler.pushPending(job.id);
         recovered++;
         logger.info(`Job recovered (was running): ${job.id}`);
       } else if (isQueuedJob(job)) {
-        this.pending.push(job.id);
+        this.scheduler.pushPending(job.id);
         recovered++;
         logger.info(`Job recovered (was queued): ${job.id}`);
       }
@@ -269,7 +255,7 @@ export class JobQueue {
 
     if (recovered > 0) {
       logger.info(`Recovered ${recovered} job(s) from previous session`);
-      this.processNext();
+      void this.scheduler.processNext();
     }
 
     return recovered;
@@ -278,10 +264,10 @@ export class JobQueue {
 
   /**
    * 실패 잡 정리 — JobCleanupService에 위임 (Plan C #C6).
-   * 호출부는 fire-and-forget(`void this.cleanupFailedJobArtifacts(...)`) 또는
-   * await(retryJob의 race 차단) 형태로 사용한다.
+   * setDependencies 전에는 no-op (테스트 환경 호환).
    */
   private async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    if (!this.cleanupService) return;
     await this.cleanupService.cleanupFailedJobArtifacts(issueNumber);
   }
 
@@ -319,13 +305,11 @@ export class JobQueue {
     }
 
     const job = this.store.create(issueNumber, repo, dependencies, isRetry, initialPhaseResults, priority, triggerReason);
-    // Convert StoreJob to discriminated union Job type
     const snapshot = convertStoreJobToJob(job);
-    this.pending.push(job.id);
-    logger.info(`Job enqueued: ${job.id} (pending: ${this.pending.length}, running: ${this.running.size})`);
+    const status = this.scheduler.getStatus();
+    logger.info(`Job enqueued: ${job.id} (pending: ${status.pending + 1}, running: ${status.running})`);
 
-    // Try to process next
-    this.processNext();
+    this.scheduler.enqueue(job.id);
 
     return snapshot;
   }
@@ -374,16 +358,14 @@ export class JobQueue {
    */
   cancel(jobId: string): boolean {
     // Remove from pending
-    const pendingIdx = this.pending.indexOf(jobId);
-    if (pendingIdx >= 0) {
-      this.pending.splice(pendingIdx, 1);
+    if (this.scheduler.removePending(jobId)) {
       this.store.update(jobId, { status: "cancelled", completedAt: new Date().toISOString() });
       logger.info(`Job cancelled (was pending): ${jobId}`);
       return true;
     }
 
     // Mark running job for cancellation
-    if (this.running.has(jobId)) {
+    if (this.scheduler.isRunning(jobId)) {
       this.cancelled.add(jobId);
       this.store.update(jobId, { status: "cancelled", completedAt: new Date().toISOString() });
       // Kill active task if tracked
@@ -411,20 +393,7 @@ export class JobQueue {
    * Sets the concurrency limit and immediately processes pending jobs if capacity allows.
    */
   setConcurrency(n: number): void {
-    if (n <= 0 || !Number.isInteger(n)) {
-      throw new Error("Concurrency must be a positive integer");
-    }
-
-    this.concurrency = n;
-    logger.info(`Concurrency updated to ${n}`);
-
-    // Trigger immediate processing if we now have more capacity
-    this.processNext();
-
-    // If processNext is already running (re-entrancy), ensure it gets called again
-    if (this.isProcessing && !this.needsReprocess) {
-      this.needsReprocess = true;
-    }
+    this.scheduler.setConcurrency(n);
   }
 
   /**
@@ -432,62 +401,14 @@ export class JobQueue {
    * Pass null to remove the project-specific limit.
    */
   setProjectConcurrency(repo: string, limit: number | null): void {
-    if (limit !== null && (limit <= 0 || !Number.isInteger(limit))) {
-      throw new Error("Project concurrency limit must be a positive integer");
-    }
-
-    if (limit === null) {
-      this.projectConcurrency.delete(repo);
-      logger.info(`Project concurrency limit removed for ${repo}`);
-    } else {
-      this.projectConcurrency.set(repo, limit);
-      logger.info(`Project concurrency limit for ${repo} set to ${limit}`);
-    }
-
-    // Trigger immediate processing in case capacity increased
-    this.processNext();
+    this.scheduler.setProjectConcurrency(repo, limit);
   }
 
   /**
    * Returns queue status.
    */
   getStatus(): { pending: number; running: number; concurrency: number } {
-    return {
-      pending: this.pending.length + this.processingJobs.size,
-      running: this.running.size,
-      concurrency: this.concurrency,
-    };
-  }
-
-  /**
-   * Checks if a new job can be started for the given repo based on project-specific concurrency limits.
-   */
-  private canStartJobForRepo(repo: string): boolean {
-    const projectLimit = this.projectConcurrency.get(repo);
-    if (!projectLimit) {
-      return true;
-    }
-    const currentRunning = this.runningByRepo.get(repo) ?? 0;
-    return currentRunning < projectLimit;
-  }
-
-  /**
-   * Increments the running count for a repo.
-   */
-  private addJobToRepo(jobId: string, repo: string): void {
-    this.runningByRepo.set(repo, (this.runningByRepo.get(repo) ?? 0) + 1);
-  }
-
-  /**
-   * Decrements the running count for a repo.
-   */
-  private removeJobFromRepo(jobId: string, repo: string): void {
-    const current = this.runningByRepo.get(repo) ?? 0;
-    if (current > 1) {
-      this.runningByRepo.set(repo, current - 1);
-    } else {
-      this.runningByRepo.delete(repo);
-    }
+    return this.scheduler.getStatus();
   }
 
   // Plan C #C6: 프로젝트 실패 추적/일시 정지 로직은 ProjectErrorTracker로 응집됨.
@@ -520,229 +441,4 @@ export class JobQueue {
   getProjectStatus(repo: string): ProjectErrorState | null {
     return this.errorTracker.getProjectStatus(repo);
   }
-
-  /**
-   * Gets the highest priority job from the pending queue and removes it.
-   * Priority order: high (0) > normal (1) > low (2)
-   * Within same priority: FIFO (earliest createdAt first)
-   * Missing priority defaults to 'normal'
-   */
-  private getNextPriorityJob(): string | null {
-    if (this.pending.length === 0) return null;
-
-    let bestIndex = -1;
-    let bestPriorityValue = 3; // Lower than 'low' (2)
-    let bestCreatedAt = '';
-
-    // Find the job with highest priority (lowest numeric value)
-    for (let i = 0; i < this.pending.length; i++) {
-      const jobId = this.pending[i];
-      const job = this.store.get(jobId);
-      if (!job) continue;
-
-      // Map priority to numeric value for comparison: high=0, normal=1, low=2
-      const priority = job.priority ?? 'normal';
-      const priorityValue = priority === 'high' ? 0 : priority === 'normal' ? 1 : 2;
-
-      // Select if higher priority, or same priority but earlier created, or first job
-      if (bestIndex === -1 ||
-          priorityValue < bestPriorityValue ||
-          (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)) {
-        bestIndex = i;
-        bestPriorityValue = priorityValue;
-        bestCreatedAt = job.createdAt;
-      }
-    }
-
-    if (bestIndex >= 0) {
-      return this.pending.splice(bestIndex, 1)[0];
-    }
-    return null;
-  }
-
-  /**
-   * Gets the next job using round-robin scheduling across projects.
-   * Cycles through repos starting after lastServedRepo, and within each repo
-   * selects the highest-priority job (FIFO within same priority).
-   */
-  private getNextRoundRobinJob(): string | null {
-    if (this.pending.length === 0) return null;
-
-    // Build ordered repo list and group jobs by repo (preserving insertion order)
-    const repoOrder: string[] = [];
-    const jobsByRepo = new Map<string, string[]>();
-    for (const jobId of this.pending) {
-      const job = this.store.get(jobId);
-      if (!job) continue;
-      if (!jobsByRepo.has(job.repo)) {
-        repoOrder.push(job.repo);
-        jobsByRepo.set(job.repo, []);
-      }
-      jobsByRepo.get(job.repo)!.push(jobId);
-    }
-
-    if (repoOrder.length === 0) return null;
-
-    // Determine starting index: one after lastServedRepo
-    let startIndex = 0;
-    if (this.lastServedRepo !== null) {
-      const lastIdx = repoOrder.indexOf(this.lastServedRepo);
-      if (lastIdx >= 0) {
-        startIndex = (lastIdx + 1) % repoOrder.length;
-      }
-    }
-
-    // Cycle through repos to find the next one with eligible jobs
-    for (let i = 0; i < repoOrder.length; i++) {
-      const repo = repoOrder[(startIndex + i) % repoOrder.length];
-      const repoJobs = jobsByRepo.get(repo);
-      if (!repoJobs || repoJobs.length === 0) continue;
-
-      // Select highest-priority job within this repo (FIFO within same priority)
-      let bestIndex = -1;
-      let bestPriorityValue = 3;
-      let bestCreatedAt = '';
-
-      for (let j = 0; j < repoJobs.length; j++) {
-        const jobId = repoJobs[j];
-        const job = this.store.get(jobId);
-        if (!job) continue;
-
-        const priority = job.priority ?? 'normal';
-        const priorityValue = priority === 'high' ? 0 : priority === 'normal' ? 1 : 2;
-
-        if (bestIndex === -1 ||
-            priorityValue < bestPriorityValue ||
-            (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)) {
-          bestIndex = j;
-          bestPriorityValue = priorityValue;
-          bestCreatedAt = job.createdAt;
-        }
-      }
-
-      if (bestIndex >= 0) {
-        const selectedJobId = repoJobs[bestIndex];
-        const pendingIdx = this.pending.indexOf(selectedJobId);
-        if (pendingIdx >= 0) {
-          this.pending.splice(pendingIdx, 1);
-        }
-        this.lastServedRepo = repo;
-        return selectedJobId;
-      }
-    }
-
-    return null;
-  }
-
-  private async processNext(): Promise<void> {
-    // Bail out if the store has been closed (e.g., during test teardown)
-    if (this.store.isClosed) return;
-
-    // Prevent re-entrancy
-    if (this.isProcessing) {
-      this.needsReprocess = true;
-      return;
-    }
-
-    this.isProcessing = true;
-    this.needsReprocess = false;
-
-    try {
-      // Collect job IDs that are skipped due to unmet dependencies (put back at end)
-      const deferred: string[] = [];
-
-      while (this.running.size < this.concurrency && this.pending.length > 0) {
-        const jobId = this.getNextRoundRobinJob();
-        if (!jobId) break; // No valid jobs available
-
-        // Track job as being processed
-        this.processingJobs.add(jobId);
-
-        if (this.cancelled.has(jobId)) {
-          this.cancelled.delete(jobId);
-          this.processingJobs.delete(jobId);
-          continue;
-        }
-
-        const job = this.store.get(jobId);
-        if (!job) {
-          this.processingJobs.delete(jobId);
-          continue;
-        }
-
-        // Check dependency readiness
-        if (job.dependencies && job.dependencies.length > 0) {
-          const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.store);
-          if (!met) {
-            // Check if any dependency has permanently failed — fail the dependent job immediately
-            let depFailed = false;
-            for (const depNum of job.dependencies) {
-              const depJob = this.store.findAnyByIssue(depNum, job.repo);
-              if (depJob && (isFailureJob(depJob) || isCancelledJob(depJob))) {
-                logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
-                this.store.update(jobId, {
-                  status: "failure",
-                  completedAt: new Date().toISOString(),
-                  error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
-                });
-                depFailed = true;
-                break;
-              }
-            }
-            if (!depFailed) {
-              logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
-              this.processingJobs.delete(jobId);
-              deferred.push(jobId);
-            } else {
-              this.processingJobs.delete(jobId);
-            }
-            continue;
-          }
-        }
-
-        // Check project-specific concurrency limits
-        if (!this.canStartJobForRepo(job.repo)) {
-          logger.info(`Job ${jobId} deferred due to project concurrency limit for repo ${job.repo}`);
-          this.processingJobs.delete(jobId);
-          deferred.push(jobId);
-          continue;
-        }
-
-        // Check if project is paused due to consecutive failures
-        if (this.isProjectPaused(job.repo)) {
-          const errorState = this.errorTracker.getProjectStatus(job.repo);
-          const remainingMs = errorState!.pausedUntil! - Date.now();
-          logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
-          this.processingJobs.delete(jobId);
-          deferred.push(jobId);
-          continue;
-        }
-
-        this.running.add(jobId);
-        this.addJobToRepo(jobId, job.repo);
-        this.processingJobs.delete(jobId);
-        this.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
-
-        logger.info(`Job started: ${jobId}`);
-
-        // Run async - don't await, let it run in background
-        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
-          logger.error(`Job ${jobId} unexpected error: ${getErrorMessage(err)}`);
-        });
-      }
-
-      // Re-append deferred jobs so they are retried on the next processNext() call
-      for (const jobId of deferred) {
-        this.pending.push(jobId);
-      }
-    } finally {
-      this.isProcessing = false;
-
-      // If another call was made while processing, handle it now
-      if (this.needsReprocess) {
-        setImmediate(() => this.processNext());
-      }
-    }
-  }
-
 }

--- a/src/queue/job-scheduler.ts
+++ b/src/queue/job-scheduler.ts
@@ -1,0 +1,333 @@
+import { getLogger } from "../utils/logger.js";
+import type { JobStore, Job as StoreJob } from "./job-store.js";
+import { isFailureJob, isCancelledJob } from "../types/pipeline.js";
+import type { ProjectErrorTracker } from "./project-error-tracker.js";
+import { areDependenciesMet } from "./dependency-resolver.js";
+
+const logger = getLogger();
+
+/**
+ * 잡 스케줄링 책임 (Plan C #C10 — Phase 3).
+ *
+ * 이전: `JobQueue`가 pending/running/processingJobs/runningByRepo/lastServedRepo,
+ *      그리고 round-robin + 우선순위 + dependency/project concurrency/pause 가드
+ *      로직을 모두 보관했다.
+ * 이후: 본 클래스가 큐 상태와 스케줄링 알고리즘을 응집한다. JobQueue는
+ *      `onStartJob` 콜백을 통해 실제 잡 실행(`JobLifecycle`)으로 위임한다.
+ *
+ * cancelledRef는 `JobQueue.cancel()`이 set하고 scheduler가 processNext에서
+ * 한 번 소비하는 공유 set이다. lifecycle은 별도 cancelled set을 본다 (이중 클리어 안전).
+ */
+export interface JobSchedulerOptions {
+  store: JobStore;
+  errorTracker: ProjectErrorTracker;
+  concurrency: number;
+  projectConcurrency?: Record<string, number>;
+  /** scheduler가 잡을 시작하기로 결정했을 때 호출. JobQueue가 lifecycle.execute로 위임. */
+  onStartJob: (job: StoreJob) => void;
+  /** JobQueue.cancel()과 공유되는 cancel 플래그. processNext에서 소비. */
+  cancelledRef: Set<string>;
+}
+
+export class JobScheduler {
+  private readonly pending: string[] = [];
+  private readonly running: Set<string> = new Set();
+  private readonly processingJobs: Set<string> = new Set();
+  private readonly projectConcurrency: Map<string, number> = new Map();
+  private readonly runningByRepo: Map<string, number> = new Map();
+  private lastServedRepo: string | null = null;
+  private concurrency: number;
+  private isProcessing: boolean = false;
+  private needsReprocess: boolean = false;
+
+  constructor(private readonly opts: JobSchedulerOptions) {
+    this.concurrency = opts.concurrency;
+    if (opts.projectConcurrency) {
+      Object.entries(opts.projectConcurrency).forEach(([repo, limit]) => {
+        this.projectConcurrency.set(repo, limit);
+      });
+    }
+  }
+
+  // ─── queries ───────────────────────────────────────────────
+
+  get runningCount(): number {
+    return this.running.size;
+  }
+
+  isRunning(jobId: string): boolean {
+    return this.running.has(jobId);
+  }
+
+  /** stuck monitor가 매 체크마다 호출. 직접 set을 노출해 추가 복사를 피한다. */
+  getRunningIds(): Iterable<string> {
+    return this.running;
+  }
+
+  getStatus(): { pending: number; running: number; concurrency: number } {
+    return {
+      pending: this.pending.length + this.processingJobs.size,
+      running: this.running.size,
+      concurrency: this.concurrency,
+    };
+  }
+
+  // ─── pending/queue mutations ───────────────────────────────
+
+  /** 새 잡 진입. 즉시 processNext 호출. */
+  enqueue(jobId: string): void {
+    this.pending.push(jobId);
+    void this.processNext();
+  }
+
+  /** 재시작 복구용 — pending에 push만 하고 processNext는 caller가 결정. */
+  pushPending(jobId: string): void {
+    this.pending.push(jobId);
+  }
+
+  /** pending 큐에서 제거. cancel 처리에서 사용. */
+  removePending(jobId: string): boolean {
+    const idx = this.pending.indexOf(jobId);
+    if (idx >= 0) {
+      this.pending.splice(idx, 1);
+      return true;
+    }
+    return false;
+  }
+
+  // ─── concurrency knobs ─────────────────────────────────────
+
+  setConcurrency(n: number): void {
+    if (n <= 0 || !Number.isInteger(n)) {
+      throw new Error("Concurrency must be a positive integer");
+    }
+    this.concurrency = n;
+    logger.info(`Concurrency updated to ${n}`);
+    void this.processNext();
+    if (this.isProcessing && !this.needsReprocess) {
+      this.needsReprocess = true;
+    }
+  }
+
+  setProjectConcurrency(repo: string, limit: number | null): void {
+    if (limit !== null && (limit <= 0 || !Number.isInteger(limit))) {
+      throw new Error("Project concurrency limit must be a positive integer");
+    }
+    if (limit === null) {
+      this.projectConcurrency.delete(repo);
+      logger.info(`Project concurrency limit removed for ${repo}`);
+    } else {
+      this.projectConcurrency.set(repo, limit);
+      logger.info(`Project concurrency limit for ${repo} set to ${limit}`);
+    }
+    void this.processNext();
+  }
+
+  // ─── lifecycle hooks ───────────────────────────────────────
+
+  /** lifecycle 종료 시 호출 — running/runningByRepo 정리 + 다음 잡 처리. */
+  markJobFinished(jobId: string, repo: string): void {
+    this.running.delete(jobId);
+    this.removeJobFromRepo(repo);
+    setImmediate(() => this.processNext());
+  }
+
+  /**
+   * stuck-aborted 처리: running에서 즉시 제거 + 다음 처리 트리거.
+   * runningByRepo는 lifecycle finally의 markJobFinished가 처리하므로 여기서 건드리지 않는다
+   * (handler가 stuck 후에도 어쨌든 끝나면 lifecycle이 onJobFinished로 들어옴).
+   */
+  markStuckAborted(jobId: string): void {
+    this.running.delete(jobId);
+    setTimeout(() => this.processNext(), 0);
+  }
+
+  // ─── core scheduling ───────────────────────────────────────
+
+  async processNext(): Promise<void> {
+    if (this.opts.store.isClosed) return;
+
+    if (this.isProcessing) {
+      this.needsReprocess = true;
+      return;
+    }
+    this.isProcessing = true;
+    this.needsReprocess = false;
+
+    try {
+      const deferred: string[] = [];
+
+      while (this.running.size < this.concurrency && this.pending.length > 0) {
+        const jobId = this.getNextRoundRobinJob();
+        if (!jobId) break;
+
+        this.processingJobs.add(jobId);
+
+        if (this.opts.cancelledRef.has(jobId)) {
+          this.opts.cancelledRef.delete(jobId);
+          this.processingJobs.delete(jobId);
+          continue;
+        }
+
+        const job = this.opts.store.get(jobId);
+        if (!job) {
+          this.processingJobs.delete(jobId);
+          continue;
+        }
+
+        if (job.dependencies && job.dependencies.length > 0) {
+          const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.opts.store);
+          if (!met) {
+            let depFailed = false;
+            for (const depNum of job.dependencies) {
+              const depJob = this.opts.store.findAnyByIssue(depNum, job.repo);
+              if (depJob && (isFailureJob(depJob) || isCancelledJob(depJob))) {
+                logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
+                this.opts.store.update(jobId, {
+                  status: "failure",
+                  completedAt: new Date().toISOString(),
+                  error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
+                });
+                depFailed = true;
+                break;
+              }
+            }
+            if (!depFailed) {
+              logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
+              this.processingJobs.delete(jobId);
+              deferred.push(jobId);
+            } else {
+              this.processingJobs.delete(jobId);
+            }
+            continue;
+          }
+        }
+
+        if (!this.canStartJobForRepo(job.repo)) {
+          logger.info(`Job ${jobId} deferred due to project concurrency limit for repo ${job.repo}`);
+          this.processingJobs.delete(jobId);
+          deferred.push(jobId);
+          continue;
+        }
+
+        if (this.opts.errorTracker.isProjectPaused(job.repo)) {
+          const errorState = this.opts.errorTracker.getProjectStatus(job.repo);
+          const remainingMs = errorState!.pausedUntil! - Date.now();
+          logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
+          this.processingJobs.delete(jobId);
+          deferred.push(jobId);
+          continue;
+        }
+
+        this.running.add(jobId);
+        this.addJobToRepo(job.repo);
+        this.processingJobs.delete(jobId);
+        this.opts.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
+        logger.info(`Job started: ${jobId}`);
+        this.opts.onStartJob(job);
+      }
+
+      for (const jobId of deferred) {
+        this.pending.push(jobId);
+      }
+    } finally {
+      this.isProcessing = false;
+      if (this.needsReprocess) {
+        setImmediate(() => this.processNext());
+      }
+    }
+  }
+
+  // ─── private helpers ───────────────────────────────────────
+
+  private canStartJobForRepo(repo: string): boolean {
+    const projectLimit = this.projectConcurrency.get(repo);
+    if (!projectLimit) return true;
+    const currentRunning = this.runningByRepo.get(repo) ?? 0;
+    return currentRunning < projectLimit;
+  }
+
+  private addJobToRepo(repo: string): void {
+    this.runningByRepo.set(repo, (this.runningByRepo.get(repo) ?? 0) + 1);
+  }
+
+  private removeJobFromRepo(repo: string): void {
+    const current = this.runningByRepo.get(repo) ?? 0;
+    if (current > 1) {
+      this.runningByRepo.set(repo, current - 1);
+    } else {
+      this.runningByRepo.delete(repo);
+    }
+  }
+
+  /**
+   * Round-robin: 마지막에 서빙한 repo 다음부터 순환하며, 각 repo 내에서는
+   * priority(high>normal>low) → createdAt(FIFO) 순으로 선택한다.
+   */
+  private getNextRoundRobinJob(): string | null {
+    if (this.pending.length === 0) return null;
+
+    const repoOrder: string[] = [];
+    const jobsByRepo = new Map<string, string[]>();
+    for (const jobId of this.pending) {
+      const job = this.opts.store.get(jobId);
+      if (!job) continue;
+      if (!jobsByRepo.has(job.repo)) {
+        repoOrder.push(job.repo);
+        jobsByRepo.set(job.repo, []);
+      }
+      jobsByRepo.get(job.repo)!.push(jobId);
+    }
+
+    if (repoOrder.length === 0) return null;
+
+    let startIndex = 0;
+    if (this.lastServedRepo !== null) {
+      const lastIdx = repoOrder.indexOf(this.lastServedRepo);
+      if (lastIdx >= 0) {
+        startIndex = (lastIdx + 1) % repoOrder.length;
+      }
+    }
+
+    for (let i = 0; i < repoOrder.length; i++) {
+      const repo = repoOrder[(startIndex + i) % repoOrder.length];
+      const repoJobs = jobsByRepo.get(repo);
+      if (!repoJobs || repoJobs.length === 0) continue;
+
+      let bestIndex = -1;
+      let bestPriorityValue = 3;
+      let bestCreatedAt = "";
+
+      for (let j = 0; j < repoJobs.length; j++) {
+        const jobId = repoJobs[j];
+        const job = this.opts.store.get(jobId);
+        if (!job) continue;
+
+        const priority = job.priority ?? "normal";
+        const priorityValue = priority === "high" ? 0 : priority === "normal" ? 1 : 2;
+
+        if (
+          bestIndex === -1 ||
+          priorityValue < bestPriorityValue ||
+          (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)
+        ) {
+          bestIndex = j;
+          bestPriorityValue = priorityValue;
+          bestCreatedAt = job.createdAt;
+        }
+      }
+
+      if (bestIndex >= 0) {
+        const selectedJobId = repoJobs[bestIndex];
+        const pendingIdx = this.pending.indexOf(selectedJobId);
+        if (pendingIdx >= 0) {
+          this.pending.splice(pendingIdx, 1);
+        }
+        this.lastServedRepo = repo;
+        return selectedJobId;
+      }
+    }
+
+    return null;
+  }
+}

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -69,6 +69,7 @@ describe("JobQueue", () => {
   it("should enqueue and execute a job", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     expect(job).toBeDefined();
@@ -96,6 +97,7 @@ describe("JobQueue", () => {
     });
 
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
     queue.enqueue(1, "test/repo");
     queue.enqueue(2, "test/repo2");
     queue.enqueue(3, "test/repo3");
@@ -109,6 +111,7 @@ describe("JobQueue", () => {
   it("should prevent duplicate jobs for same issue", () => {
     const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job1 = queue.enqueue(42, "test/repo");
     const job2 = queue.enqueue(42, "test/repo");
@@ -126,6 +129,7 @@ describe("JobQueue", () => {
       .mockResolvedValueOnce({ prUrl: "https://pr/new-success" });
 
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create initial failed job
     const initialJob = queue.enqueue(123, "test/repo");
@@ -161,6 +165,7 @@ describe("JobQueue", () => {
 
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/after-cancel" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create and immediately cancel a job
     const initialJob = queue.enqueue(456, "test/repo");
@@ -192,6 +197,7 @@ describe("JobQueue", () => {
   it("should auto-archive success job and allow re-enqueue", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create successful job
     const successJob = queue.enqueue(789, "test/repo");
@@ -220,6 +226,7 @@ describe("JobQueue", () => {
     // Since concurrency is 0, the job is in pending... actually the enqueue adds to pending
     // Let's test via enqueue
     const queue2 = new JobQueue(store, 1, handler);
+    queue2.setDependencies({ projectRoot: dataDir });
     const j = queue2.enqueue(99, "test/repo2");
     // cancel immediately
     const result = queue2.cancel(j!.id);
@@ -231,6 +238,7 @@ describe("JobQueue", () => {
   it("should track queue status", () => {
     const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
     const queue = new JobQueue(store, 3, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const status = queue.getStatus();
     expect(status.concurrency).toBe(3);
@@ -241,6 +249,7 @@ describe("JobQueue", () => {
   it("should handle job handler failure", async () => {
     const handler: JobHandler = vi.fn().mockRejectedValue(new Error("boom"));
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -253,6 +262,7 @@ describe("JobQueue", () => {
   it("should mark job as failure when handler returns no prUrl", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({});
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -265,6 +275,7 @@ describe("JobQueue", () => {
   it("should mark job as failure when handler returns explicit error", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ error: "Phase execution failed" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(43, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -286,6 +297,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue initial job that will fail
       const initialJob = queue.enqueue(123, "test/repo");
@@ -325,6 +337,7 @@ describe("JobQueue", () => {
       // Create a failed job with PR URL
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test error"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(456, "test/repo");
 
@@ -372,6 +385,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("retry failure"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(789, "test/repo");
@@ -405,6 +419,7 @@ describe("JobQueue", () => {
     it("should not retry jobs with logs indicating PR creation", async () => {
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test error"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(999, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -434,6 +449,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const initialJob = queue.enqueue(300, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -506,6 +522,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(123, "test/repo");
@@ -562,6 +579,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const initialJob = queue.enqueue(456, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -607,6 +625,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(789, "test/repo");
@@ -664,6 +683,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Initial job that fails
       const initialJob = queue.enqueue(555, "test/repo");
@@ -704,6 +724,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/second-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create failed job
       const failedJob = queue.enqueue(666, "test/repo");
@@ -739,6 +760,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/dep-retry-success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue dependency (issue 100) and dependent (issue 101)
       const depJob = queue.enqueue(100, "test/repo");
@@ -815,6 +837,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create and fail a job to trigger cleanup
       const job = queue.enqueue(123, "test/repo");
@@ -864,6 +887,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(456, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -893,6 +917,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(789, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -924,6 +949,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(111, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -956,6 +982,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(222, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -981,6 +1008,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(333, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -1009,6 +1037,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs with concurrency=1
       queue.enqueue(1, "test/repo");
@@ -1037,6 +1066,7 @@ describe("JobQueue", () => {
     it("should validate concurrency value", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       expect(() => queue.setConcurrency(0)).toThrow("Concurrency must be a positive integer");
       expect(() => queue.setConcurrency(-1)).toThrow("Concurrency must be a positive integer");
@@ -1059,6 +1089,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 3, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs
       queue.enqueue(1, "test/repo");
@@ -1102,6 +1133,7 @@ describe("JobQueue", () => {
       };
 
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue multiple jobs for each repo
       queue.enqueue(1, "test/repo1");
@@ -1137,6 +1169,7 @@ describe("JobQueue", () => {
 
       // No project concurrency specified - should use global limit
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo1");
       queue.enqueue(2, "test/repo1");
@@ -1168,6 +1201,7 @@ describe("JobQueue", () => {
       };
 
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Jobs should start simultaneously for different repos
       queue.enqueue(1, "test/repo1");
@@ -1191,6 +1225,7 @@ describe("JobQueue", () => {
 
       const projectConcurrency = { "test/repo": 1 };
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs for same repo with limit 1
       const job1 = queue.enqueue(1, "test/repo");
@@ -1226,6 +1261,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // First failure
       const job1 = queue.enqueue(1, "test/repo");
@@ -1271,6 +1307,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("failure after success"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Two failures
       const job1 = queue.enqueue(1, "test/repo");
@@ -1302,6 +1339,7 @@ describe("JobQueue", () => {
     it("should auto-resume project after pause duration expires", async () => {
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Manually pause project for short duration
       const shortPauseDuration = 100; // 100ms
@@ -1329,6 +1367,7 @@ describe("JobQueue", () => {
     it("should manually resume paused project", async () => {
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Pause project
       queue.pauseProject("test/repo", 60000); // 1 minute
@@ -1359,6 +1398,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Fail repo1 three times to pause it
       const job1 = queue.enqueue(1, "test/repo1");
@@ -1393,6 +1433,7 @@ describe("JobQueue", () => {
       // Test the logic by simulating job stuck abort without waiting for timeout
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job1 = queue.enqueue(1, "test/repo");
 
@@ -1417,6 +1458,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Manual pause
       queue.pauseProject("test/repo", 60000);
@@ -1440,6 +1482,7 @@ describe("JobQueue", () => {
     it("should handle getProjectStatus for non-existent project", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const status = queue.getProjectStatus("non/existent");
       expect(status).toBeNull();
@@ -1448,6 +1491,7 @@ describe("JobQueue", () => {
     it("should handle project pause with zero or negative duration", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Zero duration should effectively be no pause
       queue.pauseProject("test/repo", 0);
@@ -1467,6 +1511,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 5, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Set project limit to 1
       queue.setProjectConcurrency("test/repo", 1);
@@ -1500,6 +1545,7 @@ describe("JobQueue", () => {
 
       // Start with limit of 1
       const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Remove the limit at runtime
       queue.setProjectConcurrency("test/repo", null);
@@ -1519,6 +1565,7 @@ describe("JobQueue", () => {
     it("should validate limit value", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       expect(() => queue.setProjectConcurrency("test/repo", 0)).toThrow("Project concurrency limit must be a positive integer");
       expect(() => queue.setProjectConcurrency("test/repo", -1)).toThrow("Project concurrency limit must be a positive integer");
@@ -1540,6 +1587,7 @@ describe("JobQueue", () => {
 
       // Start with project limit of 1
       const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo");
       queue.enqueue(2, "test/repo");
@@ -1607,6 +1655,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 5, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Set different limits for two repos
       queue.setProjectConcurrency("org/repo-x", 1);
@@ -1633,6 +1682,7 @@ describe("JobQueue", () => {
     it("should clear projectErrorState on recover (paused project is resumed)", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Pause a project
       queue.pauseProject("test/repo", 60000); // 1분 pause
@@ -1652,6 +1702,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("failure 2"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // 두 번 실패하여 consecutiveFailures = 2
       const job1 = queue.enqueue(1, "test/repo");
@@ -1674,6 +1725,7 @@ describe("JobQueue", () => {
     it("should clear projectErrorState for multiple repos on recover", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // 두 repo 모두 pause
       queue.pauseProject("test/repo1", 60000);
@@ -1781,6 +1833,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Mix jobs with and without priority
       queue.enqueue(1, "test/repo", undefined, false, "low");
@@ -1839,6 +1892,7 @@ describe("JobQueue", () => {
       // concurrency=0으로 시작하여 모든 잡을 먼저 pending 큐에 쌓음
       // (A 잡들이 슬롯을 독점하기 전에 B 잡도 큐에 있어야 라운드 로빈이 동작)
       const queue = new JobQueue(store, 0, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // A: 10개 대기
       for (let i = 1; i <= 10; i++) {
@@ -1886,6 +1940,7 @@ describe("JobQueue", () => {
 
       // concurrency=1: 순차 실행으로 라운드 로빈 순서 정확히 관찰
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // A[1] 먼저 시작
       queue.enqueue(1, "project/A");
@@ -1924,6 +1979,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "project/A");
       queue.enqueue(2, "project/A");
@@ -1954,6 +2010,7 @@ describe("JobQueue", () => {
       // concurrency=0으로 시작하여 모든 잡을 큐에 쌓은 뒤 라운드 로빈 적용
       const projectConcurrency = { "project/A": 1, "project/B": 2 };
       const queue = new JobQueue(store, 0, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       for (let i = 1; i <= 5; i++) {
         queue.enqueue(i, "project/A");
@@ -1982,6 +2039,7 @@ describe("JobQueue", () => {
     it("should resolve immediately when no jobs are running", async () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const start = Date.now();
       await queue.shutdown(5000);
@@ -1991,6 +2049,7 @@ describe("JobQueue", () => {
     it("should reject new jobs after shutdown", async () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       void queue.shutdown(100);
 
@@ -2007,6 +2066,7 @@ describe("JobQueue", () => {
           })
       );
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
       queue.enqueue(1, "test/repo");
 
       await new Promise((r) => setTimeout(r, 30));
@@ -2022,6 +2082,7 @@ describe("JobQueue", () => {
     it("should resolve after timeout even if jobs are still running", async () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
       queue.enqueue(1, "test/repo");
 
       await new Promise((r) => setTimeout(r, 30));
@@ -2040,6 +2101,7 @@ describe("JobQueue", () => {
     it("should return undefined when no taskFactory is set", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo");
       const jobs = store.list();
@@ -2052,6 +2114,7 @@ describe("JobQueue", () => {
     it("should return undefined and log warning when queue is shutting down", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       void queue.shutdown(5000);
 

--- a/tests/queue/job-scheduler.test.ts
+++ b/tests/queue/job-scheduler.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JobScheduler } from "../../src/queue/job-scheduler.js";
+import type { JobStore, Job as StoreJob } from "../../src/queue/job-store.js";
+import type { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+
+function makeStoreJob(overrides: Partial<StoreJob> = {}): StoreJob {
+  return {
+    id: "job-x",
+    issueNumber: 1,
+    repo: "a/b",
+    status: "queued",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastUpdatedAt: "2025-01-01T00:00:00.000Z",
+    logs: [],
+    currentStep: null,
+    ...overrides,
+  } as unknown as StoreJob;
+}
+
+function makeStore(jobs: Record<string, StoreJob> = {}): JobStore {
+  return {
+    isClosed: false,
+    get: vi.fn((id: string) => jobs[id]),
+    update: vi.fn(),
+    findAnyByIssue: vi.fn(),
+    findCompletedByIssue: vi.fn(() => undefined),
+  } as unknown as JobStore;
+}
+
+function makeTracker(paused = new Set<string>()): ProjectErrorTracker {
+  return {
+    isProjectPaused: vi.fn((repo: string) => paused.has(repo)),
+    getProjectStatus: vi.fn((repo: string) =>
+      paused.has(repo) ? { pausedUntil: Date.now() + 60_000 } : null
+    ),
+  } as unknown as ProjectErrorTracker;
+}
+
+describe("JobScheduler", () => {
+  let cancelled: Set<string>;
+  let onStartJob: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    cancelled = new Set();
+    onStartJob = vi.fn();
+  });
+
+  it("enqueue → onStartJob 호출 + running.size 증가 + store.update(running)", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledWith(j);
+    expect(scheduler.runningCount).toBe(1);
+    expect(scheduler.isRunning("j1")).toBe(true);
+    expect(store.update).toHaveBeenCalledWith(
+      "j1",
+      expect.objectContaining({ status: "running" })
+    );
+  });
+
+  it("concurrency 한도 초과 시 pending 유지", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "a/b" });
+    const j2 = makeStoreJob({ id: "j2", repo: "c/d" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+    expect(scheduler.getStatus()).toEqual({ pending: 1, running: 1, concurrency: 1 });
+  });
+
+  it("markJobFinished로 슬롯 해제 시 다음 잡 시작", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "a/b" });
+    const j2 = makeStoreJob({ id: "j2", repo: "c/d" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+
+    scheduler.markJobFinished("j1", "a/b");
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledTimes(2);
+    expect(scheduler.runningCount).toBe(1);
+    expect(scheduler.isRunning("j2")).toBe(true);
+  });
+
+  it("removePending: pending에서 제거 후 onStartJob 호출 안 됨", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 0, // 즉시 처리 안 됨
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("j1");
+    expect(scheduler.removePending("j1")).toBe(true);
+    expect(scheduler.removePending("j1")).toBe(false);
+    expect(onStartJob).not.toHaveBeenCalled();
+  });
+
+  it("cancelledRef에 미리 set된 잡은 onStartJob 호출 안 됨 + 플래그 클리어", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    cancelled.add("j1");
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(cancelled.has("j1")).toBe(false);
+  });
+
+  it("project pause 상태면 잡을 deferred 처리 (다음 호출에 다시 시도)", async () => {
+    const j = makeStoreJob({ id: "j1", repo: "paused/repo" });
+    const store = makeStore({ j1: j });
+    const paused = new Set(["paused/repo"]);
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(paused),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(scheduler.getStatus().pending).toBe(1);
+  });
+
+  it("setProjectConcurrency 0이면 다음 잡은 시작 안 됨, null이면 제한 해제", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "r1" });
+    const j2 = makeStoreJob({ id: "j2", repo: "r1" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 5,
+      projectConcurrency: { r1: 1 },
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+
+    // r1 제한 1 → j1만 시작
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+    expect(scheduler.getStatus().pending).toBe(1);
+
+    scheduler.setProjectConcurrency("r1", null);
+    await new Promise((r) => setImmediate(r));
+
+    // 제한 해제 → j2 시작
+    expect(onStartJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("setConcurrency: 양수 정수가 아니면 throw", () => {
+    const scheduler = new JobScheduler({
+      store: makeStore(),
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+    expect(() => scheduler.setConcurrency(0)).toThrow();
+    expect(() => scheduler.setConcurrency(-1)).toThrow();
+    expect(() => scheduler.setConcurrency(1.5)).toThrow();
+  });
+
+  it("dependency 미충족이면 deferred", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "r1", dependencies: [99] });
+    const store = makeStore({ j1 });
+    (store.findAnyByIssue as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(scheduler.getStatus().pending).toBe(1);
+  });
+
+  it("round-robin: 다른 repo 잡을 번갈아 서빙", async () => {
+    const j1a = makeStoreJob({ id: "j1a", repo: "A", createdAt: "2025-01-01T00:00:00Z" });
+    const j1b = makeStoreJob({ id: "j1b", repo: "A", createdAt: "2025-01-01T00:00:01Z" });
+    const j2a = makeStoreJob({ id: "j2a", repo: "B", createdAt: "2025-01-01T00:00:02Z" });
+    const store = makeStore({ j1a, j1b, j2a });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("j1a");
+    scheduler.pushPending("j1b");
+    scheduler.pushPending("j2a");
+    void scheduler.processNext();
+    await new Promise((r) => setImmediate(r));
+
+    // 첫 잡: A repo의 가장 빠른 j1a
+    expect(onStartJob).toHaveBeenNthCalledWith(1, j1a);
+
+    scheduler.markJobFinished("j1a", "A");
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // 다음 잡: 다른 repo B의 j2a (round-robin)
+    expect(onStartJob).toHaveBeenNthCalledWith(2, j2a);
+  });
+
+  it("priority: high가 normal보다 먼저", async () => {
+    const jHigh = makeStoreJob({ id: "jH", repo: "X", priority: "high", createdAt: "2025-01-01T00:00:01Z" } as Partial<StoreJob>);
+    const jNorm = makeStoreJob({ id: "jN", repo: "X", priority: "normal", createdAt: "2025-01-01T00:00:00Z" } as Partial<StoreJob>);
+    const store = makeStore({ jH: jHigh, jN: jNorm });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("jN");
+    scheduler.pushPending("jH");
+    void scheduler.processNext();
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenNthCalledWith(1, jHigh);
+  });
+
+  it("store.isClosed면 processNext no-op", async () => {
+    const store = makeStore();
+    (store as unknown as { isClosed: boolean }).isClosed = true;
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+    scheduler.pushPending("any");
+    await scheduler.processNext();
+    expect(onStartJob).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 스케줄링 책임(pending/running/processNext/round-robin/repo concurrency)을 신규 `JobScheduler`로 응집
- `JobQueue`는 thin Facade로 축소 (748 → 444줄, **-304**)
- `cleanupService` nullable 전환 → `setDependencies` 후에만 활성. `process.cwd()` fallback 완전 제거
- `src/queue/` 내 `process.cwd()` 직접 참조 **0건 달성** (Plan C 검증 게이트)
- 외부 public API(JobQueue 메서드 시그니처) 무변경

## 변경 파일
- 신규: `src/queue/job-scheduler.ts` (333줄)
- 신규: `tests/queue/job-scheduler.test.ts` (12 tests)
- 수정: `src/queue/job-queue.ts` (-304)
- 수정: `tests/queue/job-queue.test.ts` (setDependencies 일괄 주입 +63)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean
- [x] `tests/queue/job-scheduler.test.ts` 12 tests (enqueue/concurrency/cancel/pause/round-robin/priority/dependency)
- [x] `tests/queue/job-queue.test.ts` 67+15 tests 회귀 통과 (cleanup 포함)
- [x] `grep -n "process.cwd" src/queue/*.ts` → 주석만 남음, 코드 참조 0건

## Plan C #C10 진행
- Phase 1 (StuckJobMonitor): #817 merged
- Phase 2 (JobLifecycle): #818 merged
- Phase 3 (JobScheduler + process.cwd 근절): **본 PR**
- 후속(별도): JobQueueOptions 객체화는 테스트 60+ 위치 변경 부담으로 본 PR 제외 (Phase 4 후보)

## Plan C 전체 진행 (작업 단위 기준)
- 11/12 완료 추정 (#C9 dashboard 분할만 잔여)