### PR TITLE
refactor(server): /api/config 라우트 분할 (Plan C #C9 6단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -7,15 +7,12 @@ import { resolve, join } from "path";
 import { homedir } from "os";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
-import { loadConfig, updateConfigSection } from "../config/loader.js";
-import { maskSensitiveConfig } from "../utils/config-masker.js";
-import { getBasicFieldMetas } from "../config/schema-meta.js";
-import { getPresets } from "../config/presets.js";
+import { loadConfig } from "../config/loader.js";
 import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { UpdateConfigRequestSchema, GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runAllChecks } from "../doctor/checks.js";
@@ -35,6 +32,7 @@ import { registerVersionRoutes } from "./routes/version.js";
 import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
+import { registerConfigRoutes } from "./routes/config.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -520,85 +518,10 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   }
 
-  // Get configuration (masked for security)
-  api.get("/api/config", (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const maskedConfig = maskSensitiveConfig(config);
-      return c.json({ config: maskedConfig });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to load configuration: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Get Basic tab field metadata (type, default, min/max, options)
-  api.get("/api/config/schema-meta", (c) => {
-    return c.json({ fields: getBasicFieldMetas() });
-  });
-
-  // Get config presets list
-  api.get("/api/config/presets", (c) => {
-    return c.json({ presets: getPresets() });
-  });
-
   const configPath = `${rootDir}/config.yml`;
 
-  // Update configuration
-  api.put("/api/config", zValidator('json', UpdateConfigRequestSchema.passthrough(), zodValidationHook), async (c) => {
-    try {
-      const body = c.req.valid('json');
-
-      // Update configuration file
-      // Filter out undefined values and complex sections (projects)
-      // hooks is passed through via the passthrough schema and saved to config
-      const { projects, ...safeData } = body as Record<string, unknown>;
-      const cleanedData = Object.fromEntries(
-        Object.entries(safeData).map(([key, value]) => [
-          key,
-          typeof value === 'object' && value !== null
-            ? Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined))
-            : value
-        ]).filter(([, v]) => v !== undefined)
-      ) as Partial<AQConfig>;
-
-      updateConfigSection(rootDir, cleanedData);
-      configWatcher?.refresh();
-
-      // Apply runtime changes if configWatcher is available
-      if (configWatcher) {
-        try {
-          // Load updated config for runtime application
-          const newConfig = configWatcher.current();
-
-          // Apply runtime changes immediately (force update)
-          if (body.general?.concurrency !== undefined) {
-            queue.setConcurrency(newConfig.general.concurrency);
-          }
-          if (body.general?.logLevel !== undefined) {
-            setGlobalLogLevel(newConfig.general.logLevel);
-          }
-
-          // Broadcast config change to SSE clients
-          broadcastToAllClients('configChanged', {
-            changes: body,
-            timestamp: new Date().toISOString()
-          });
-        } catch (runtimeError: unknown) {
-          // Log runtime application error but don't fail the request
-          const logger = getLogger();
-          logger.warn(`Failed to apply runtime config changes: ${getErrorMessage(runtimeError)}`);
-        }
-      }
-
-      return c.json({ success: true, message: "Configuration updated successfully" });
-    } catch (error: unknown) {
-      const rawMessage = getErrorMessage(error);
-      const isValidationError = rawMessage.includes("validation") || rawMessage.includes("Invalid") || rawMessage.includes("not found");
-      const status = isValidationError ? 400 : 500;
-      const prefix = isValidationError ? "Configuration validation failed" : "Failed to update configuration";
-      return c.json({ error: `${prefix}: ${sanitizeErrorMessage(rawMessage)}` }, status);
-    }
-  });
+  // Config: 도메인 라우트 분할 (Plan C #C9)
+  registerConfigRoutes(api, { queue, sseManager, configWatcher, rootDir });
 
   // Projects: 도메인 라우트 분할 (Plan C #C9)
   registerProjectsRoutes(api, { queue, configWatcher, rootDir, configPath });

--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -1,0 +1,117 @@
+import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { SSEManager } from "../sse-manager.js";
+import type { AQConfig } from "../../types/config.js";
+import { safeError } from "../route-context.js";
+import { loadConfig, updateConfigSection } from "../../config/loader.js";
+import { maskSensitiveConfig } from "../../utils/config-masker.js";
+import { getBasicFieldMetas } from "../../config/schema-meta.js";
+import { getPresets } from "../../config/presets.js";
+import { UpdateConfigRequestSchema } from "../../types/api.js";
+import { zodValidationHook } from "../dashboard-api.js";
+import { setGlobalLogLevel, getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+export interface ConfigRouteContext {
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+}
+
+/**
+ * /api/config/* 라우트 등록 (Plan C #C9 — 6단계).
+ *
+ * 이전: dashboard-api.ts 524-601 (4 routes, 78줄).
+ * GET /api/config는 마스킹된 설정을 반환하고, PUT은 업데이트 후 런타임 적용 +
+ * SSE 브로드캐스트까지 수행한다.
+ */
+export function registerConfigRoutes(api: Hono, ctx: ConfigRouteContext): void {
+  const { queue, sseManager, configWatcher, rootDir } = ctx;
+
+  // Get configuration (masked for security)
+  api.get("/api/config", (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const maskedConfig = maskSensitiveConfig(config);
+      return c.json({ config: maskedConfig });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to load configuration");
+    }
+  });
+
+  // Get Basic tab field metadata (type, default, min/max, options)
+  api.get("/api/config/schema-meta", (c) => {
+    return c.json({ fields: getBasicFieldMetas() });
+  });
+
+  // Get config presets list
+  api.get("/api/config/presets", (c) => {
+    return c.json({ presets: getPresets() });
+  });
+
+  // Update configuration
+  api.put(
+    "/api/config",
+    zValidator("json", UpdateConfigRequestSchema.passthrough(), zodValidationHook),
+    async (c) => {
+      try {
+        const body = c.req.valid("json");
+
+        // Filter out undefined values and complex sections (projects).
+        // hooks는 passthrough 스키마로 통과되어 config에 저장된다.
+        const { projects: _projects, ...safeData } = body as Record<string, unknown>;
+        const cleanedData = Object.fromEntries(
+          Object.entries(safeData)
+            .map(([key, value]) => [
+              key,
+              typeof value === "object" && value !== null
+                ? Object.fromEntries(
+                    Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined)
+                  )
+                : value,
+            ])
+            .filter(([, v]) => v !== undefined)
+        ) as Partial<AQConfig>;
+
+        updateConfigSection(rootDir, cleanedData);
+        configWatcher?.refresh();
+
+        if (configWatcher) {
+          try {
+            const newConfig = configWatcher.current();
+
+            if (body.general?.concurrency !== undefined) {
+              queue.setConcurrency(newConfig.general.concurrency);
+            }
+            if (body.general?.logLevel !== undefined) {
+              setGlobalLogLevel(newConfig.general.logLevel);
+            }
+
+            sseManager.broadcast("configChanged", {
+              changes: body,
+              timestamp: new Date().toISOString(),
+            });
+          } catch (runtimeError: unknown) {
+            // 런타임 적용 실패는 요청 자체를 실패로 만들지 않는다 — 경고만 남기고 응답은 success.
+            getLogger().warn(`Failed to apply runtime config changes: ${getErrorMessage(runtimeError)}`);
+          }
+        }
+
+        return c.json({ success: true, message: "Configuration updated successfully" });
+      } catch (error: unknown) {
+        const rawMessage = getErrorMessage(error);
+        const isValidationError =
+          rawMessage.includes("validation") ||
+          rawMessage.includes("Invalid") ||
+          rawMessage.includes("not found");
+        const status = isValidationError ? 400 : 500;
+        const prefix = isValidationError ? "Configuration validation failed" : "Failed to update configuration";
+        return c.json({ error: `${prefix}: ${sanitizeErrorMessage(rawMessage)}` }, status);
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/config.ts` 신규: 4개 라우트 캡슐화
  - `GET /api/config` (마스킹된 설정 반환)
  - `GET /api/config/schema-meta` (Basic 탭 필드 메타)
  - `GET /api/config/presets` (preset 목록)
  - `PUT /api/config` (업데이트 + 런타임 적용 + SSE 브로드캐스트)
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts에서 unused import 정리: `maskSensitiveConfig` / `getBasicFieldMetas` / `getPresets` / `updateConfigSection` / `UpdateConfigRequestSchema`
- dashboard-api.ts 1345 → 1268줄 (**-77**)

## 변경 파일
- 신규: `src/server/routes/config.ts` (117줄)
- 수정: `src/server/dashboard-api.ts` (-77)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (본 PR): -77
- **총 -851줄, 2119 → 1268**

남은 도메인: setup / repositories / health / doctor / sse / skip-events / auth / new-issue