### PR TITLE
refactor(server): /api/version + claude-profile + update 라우트 분할 (Plan C #C9 2단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -3,8 +3,7 @@ import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
-import { fileURLToPath } from "url";
-import { resolve, normalize, basename, join } from "path";
+import { resolve, normalize, join } from "path";
 import { homedir } from "os";
 import type { JobStore, Job, ListJobsOptions } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
@@ -14,14 +13,12 @@ import { maskSensitiveConfig } from "../utils/config-masker.js";
 import { getBasicFieldMetas } from "../config/schema-meta.js";
 import { getPresets } from "../config/presets.js";
 import type { ProjectConfig, AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
-import { checkClaudeQuota } from "../claude/quota-checker.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
 import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, UpdateJobPriorityRequestSchema, UpdateProjectRequestSchema, GetMetricsQuerySchema, CancelJobRequestSchema, RetryJobRequestSchema, GetNotificationsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
 import { runAllChecks } from "../doctor/checks.js";
 import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
@@ -37,6 +34,7 @@ import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
+import { registerVersionRoutes } from "./routes/version.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -1331,132 +1329,15 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Start periodic cleanup when dashboard routes are created
   startPeriodicCleanup();
 
-  // Helper to read current version from package.json
-  // import.meta.url 기준으로 설치 루트를 도출한다.
-  // process.cwd()는 서버 실행 디렉토리일 뿐 AQM 설치 루트와 다를 수 있어
-  // "ENOENT: package.json" 에러 → 대시보드 버전 표시 unknown 원인이 된다.
-  const getCurrentVersion = (): string => {
-    // src/server/dashboard-api.ts (dev) 또는 dist/server/dashboard-api.js (build)
-    // 둘 다 루트에서 2단계 위 → ../../package.json로 동일하게 접근 가능
-    const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-    return packageJson.version;
-  };
-
-  // Get version information (current version + update check)
-  api.get("/api/version", async (c) => {
-    try {
-      const currentVersion = getCurrentVersion();
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
-
-      try {
-        const updateInfo = await selfUpdater.checkForUpdates();
-        return c.json({
-          currentVersion,
-          currentHash: updateInfo.currentHash.substring(0, 8),
-          remoteHash: updateInfo.remoteHash.substring(0, 8),
-          hasUpdates: updateInfo.hasUpdates,
-          packageLockChanged: updateInfo.packageLockChanged,
-        });
-      } catch (updateError: unknown) {
-        getLogger().warn(`업데이트 확인 실패: ${getErrorMessage(updateError)}`);
-        return c.json({
-          currentVersion,
-          currentHash: "unknown",
-          remoteHash: "unknown",
-          hasUpdates: false,
-          packageLockChanged: false,
-          error: "업데이트 확인에 실패했습니다",
-        });
-      }
-    } catch (error: unknown) {
-      return c.json({ error: `버전 정보 조회 실패: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Claude profile
-  api.get("/api/claude-profile", async (c) => {
-    const configDir = process.env.CLAUDE_CONFIG_DIR || "";
-    const profile = configDir ? basename(configDir).replace(/^\.claude-?/, "") || "default" : "default";
-    const config = configWatcher?.current() ?? loadConfig(rootDir);
-    const models = config.commands.claudeCli.models;
-
-    let cliVersion = "unknown";
-    try {
-      const result = await runCli(config.commands.claudeCli.path, ["--version"], { timeout: 5000 });
-      if (result.exitCode === 0) cliVersion = result.stdout.trim();
-    } catch { /* 비차단 버전 조회 — 실패 무시 */ }
-
-    return c.json({
-      profile,
-      configDir,
-      cliVersion,
-      model: config.commands.claudeCli.model,
-      models: {
-        plan: models?.plan,
-        phase: models?.phase,
-        review: models?.review,
-        fallback: models?.fallback,
-      },
-      maxTurns: config.commands.claudeCli.maxTurns,
-      timeout: config.commands.claudeCli.timeout,
-      quotaStatus: currentQuotaStatus,
-    });
-  });
-
-  // Refresh Claude quota status
-  api.post("/api/claude-profile/refresh", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const status = await checkClaudeQuota(config.commands.claudeCli);
-      currentQuotaStatus = status;
-      return c.json({ quotaStatus: status });
-    } catch (error: unknown) {
-      return c.json({ error: `quota 재검사 실패: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Perform self-update
-  api.post("/api/update", async (c) => {
-    try {
-      const activeJobs = store.list().filter(job => job.status === "running" || job.status === "queued");
-      if (activeJobs.length > 0) {
-        getLogger().info(`업데이트 전 진행 중인 잡 ${activeJobs.length}개 취소 중`);
-        for (const job of activeJobs) {
-          queue.cancel(job.id);
-          getLogger().info(`잡 취소: ${job.id} (이슈 #${job.issueNumber}, 상태: ${job.status})`);
-        }
-      }
-
-      const config = loadConfig(rootDir);
-      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
-      getLogger().info("사용자 요청으로 업데이트 시작");
-
-      const result = await selfUpdater.performSelfUpdate();
-      if (result.updated) {
-        broadcastToAllClients('updateCompleted', {
-          updated: result.updated,
-          needsRestart: result.needsRestart,
-          timestamp: new Date().toISOString()
-        });
-      }
-
-      return c.json({
-        message: result.updated ? "업데이트가 완료되었습니다" : "이미 최신 버전입니다",
-        updated: result.updated,
-        needsRestart: result.needsRestart,
-      });
-    } catch (error: unknown) {
-      const rawMessage = getErrorMessage(error);
-      getLogger().error(`업데이트 실패: ${rawMessage}`);
-      const message = sanitizeErrorMessage(rawMessage);
-      broadcastToAllClients('updateFailed', {
-        error: message,
-        timestamp: new Date().toISOString()
-      });
-      return c.json({ error: `업데이트 실패: ${message}` }, 500);
-    }
+  // Version/update/claude-profile: 도메인 라우트 분할 (Plan C #C9)
+  registerVersionRoutes(api, {
+    store,
+    queue,
+    sseManager,
+    configWatcher,
+    rootDir,
+    getQuotaStatus: () => currentQuotaStatus,
+    setQuotaStatus: (s) => { currentQuotaStatus = s; },
   });
 
   // Repositories API - project-level aggregated information with health and stats

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -1,0 +1,162 @@
+import type { Hono } from "hono";
+import { basename } from "path";
+import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
+import type { JobStore } from "../../queue/job-store.js";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { SSEManager } from "../sse-manager.js";
+import type { QuotaStatus } from "../../types/config.js";
+import { safeError } from "../route-context.js";
+import { loadConfig } from "../../config/loader.js";
+import { SelfUpdater } from "../../update/self-updater.js";
+import { checkClaudeQuota } from "../../claude/quota-checker.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+/**
+ * AQM 설치 루트의 package.json에서 버전을 읽는다.
+ * import.meta.url 기준으로 — process.cwd()는 서버 실행 디렉토리일 뿐 설치 루트와
+ * 다를 수 있어 "ENOENT: package.json" 에러를 일으킬 수 있다.
+ *
+ * src/server/routes/version.ts (dev) → ../../../package.json
+ * dist/server/routes/version.js (build) → ../../../package.json (동일)
+ */
+function getCurrentVersion(): string {
+  const packageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return packageJson.version;
+}
+
+export interface VersionRouteContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+  getQuotaStatus: () => QuotaStatus | null;
+  setQuotaStatus: (status: QuotaStatus) => void;
+}
+
+/**
+ * /api/version, /api/claude-profile*, /api/update 라우트 등록 (Plan C #C9 — 2단계).
+ *
+ * 이전: dashboard-api.ts 1346-1460 (4 routes, 115줄).
+ */
+export function registerVersionRoutes(api: Hono, ctx: VersionRouteContext): void {
+  const { store, queue, sseManager, configWatcher, rootDir, getQuotaStatus, setQuotaStatus } = ctx;
+
+  api.get("/api/version", async (c) => {
+    try {
+      const currentVersion = getCurrentVersion();
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
+
+      try {
+        const updateInfo = await selfUpdater.checkForUpdates();
+        return c.json({
+          currentVersion,
+          currentHash: updateInfo.currentHash.substring(0, 8),
+          remoteHash: updateInfo.remoteHash.substring(0, 8),
+          hasUpdates: updateInfo.hasUpdates,
+          packageLockChanged: updateInfo.packageLockChanged,
+        });
+      } catch (updateError: unknown) {
+        getLogger().warn(`업데이트 확인 실패: ${getErrorMessage(updateError)}`);
+        return c.json({
+          currentVersion,
+          currentHash: "unknown",
+          remoteHash: "unknown",
+          hasUpdates: false,
+          packageLockChanged: false,
+          error: "업데이트 확인에 실패했습니다",
+        });
+      }
+    } catch (error: unknown) {
+      return safeError(c, error, "버전 정보 조회 실패");
+    }
+  });
+
+  api.get("/api/claude-profile", async (c) => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR || "";
+    const profile = configDir ? basename(configDir).replace(/^\.claude-?/, "") || "default" : "default";
+    const config = configWatcher?.current() ?? loadConfig(rootDir);
+    const models = config.commands.claudeCli.models;
+
+    let cliVersion = "unknown";
+    try {
+      const result = await runCli(config.commands.claudeCli.path, ["--version"], { timeout: 5000 });
+      if (result.exitCode === 0) cliVersion = result.stdout.trim();
+    } catch { /* 비차단 버전 조회 — 실패 무시 */ }
+
+    return c.json({
+      profile,
+      configDir,
+      cliVersion,
+      model: config.commands.claudeCli.model,
+      models: {
+        plan: models?.plan,
+        phase: models?.phase,
+        review: models?.review,
+        fallback: models?.fallback,
+      },
+      maxTurns: config.commands.claudeCli.maxTurns,
+      timeout: config.commands.claudeCli.timeout,
+      quotaStatus: getQuotaStatus(),
+    });
+  });
+
+  api.post("/api/claude-profile/refresh", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const status = await checkClaudeQuota(config.commands.claudeCli);
+      setQuotaStatus(status);
+      return c.json({ quotaStatus: status });
+    } catch (error: unknown) {
+      return safeError(c, error, "quota 재검사 실패");
+    }
+  });
+
+  api.post("/api/update", async (c) => {
+    try {
+      const activeJobs = store.list().filter(job => job.status === "running" || job.status === "queued");
+      if (activeJobs.length > 0) {
+        getLogger().info(`업데이트 전 진행 중인 잡 ${activeJobs.length}개 취소 중`);
+        for (const job of activeJobs) {
+          queue.cancel(job.id);
+          getLogger().info(`잡 취소: ${job.id} (이슈 #${job.issueNumber}, 상태: ${job.status})`);
+        }
+      }
+
+      const config = loadConfig(rootDir);
+      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
+      getLogger().info("사용자 요청으로 업데이트 시작");
+
+      const result = await selfUpdater.performSelfUpdate();
+      if (result.updated) {
+        sseManager.broadcast("updateCompleted", {
+          updated: result.updated,
+          needsRestart: result.needsRestart,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      return c.json({
+        message: result.updated ? "업데이트가 완료되었습니다" : "이미 최신 버전입니다",
+        updated: result.updated,
+        needsRestart: result.needsRestart,
+      });
+    } catch (error: unknown) {
+      const rawMessage = getErrorMessage(error);
+      getLogger().error(`업데이트 실패: ${rawMessage}`);
+      const message = sanitizeErrorMessage(rawMessage);
+      sseManager.broadcast("updateFailed", {
+        error: message,
+        timestamp: new Date().toISOString(),
+      });
+      return c.json({ error: `업데이트 실패: ${message}` }, 500);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/version.ts` 신규: 4개 라우트 캡슐화 (version, claude-profile, claude-profile/refresh, update)
- `getCurrentVersion` 헬퍼를 라우트 모듈로 이동 (import.meta.url 기준 package.json 읽기)
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts에서 SelfUpdater / checkClaudeQuota / basename / fileURLToPath import 정리
- dashboard-api.ts 1977 → 1858줄 (**-119**)

## 변경 파일
- 신규: `src/server/routes/version.ts` (148줄)
- 수정: `src/server/dashboard-api.ts` (-119)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 진행
- 1단계: notifications (#820 merged) — 142줄 감축
- **2단계: version (본 PR)** — 119줄 감축
- 누계 dashboard-api.ts: 2119 → 1858 (**-261**)

남은 도메인: jobs / projects / config / setup / stats / repositories / health / doctor / sse