### PR TITLE
refactor(server): /api/doctor 라우트 분할 (Plan C #C9 8단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -13,8 +13,6 @@ import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
 import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { runAllChecks } from "../doctor/checks.js";
-import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
 import { runCli } from "../utils/cli-runner.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
@@ -32,6 +30,7 @@ import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
+import { registerDoctorRoutes } from "./routes/doctor.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -974,82 +973,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  api.get("/api/doctor/run", async (c) => {
-    try {
-      const checks = await runAllChecks();
-      return c.json({ checks });
-    } catch (error: unknown) {
-      return c.json({ error: `Doctor run failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // POST /api/doctor/heal/stdin — stdin bridge for active Level2 process
-  // Declared before :id route so 'stdin' is not captured as checkId
-  api.post("/api/doctor/heal/stdin", async (c) => {
-    const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
-    const input = typeof body?.input === 'string' ? body.input : null;
-    if (input === null) {
-      return c.json({ error: "Missing 'input' field" }, 400);
-    }
-    const ok = writeToActiveHealProcess(input);
-    if (!ok) {
-      return c.json({ error: "No active heal process" }, 404);
-    }
-    return c.json({ ok: true });
-  });
-
-  // POST /api/doctor/heal/:id — Level1 auto-fix (runs autoFixCommand, waits for completion)
-  api.post("/api/doctor/heal/:id", async (c) => {
-    const checkId = c.req.param("id");
-    try {
-      const result = await healLevel1(checkId);
-      return c.json({ ok: true, stdout: result.stdout, stderr: result.stderr });
-    } catch (error: unknown) {
-      return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
-    }
-  });
-
-  // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
-  api.get("/api/doctor/heal/:id/stream", (c) => {
-    const checkId = c.req.param("id");
-    const encoder = new TextEncoder();
-
-    const stream = new ReadableStream({
-      start(controller) {
-        healLevel2(checkId, {
-          onData(chunk) {
-            try {
-              for (const line of chunk.split('\n')) {
-                if (line.length > 0) {
-                  controller.enqueue(encoder.encode(`data: ${line}\n\n`));
-                }
-              }
-            } catch { /* stream closed */ }
-          },
-          onDone() {
-            try {
-              controller.enqueue(encoder.encode(`event: done\ndata: \n\n`));
-              controller.close();
-            } catch { /* already closed */ }
-          },
-          onFail(msg) {
-            try {
-              controller.enqueue(encoder.encode(`event: fail\ndata: ${msg}\n\n`));
-              controller.close();
-            } catch { /* already closed */ }
-          },
-        });
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
+  // Doctor: 도메인 라우트 분할 (Plan C #C9)
+  registerDoctorRoutes(api);
 
   // Notifications: 도메인 라우트 분할 (Plan C #C9)
   registerNotificationsRoutes(api, { store, sseManager, readOnly: !!readOnly });

--- a/src/server/routes/doctor.ts
+++ b/src/server/routes/doctor.ts
@@ -1,0 +1,91 @@
+import type { Hono } from "hono";
+import { safeError } from "../route-context.js";
+import { runAllChecks } from "../../doctor/checks.js";
+import { healLevel1, healLevel2, writeToActiveHealProcess } from "../../doctor/heal.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+/**
+ * /api/doctor/* 라우트 등록 (Plan C #C9 — 8단계).
+ *
+ * 이전: dashboard-api.ts 977-1052 (4 routes, ~75줄).
+ * 의존성이 doctor 모듈에 한정되어 ctx 인자가 없다.
+ */
+export function registerDoctorRoutes(api: Hono): void {
+  api.get("/api/doctor/run", async (c) => {
+    try {
+      const checks = await runAllChecks();
+      return c.json({ checks });
+    } catch (error: unknown) {
+      return safeError(c, error, "Doctor run failed");
+    }
+  });
+
+  // POST /api/doctor/heal/stdin — stdin bridge for active Level2 process.
+  // Declared BEFORE :id route so "stdin" is not captured as checkId.
+  api.post("/api/doctor/heal/stdin", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+    const input = typeof body?.input === "string" ? body.input : null;
+    if (input === null) {
+      return c.json({ error: "Missing 'input' field" }, 400);
+    }
+    const ok = writeToActiveHealProcess(input);
+    if (!ok) {
+      return c.json({ error: "No active heal process" }, 404);
+    }
+    return c.json({ ok: true });
+  });
+
+  // POST /api/doctor/heal/:id — Level1 auto-fix (runs autoFixCommand, waits for completion)
+  api.post("/api/doctor/heal/:id", async (c) => {
+    const checkId = c.req.param("id");
+    try {
+      const result = await healLevel1(checkId);
+      return c.json({ ok: true, stdout: result.stdout, stderr: result.stderr });
+    } catch (error: unknown) {
+      return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
+    }
+  });
+
+  // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
+  api.get("/api/doctor/heal/:id/stream", (c) => {
+    const checkId = c.req.param("id");
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream({
+      start(controller) {
+        healLevel2(checkId, {
+          onData(chunk) {
+            try {
+              for (const line of chunk.split("\n")) {
+                if (line.length > 0) {
+                  controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+                }
+              }
+            } catch { /* stream closed */ }
+          },
+          onDone() {
+            try {
+              controller.enqueue(encoder.encode(`event: done\ndata: \n\n`));
+              controller.close();
+            } catch { /* already closed */ }
+          },
+          onFail(msg) {
+            try {
+              controller.enqueue(encoder.encode(`event: fail\ndata: ${msg}\n\n`));
+              controller.close();
+            } catch { /* already closed */ }
+          },
+        });
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      },
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/doctor.ts` 신규: 4개 라우트 캡슐화
  - `GET /api/doctor/run` (전체 검사)
  - `POST /api/doctor/heal/stdin` (활성 Level2 프로세스 stdin 브릿지)
  - `POST /api/doctor/heal/:id` (Level1 자동 수정)
  - `GET /api/doctor/heal/:id/stream` (Level2 SSE 스트리밍)
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts에서 doctor 모듈 import 정리: `runAllChecks` / `healLevel1` / `healLevel2` / `writeToActiveHealProcess`
- dashboard-api.ts 1058 → 983줄 (**-75**) — **1000줄 아래로 진입**

## 변경 파일
- 신규: `src/server/routes/doctor.ts` (91줄)
- 수정: `src/server/dashboard-api.ts` (-75)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (#826): -210
- 8단계 doctor (본 PR): -75
- **총 -1136줄, 2119 → 983 (1000줄 미만 달성)**

남은 도메인: repositories / health / sse / skip-events / auth / new-issue / projects-health