### PR TITLE
refactor(server): /api/stats + /api/metrics 라우트 분할 (Plan C #C9 5단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -15,8 +15,8 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { UpdateConfigRequestSchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, GetMetricsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
-import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
+import { UpdateConfigRequestSchema, GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runAllChecks } from "../doctor/checks.js";
 import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
@@ -34,6 +34,7 @@ import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
 import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
+import { registerStatsRoutes } from "./routes/stats.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -705,144 +706,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  // Aggregate stats
-  api.get("/api/stats", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "7d",
-      };
-
-      const parseResult = GetStatsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const stats = getJobStats(store.getAqDb(), parseResult.data);
-      return c.json(stats);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Cost stats
-  api.get("/api/stats/costs", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "30d",
-        groupBy: c.req.query("groupBy") || "project",
-      };
-
-      const parseResult = GetCostsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const costs = getCostStats(store.getAqDb(), parseResult.data);
-      return c.json(costs);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch cost stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Project stats (success rate + cost per project)
-  api.get("/api/stats/projects", (c) => {
-    try {
-      const queryParams = {
-        timeRange: c.req.query("timeRange") || "7d",
-      };
-
-      const parseResult = GetProjectStatsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: parseResult.error
-        }, 400);
-      }
-
-      const stats = getProjectStatsWithTimeRange(store.getAqDb(), parseResult.data);
-      return c.json(stats);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch project stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Failure reason top-N analysis
-  api.get("/api/metrics/failure-reasons", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window"),
-        top: c.req.query("top"),
-      };
-
-      const parseResult = GetFailureReasonsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const result = getFailureReasons(store.getAqDb(), parseResult.data, patternStore);
-      return c.json(result);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch failure reasons: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Throughput time series
-  api.get("/api/metrics/throughput", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window") || "7d",
-      };
-
-      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const data = getThroughputTimeSeries(store.getAqDb(), parseResult.data);
-      return c.json(data);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch throughput metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Success rate metrics
-  api.get("/api/metrics/success-rate", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window") || "7d",
-      };
-
-      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const data = getSuccessRate(store.getAqDb(), parseResult.data);
-      return c.json(data);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch success rate metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
+  registerStatsRoutes(api, { store, patternStore });
 
   // SSE stream for job logs
   api.get("/api/jobs/:id/logs/stream", (c) => {

--- a/src/server/routes/stats.ts
+++ b/src/server/routes/stats.ts
@@ -1,0 +1,156 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import type { PatternStore } from "../../learning/pattern-store.js";
+import { safeError } from "../route-context.js";
+import {
+  GetStatsQuerySchema,
+  GetCostsQuerySchema,
+  GetProjectStatsQuerySchema,
+  GetFailureReasonsQuerySchema,
+  GetMetricsQuerySchema,
+  formatZodError,
+} from "../../types/api.js";
+import {
+  getJobStats,
+  getCostStats,
+  getProjectStatsWithTimeRange,
+  getFailureReasons,
+  getThroughputTimeSeries,
+  getSuccessRate,
+} from "../../store/queries.js";
+
+export interface StatsRouteContext {
+  store: JobStore;
+  patternStore?: PatternStore;
+}
+
+/**
+ * /api/stats/* + /api/metrics/* 라우트 등록 (Plan C #C9 — 5단계).
+ *
+ * 이전: dashboard-api.ts 709-845 (6 read-only routes, ~140줄).
+ * 모두 동일한 패턴 — query parse → DB 조회 → JSON 반환.
+ */
+export function registerStatsRoutes(api: Hono, ctx: StatsRouteContext): void {
+  const { store, patternStore } = ctx;
+
+  // Aggregate stats
+  api.get("/api/stats", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetStatsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const stats = getJobStats(store.getAqDb(), parseResult.data);
+      return c.json(stats);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch stats");
+    }
+  });
+
+  // Cost stats
+  api.get("/api/stats/costs", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "30d",
+        groupBy: c.req.query("groupBy") || "project",
+      };
+
+      const parseResult = GetCostsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const costs = getCostStats(store.getAqDb(), parseResult.data);
+      return c.json(costs);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch cost stats");
+    }
+  });
+
+  // Project stats (success rate + cost per project)
+  api.get("/api/stats/projects", (c) => {
+    try {
+      const queryParams = {
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetProjectStatsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: parseResult.error }, 400);
+      }
+
+      const stats = getProjectStatsWithTimeRange(store.getAqDb(), parseResult.data);
+      return c.json(stats);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch project stats");
+    }
+  });
+
+  // Failure reason top-N analysis
+  api.get("/api/metrics/failure-reasons", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window"),
+        top: c.req.query("top"),
+      };
+
+      const parseResult = GetFailureReasonsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const result = getFailureReasons(store.getAqDb(), parseResult.data, patternStore);
+      return c.json(result);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch failure reasons");
+    }
+  });
+
+  // Throughput time series
+  api.get("/api/metrics/throughput", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const data = getThroughputTimeSeries(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch throughput metrics");
+    }
+  });
+
+  // Success rate metrics
+  api.get("/api/metrics/success-rate", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const data = getSuccessRate(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch success rate metrics");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/stats.ts` 신규: 6개 read-only 라우트 캡슐화
  - `/api/stats`, `/api/stats/costs`, `/api/stats/projects`
  - `/api/metrics/failure-reasons`, `/api/metrics/throughput`, `/api/metrics/success-rate`
- `safeError(c, e, prefix)` 적용 (6회)
- dashboard-api.ts에서 11개 unused import 정리:
  - `Get*QuerySchema` 5종 (Stats / Costs / ProjectStats / FailureReasons / Metrics)
  - `getJobStats` / `getCostStats` / `getProjectStatsWithTimeRange` / `getFailureReasons` / `getThroughputTimeSeries` / `getSuccessRate`
- dashboard-api.ts 1480 → 1345줄 (**-135**)

## 변경 파일
- 신규: `src/server/routes/stats.ts` (156줄)
- 수정: `src/server/dashboard-api.ts` (-135)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (본 PR): -135
- **총 -774줄, 2119 → 1345**

남은 도메인: config / setup / repositories / health / doctor / sse / skip-events / auth / new-issue