### PR TITLE
refactor(server): /api/notifications 라우트 분할 (Plan C #C9 1단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -36,6 +36,7 @@ import { z } from "zod";
 import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
+import { registerNotificationsRoutes } from "./routes/notifications.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -1969,151 +1970,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     });
   });
 
-  // Notifications: unread count
-  api.get("/api/notifications/unread-count", (c) => {
-    try {
-      const unreadCount = store.getAqDb().countUnreadNotifications();
-      return c.json({ unreadCount });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch unread count: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: list with pagination
-  api.get("/api/notifications", (c) => {
-    try {
-      const queryParams = {
-        isRead: c.req.query("isRead"),
-        type: c.req.query("type"),
-        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
-        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
-      };
-
-      const parseResult = GetNotificationsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const { isRead, type: typeFilter, limit, offset } = parseResult.data;
-      const aqDb = store.getAqDb();
-      const isReadFilter = isRead === "true" ? true : isRead === "false" ? false : undefined;
-      const notifFilter: { isRead?: boolean; type?: string } = {};
-      if (isReadFilter !== undefined) notifFilter.isRead = isReadFilter;
-      if (typeFilter !== undefined) notifFilter.type = typeFilter;
-      const notifications = aqDb.listNotifications({ ...notifFilter, limit, offset });
-      const total = aqDb.countNotifications(notifFilter);
-      const unreadCount = aqDb.countUnreadNotifications();
-      const start = offset ?? 0;
-
-      return c.json({
-        notifications,
-        total,
-        unreadCount,
-        pagination: {
-          total,
-          offset: start,
-          limit: limit ?? total,
-          hasMore: start + notifications.length < total,
-        },
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: mark all as read (static route before :id/read)
-  api.post("/api/notifications/read-all", (c) => {
-    try {
-      const count = store.getAqDb().markAllNotificationsRead();
-      broadcastToAllClients("notificationsReadAll", { count, timestamp: Date.now() });
-      return c.json({ status: "ok", count });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to mark all notifications as read: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: mark individual as read
-  api.post("/api/notifications/:id/read", (c) => {
-    try {
-      const idParam = c.req.param("id");
-      const id = parseInt(idParam, 10);
-      if (isNaN(id) || id <= 0) {
-        return c.json({ error: "Invalid notification id" }, 400);
-      }
-      const updated = store.getAqDb().markNotificationRead(id);
-      if (!updated) {
-        return c.json({ error: "Notification not found" }, 404);
-      }
-      return c.json({ status: "ok", id });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to mark notification as read: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: prune read notifications older than maxAgeDays (default 14)
-  api.post("/api/notifications/prune", async (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      let maxAgeDays = 14;
-      try {
-        const body = await c.req.json<{ maxAgeDays?: unknown }>();
-        if (typeof body?.maxAgeDays === "number" && body.maxAgeDays > 0) {
-          maxAgeDays = Math.floor(body.maxAgeDays);
-        }
-      } catch {
-        // body 없음 → 기본값 14일
-      }
-      const deleted = store.pruneReadNotifications(maxAgeDays);
-      broadcastToAllClients("notificationsPruned", { deleted, maxAgeDays, timestamp: Date.now() });
-      return c.json({ deleted, maxAgeDays });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to prune notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: delete all (옵션으로 isRead 필터)
-  api.delete("/api/notifications", (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const isReadParam = c.req.query("isRead");
-      const filter: { isRead?: boolean } = {};
-      if (isReadParam === "true") filter.isRead = true;
-      else if (isReadParam === "false") filter.isRead = false;
-      const deleted = store.deleteAllNotifications(filter);
-      broadcastToAllClients("notificationsDeleted", { deleted, timestamp: Date.now() });
-      return c.json({ deleted });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: delete single
-  api.delete("/api/notifications/:id", (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const idParam = c.req.param("id");
-      const id = parseInt(idParam, 10);
-      if (isNaN(id) || id <= 0) {
-        return c.json({ error: "Invalid notification id" }, 400);
-      }
-      const deleted = store.deleteNotification(id);
-      if (!deleted) {
-        return c.json({ error: "Notification not found" }, 404);
-      }
-      return c.json({ status: "ok", id });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete notification: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Notifications: 도메인 라우트 분할 (Plan C #C9)
+  registerNotificationsRoutes(api, { store, sseManager, readOnly: !!readOnly });
 
   return api;
 }

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -1,0 +1,164 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import type { SSEManager } from "../sse-manager.js";
+import { safeError } from "../route-context.js";
+import { GetNotificationsQuerySchema, formatZodError } from "../../types/api.js";
+
+export interface NotificationsRouteContext {
+  store: JobStore;
+  sseManager: SSEManager;
+  readOnly: boolean;
+}
+
+/**
+ * /api/notifications/* 라우트 등록 (Plan C #C9 — 1단계).
+ *
+ * 이전: dashboard-api.ts 1973-2117 (145줄, 7 routes).
+ * 이후: 본 파일이 단일 책임으로 캡슐화. dashboard-api.ts의 createDashboardRoutes는
+ *      `registerNotificationsRoutes(api, { store, sseManager, readOnly })`만 호출.
+ */
+export function registerNotificationsRoutes(api: Hono, ctx: NotificationsRouteContext): void {
+  const { store, sseManager, readOnly } = ctx;
+
+  api.get("/api/notifications/unread-count", (c) => {
+    try {
+      const unreadCount = store.getAqDb().countUnreadNotifications();
+      return c.json({ unreadCount });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch unread count");
+    }
+  });
+
+  api.get("/api/notifications", (c) => {
+    try {
+      const queryParams = {
+        isRead: c.req.query("isRead"),
+        type: c.req.query("type"),
+        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
+        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
+      };
+
+      const parseResult = GetNotificationsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error)
+        }, 400);
+      }
+
+      const { isRead, type: typeFilter, limit, offset } = parseResult.data;
+      const aqDb = store.getAqDb();
+      const isReadFilter = isRead === "true" ? true : isRead === "false" ? false : undefined;
+      const notifFilter: { isRead?: boolean; type?: string } = {};
+      if (isReadFilter !== undefined) notifFilter.isRead = isReadFilter;
+      if (typeFilter !== undefined) notifFilter.type = typeFilter;
+      const notifications = aqDb.listNotifications({ ...notifFilter, limit, offset });
+      const total = aqDb.countNotifications(notifFilter);
+      const unreadCount = aqDb.countUnreadNotifications();
+      const start = offset ?? 0;
+
+      return c.json({
+        notifications,
+        total,
+        unreadCount,
+        pagination: {
+          total,
+          offset: start,
+          limit: limit ?? total,
+          hasMore: start + notifications.length < total,
+        },
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch notifications");
+    }
+  });
+
+  // mark all as read (static route before :id/read)
+  api.post("/api/notifications/read-all", (c) => {
+    try {
+      const count = store.getAqDb().markAllNotificationsRead();
+      sseManager.broadcast("notificationsReadAll", { count, timestamp: Date.now() });
+      return c.json({ status: "ok", count });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to mark all notifications as read");
+    }
+  });
+
+  api.post("/api/notifications/:id/read", (c) => {
+    try {
+      const idParam = c.req.param("id");
+      const id = parseInt(idParam, 10);
+      if (isNaN(id) || id <= 0) {
+        return c.json({ error: "Invalid notification id" }, 400);
+      }
+      const updated = store.getAqDb().markNotificationRead(id);
+      if (!updated) {
+        return c.json({ error: "Notification not found" }, 404);
+      }
+      return c.json({ status: "ok", id });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to mark notification as read");
+    }
+  });
+
+  // prune read notifications older than maxAgeDays (default 14)
+  api.post("/api/notifications/prune", async (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      let maxAgeDays = 14;
+      try {
+        const body = await c.req.json<{ maxAgeDays?: unknown }>();
+        if (typeof body?.maxAgeDays === "number" && body.maxAgeDays > 0) {
+          maxAgeDays = Math.floor(body.maxAgeDays);
+        }
+      } catch {
+        // body 없음 → 기본값 14일
+      }
+      const deleted = store.pruneReadNotifications(maxAgeDays);
+      sseManager.broadcast("notificationsPruned", { deleted, maxAgeDays, timestamp: Date.now() });
+      return c.json({ deleted, maxAgeDays });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to prune notifications");
+    }
+  });
+
+  // delete all (옵션으로 isRead 필터)
+  api.delete("/api/notifications", (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const isReadParam = c.req.query("isRead");
+      const filter: { isRead?: boolean } = {};
+      if (isReadParam === "true") filter.isRead = true;
+      else if (isReadParam === "false") filter.isRead = false;
+      const deleted = store.deleteAllNotifications(filter);
+      sseManager.broadcast("notificationsDeleted", { deleted, timestamp: Date.now() });
+      return c.json({ deleted });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete notifications");
+    }
+  });
+
+  api.delete("/api/notifications/:id", (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const idParam = c.req.param("id");
+      const id = parseInt(idParam, 10);
+      if (isNaN(id) || id <= 0) {
+        return c.json({ error: "Invalid notification id" }, 400);
+      }
+      const deleted = store.deleteNotification(id);
+      if (!deleted) {
+        return c.json({ error: "Notification not found" }, 404);
+      }
+      return c.json({ status: "ok", id });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete notification");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/notifications.ts` 신규: 7개 알림 라우트 캡슐화
- `registerNotificationsRoutes(api, ctx)` 패턴 도입 — #C9 후속 분할의 템플릿
- `safeError(c, e, prefix)` 적용 — `sanitizeErrorMessage(getErrorMessage(e))` 7회 치환
- `dashboard-api.ts` 2119 → 1977줄 (**-142**)

## 변경 파일
- 신규: `src/server/routes/notifications.ts` (164줄)
- 수정: `src/server/dashboard-api.ts` (-142)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 분할 전략
변경폭이 큰 도메인 분할은 단계별로 진행해 리스크 최소화:
1. **본 PR**: notifications (가장 작고 self-contained, 패턴 검증)
2. 후속: jobs / projects / config / setup / stats / version / repositories / health / doctor / sse
3. 마지막 (#C12): `createDashboardRoutes` 시그니처 정리 → DashboardContext 단일 인자