### PR TITLE
refactor(server): /api/setup 라우트 분할 (Plan C #C9 7단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -2,9 +2,7 @@ import { Hono, type Context, type Next } from "hono";
 import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
-import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
 import { resolve, join } from "path";
-import { homedir } from "os";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig } from "../config/loader.js";
@@ -33,6 +31,7 @@ import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
+import { registerSetupRoutes } from "./routes/setup.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -278,48 +277,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
 }
 
 const SSE_INITIAL_JOB_LIMIT = 20;
-
-const SetupPreviewBodySchema = z.object({
-  repo: z.string().min(1),
-  repoPath: z.string().min(1),
-  baseBranch: z.string().optional(),
-  mode: z.string().optional(),
-  token: z.string().optional(),
-});
-
-const SetupLabelsBodySchema = z.object({
-  repo: z.string().min(1),
-  token: z.string().min(1),
-  labels: z.array(z.string().min(1)).default(["aqm-by"]),
-});
-
-function generateSetupYaml(repo: string, repoPath: string, baseBranch?: string, mode?: string): string {
-  const projectLines = [
-    `  - repo: "${repo}"`,
-    `    path: "${repoPath}"`,
-  ];
-  if (baseBranch) projectLines.push(`    baseBranch: "${baseBranch}"`);
-  if (mode) projectLines.push(`    mode: "${mode}"`);
-  return `# AI Quartermaster 설정 파일\n# 전체 옵션은 docs/config-schema.md 참조\n\nprojects:\n${projectLines.join('\n')}\n`;
-}
-
-function computeYamlDiff(
-  existingYaml: string | null,
-  newYaml: string
-): { added: string[]; removed: string[]; unchanged: string[] } {
-  const newLines = newYaml.split('\n').filter(l => l.trim());
-  if (!existingYaml) {
-    return { added: newLines, removed: [], unchanged: [] };
-  }
-  const existingLines = existingYaml.split('\n').filter(l => l.trim());
-  const existingSet = new Set(existingLines);
-  const newSet = new Set(newLines);
-  return {
-    added: newLines.filter(l => !existingSet.has(l)),
-    removed: existingLines.filter(l => !newSet.has(l)),
-    unchanged: newLines.filter(l => existingSet.has(l)),
-  };
-}
 
 const NewIssueRequestSchema = z.object({
   category: z.enum(["bug", "feature", "refactor", "docs"]),
@@ -923,175 +880,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  // Setup wizard: validate GitHub personal access token
-  api.get("/api/setup/validate-token", async (c) => {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
-    }
-
-    const token = authHeader.slice("Bearer ".length).trim();
-    if (!token) {
-      return c.json({ error: "Token must not be empty" }, 400);
-    }
-
-    try {
-      const response = await fetch("https://api.github.com/user", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "AI-Quartermaster",
-        },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          return c.json({ error: "Invalid GitHub token" }, 401);
-        }
-        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
-      }
-
-      const data = (await response.json()) as Record<string, unknown>;
-      const username = typeof data.login === "string" ? data.login : null;
-      const avatarUrl = typeof data.avatar_url === "string" ? data.avatar_url : null;
-      const publicRepos = typeof data.public_repos === "number" ? data.public_repos : null;
-
-      return c.json({ username, avatar_url: avatarUrl, public_repos: publicRepos });
-    } catch (error: unknown) {
-      return c.json({ error: `Token validation failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: fetch authenticated user's GitHub repos
-  api.get("/api/setup/repos", async (c) => {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
-    }
-    const token = authHeader.slice("Bearer ".length).trim();
-    if (!token) {
-      return c.json({ error: "Token must not be empty" }, 400);
-    }
-
-    try {
-      const response = await fetch(
-        "https://api.github.com/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator",
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "AI-Quartermaster",
-          },
-        }
-      );
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          return c.json({ error: "Invalid GitHub token" }, 401);
-        }
-        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
-      }
-
-      const data = (await response.json()) as Array<Record<string, unknown>>;
-      const repos = data
-        .filter((r) => typeof r.full_name === "string")
-        .map((r) => ({
-          full_name: r.full_name as string,
-          private: Boolean(r.private),
-          description: typeof r.description === "string" ? r.description : null,
-        }));
-      return c.json({ repos });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch repos: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: auto-create AQM labels in the target repository
-  api.post("/api/setup/labels", zValidator('json', SetupLabelsBodySchema, zodValidationHook), async (c) => {
-    const { repo, token, labels } = c.req.valid('json');
-
-    const ghHeaders: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "AI-Quartermaster",
-      "Content-Type": "application/json",
-    };
-
-    const results: Array<{ label: string; status: "created" | "skipped" | "failed" }> = [];
-
-    for (const label of labels) {
-      try {
-        const checkResp = await fetch(
-          `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(label)}`,
-          { headers: ghHeaders }
-        );
-
-        if (checkResp.status === 200) {
-          results.push({ label, status: "skipped" });
-          continue;
-        }
-
-        if (checkResp.status !== 404) {
-          results.push({ label, status: "failed" });
-          continue;
-        }
-
-        // Label doesn't exist — create it
-        const createResp = await fetch(`https://api.github.com/repos/${repo}/labels`, {
-          method: "POST",
-          headers: ghHeaders,
-          body: JSON.stringify({ name: label, color: "0075ca", description: "AI Quartermaster task" }),
-        });
-        results.push({ label, status: createResp.ok ? "created" : "failed" });
-      } catch {
-        results.push({ label, status: "failed" });
-      }
-    }
-
-    return c.json({ results });
-  });
-
-  // Setup wizard: preview YAML diff before applying
-  api.post("/api/setup/preview", zValidator('json', SetupPreviewBodySchema, zodValidationHook), async (c) => {
-    try {
-      const { repo, repoPath, baseBranch, mode } = c.req.valid('json');
-      const configPath = resolve(rootDir, "config.yml");
-      const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
-      const existingYaml = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
-      const diff = computeYamlDiff(existingYaml, newYaml);
-      return c.json({ yaml: newYaml, existingYaml, diff });
-    } catch (error: unknown) {
-      return c.json({ error: `Preview failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: apply config.yml with backup
-  api.post("/api/setup/apply", zValidator('json', SetupPreviewBodySchema, zodValidationHook), async (c) => {
-    try {
-      const { repo, repoPath, baseBranch, mode, token } = c.req.valid('json');
-      const configPath = resolve(rootDir, "config.yml");
-      let backupPath: string | null = null;
-      if (existsSync(configPath)) {
-        // 타임스탬프 접미사로 이전 백업을 보존한다 (여러 번 apply 해도 직전 상태로 롤백 가능)
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        backupPath = `${configPath}.bak.${timestamp}`;
-        copyFileSync(configPath, backupPath);
-      }
-      const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
-      writeFileSync(configPath, newYaml, 'utf-8');
-      if (token) {
-        const credentialsDir = join(homedir(), '.aqm');
-        mkdirSync(credentialsDir, { recursive: true });
-        writeFileSync(join(credentialsDir, 'credentials'), `GITHUB_TOKEN=${token}\n`, { mode: 0o600 });
-      }
-      return c.json({ success: true, configPath, backupPath });
-    } catch (error: unknown) {
-      return c.json({ error: `Apply failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
+  registerSetupRoutes(api, { rootDir });
 
   // Health check endpoint
   api.get("/api/health", async (c) => {

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -1,0 +1,238 @@
+import type { Hono } from "hono";
+import { resolve, join } from "path";
+import { homedir } from "os";
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { safeError } from "../route-context.js";
+import { zodValidationHook } from "../dashboard-api.js";
+
+export interface SetupRouteContext {
+  rootDir: string;
+}
+
+const SetupPreviewBodySchema = z.object({
+  repo: z.string().min(1),
+  repoPath: z.string().min(1),
+  baseBranch: z.string().optional(),
+  mode: z.string().optional(),
+  token: z.string().optional(),
+});
+
+const SetupLabelsBodySchema = z.object({
+  repo: z.string().min(1),
+  token: z.string().min(1),
+  labels: z.array(z.string().min(1)).default(["aqm-by"]),
+});
+
+const GH_HEADERS_BASE = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "AI-Quartermaster",
+} as const;
+
+function generateSetupYaml(repo: string, repoPath: string, baseBranch?: string, mode?: string): string {
+  const projectLines = [
+    `  - repo: "${repo}"`,
+    `    path: "${repoPath}"`,
+  ];
+  if (baseBranch) projectLines.push(`    baseBranch: "${baseBranch}"`);
+  if (mode) projectLines.push(`    mode: "${mode}"`);
+  return `# AI Quartermaster 설정 파일\n# 전체 옵션은 docs/config-schema.md 참조\n\nprojects:\n${projectLines.join("\n")}\n`;
+}
+
+function computeYamlDiff(
+  existingYaml: string | null,
+  newYaml: string
+): { added: string[]; removed: string[]; unchanged: string[] } {
+  const newLines = newYaml.split("\n").filter((l) => l.trim());
+  if (!existingYaml) {
+    return { added: newLines, removed: [], unchanged: [] };
+  }
+  const existingLines = existingYaml.split("\n").filter((l) => l.trim());
+  const existingSet = new Set(existingLines);
+  const newSet = new Set(newLines);
+  return {
+    added: newLines.filter((l) => !existingSet.has(l)),
+    removed: existingLines.filter((l) => !newSet.has(l)),
+    unchanged: newLines.filter((l) => existingSet.has(l)),
+  };
+}
+
+/**
+ * /api/setup/* 라우트 등록 (Plan C #C9 — 7단계).
+ *
+ * 이전: dashboard-api.ts 927-1095 (5 routes, ~170줄) + 인라인 스키마/헬퍼.
+ * 셋업 위자드 흐름: validate-token → repos 목록 → labels 자동 생성 → preview → apply.
+ */
+export function registerSetupRoutes(api: Hono, ctx: SetupRouteContext): void {
+  const { rootDir } = ctx;
+
+  // Validate GitHub personal access token
+  api.get("/api/setup/validate-token", async (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
+    }
+
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) {
+      return c.json({ error: "Token must not be empty" }, 400);
+    }
+
+    try {
+      const response = await fetch("https://api.github.com/user", {
+        headers: { ...GH_HEADERS_BASE, Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return c.json({ error: "Invalid GitHub token" }, 401);
+        }
+        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
+      }
+
+      const data = (await response.json()) as Record<string, unknown>;
+      const username = typeof data.login === "string" ? data.login : null;
+      const avatarUrl = typeof data.avatar_url === "string" ? data.avatar_url : null;
+      const publicRepos = typeof data.public_repos === "number" ? data.public_repos : null;
+
+      return c.json({ username, avatar_url: avatarUrl, public_repos: publicRepos });
+    } catch (error: unknown) {
+      return safeError(c, error, "Token validation failed");
+    }
+  });
+
+  // Fetch authenticated user's GitHub repos
+  api.get("/api/setup/repos", async (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
+    }
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) {
+      return c.json({ error: "Token must not be empty" }, 400);
+    }
+
+    try {
+      const response = await fetch(
+        "https://api.github.com/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator",
+        { headers: { ...GH_HEADERS_BASE, Authorization: `Bearer ${token}` } }
+      );
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return c.json({ error: "Invalid GitHub token" }, 401);
+        }
+        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
+      }
+
+      const data = (await response.json()) as Array<Record<string, unknown>>;
+      const repos = data
+        .filter((r) => typeof r.full_name === "string")
+        .map((r) => ({
+          full_name: r.full_name as string,
+          private: Boolean(r.private),
+          description: typeof r.description === "string" ? r.description : null,
+        }));
+      return c.json({ repos });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch repos");
+    }
+  });
+
+  // Auto-create AQM labels in the target repository
+  api.post(
+    "/api/setup/labels",
+    zValidator("json", SetupLabelsBodySchema, zodValidationHook),
+    async (c) => {
+      const { repo, token, labels } = c.req.valid("json");
+
+      const ghHeaders: Record<string, string> = {
+        ...GH_HEADERS_BASE,
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      };
+
+      const results: Array<{ label: string; status: "created" | "skipped" | "failed" }> = [];
+
+      for (const label of labels) {
+        try {
+          const checkResp = await fetch(
+            `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(label)}`,
+            { headers: ghHeaders }
+          );
+
+          if (checkResp.status === 200) {
+            results.push({ label, status: "skipped" });
+            continue;
+          }
+
+          if (checkResp.status !== 404) {
+            results.push({ label, status: "failed" });
+            continue;
+          }
+
+          // Label doesn't exist — create it
+          const createResp = await fetch(`https://api.github.com/repos/${repo}/labels`, {
+            method: "POST",
+            headers: ghHeaders,
+            body: JSON.stringify({ name: label, color: "0075ca", description: "AI Quartermaster task" }),
+          });
+          results.push({ label, status: createResp.ok ? "created" : "failed" });
+        } catch {
+          results.push({ label, status: "failed" });
+        }
+      }
+
+      return c.json({ results });
+    }
+  );
+
+  // Preview YAML diff before applying
+  api.post(
+    "/api/setup/preview",
+    zValidator("json", SetupPreviewBodySchema, zodValidationHook),
+    async (c) => {
+      try {
+        const { repo, repoPath, baseBranch, mode } = c.req.valid("json");
+        const configPath = resolve(rootDir, "config.yml");
+        const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
+        const existingYaml = existsSync(configPath) ? readFileSync(configPath, "utf-8") : null;
+        const diff = computeYamlDiff(existingYaml, newYaml);
+        return c.json({ yaml: newYaml, existingYaml, diff });
+      } catch (error: unknown) {
+        return safeError(c, error, "Preview failed");
+      }
+    }
+  );
+
+  // Apply config.yml with backup
+  api.post(
+    "/api/setup/apply",
+    zValidator("json", SetupPreviewBodySchema, zodValidationHook),
+    async (c) => {
+      try {
+        const { repo, repoPath, baseBranch, mode, token } = c.req.valid("json");
+        const configPath = resolve(rootDir, "config.yml");
+        let backupPath: string | null = null;
+        if (existsSync(configPath)) {
+          // 타임스탬프 접미사로 이전 백업 보존 (여러 번 apply 해도 직전 상태로 롤백 가능)
+          const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+          backupPath = `${configPath}.bak.${timestamp}`;
+          copyFileSync(configPath, backupPath);
+        }
+        const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
+        writeFileSync(configPath, newYaml, "utf-8");
+        if (token) {
+          const credentialsDir = join(homedir(), ".aqm");
+          mkdirSync(credentialsDir, { recursive: true });
+          writeFileSync(join(credentialsDir, "credentials"), `GITHUB_TOKEN=${token}\n`, { mode: 0o600 });
+        }
+        return c.json({ success: true, configPath, backupPath });
+      } catch (error: unknown) {
+        return safeError(c, error, "Apply failed");
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/setup.ts` 신규: 5개 라우트 캡슐화 (셋업 위자드)
  - `GET /api/setup/validate-token` (GitHub PAT 검증)
  - `GET /api/setup/repos` (사용자 repo 목록)
  - `POST /api/setup/labels` (AQM 라벨 자동 생성)
  - `POST /api/setup/preview` (config.yml diff 미리보기)
  - `POST /api/setup/apply` (config.yml 백업 + 적용)
- 인라인 헬퍼 이전: `generateSetupYaml`, `computeYamlDiff`, `SetupPreviewBodySchema`, `SetupLabelsBodySchema`
- GitHub 공통 헤더(`GH_HEADERS_BASE`) 상수화로 중복 제거
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts unused import 정리: `readFileSync` / `writeFileSync` / `copyFileSync` / `mkdirSync` / `homedir`
- dashboard-api.ts 1268 → 1058줄 (**-210**)

## 변경 파일
- 신규: `src/server/routes/setup.ts` (238줄)
- 수정: `src/server/dashboard-api.ts` (-210)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (본 PR): -210
- **총 -1061줄, 2119 → 1058**

남은 도메인: repositories / health / doctor / sse / skip-events / auth / new-issue