### PR TITLE
refactor(server): /api/repositories + projects-health + health 라우트 분할 (Plan C #C9 9단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -10,14 +10,12 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
-import { getProjectSummary } from "../store/queries.js";
+import { GetSkipEventsQuerySchema, formatZodError } from "../types/api.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runCli } from "../utils/cli-runner.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { statusToNotificationType } from "../types/pipeline.js";
-import { existsSync, statSync } from "fs";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
@@ -31,6 +29,7 @@ import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
 import { registerDoctorRoutes } from "./routes/doctor.js";
+import { registerHealthRoutes } from "./routes/health.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -131,100 +130,6 @@ export function zodValidationHook(
 }
 
 export { zValidator };
-
-/**
- * Health check helper functions
- */
-async function checkGitRemoteAccess(projectPath: string, gitPath: string): Promise<{ status: "ok" | "error"; message?: string }> {
-  try {
-    const result = await runCli(gitPath, ["ls-remote", "--heads", "origin"], { cwd: projectPath, timeout: 10000 });
-    if (result.exitCode !== 0) {
-      return {
-        status: "error",
-        message: `Git remote not accessible: ${result.stderr || "Cannot connect to remote"}`
-      };
-    }
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Git remote check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkLocalPath(projectPath: string): Promise<{ status: "ok" | "error"; message?: string }> {
-  try {
-    if (!existsSync(projectPath)) {
-      return { status: "error", message: "Project path does not exist" };
-    }
-
-    const stats = statSync(projectPath);
-    if (!stats.isDirectory()) {
-      return { status: "error", message: "Project path is not a directory" };
-    }
-
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Local path check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkDiskSpace(projectPath: string): Promise<{ status: "ok" | "warning" | "error"; message?: string; freeBytes?: number }> {
-  try {
-    const result = await runCli("df", ["-B1", projectPath], { timeout: 5000 });
-    if (result.exitCode !== 0) {
-      return { status: "warning", message: "Could not check disk space" };
-    }
-
-    const lines = result.stdout.trim().split('\n');
-    if (lines.length < 2) {
-      return { status: "warning", message: "Could not parse disk space output" };
-    }
-
-    const parts = lines[1].split(/\s+/);
-    const available = parseInt(parts[3] || "0", 10);
-
-    if (available === 0) {
-      return { status: "error", message: "No free disk space", freeBytes: available };
-    } else if (available < 1024 * 1024 * 1024) { // Less than 1GB
-      return { status: "warning", message: "Low disk space (< 1GB)", freeBytes: available };
-    }
-
-    return { status: "ok", freeBytes: available };
-  } catch (error: unknown) {
-    return {
-      status: "warning",
-      message: `Disk space check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkDependencies(projectPath: string): Promise<{ status: "ok" | "warning" | "error"; message?: string }> {
-  try {
-    // Check if package.json exists
-    const packageJsonPath = resolve(projectPath, "package.json");
-    if (!existsSync(packageJsonPath)) {
-      return { status: "warning", message: "No package.json found" };
-    }
-
-    // Check if node_modules exists
-    const nodeModulesPath = resolve(projectPath, "node_modules");
-    if (!existsSync(nodeModulesPath)) {
-      return { status: "warning", message: "Dependencies not installed (no node_modules)" };
-    }
-
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Dependencies check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
 
 /**
  * Applies runtime configuration changes to system components.
@@ -706,238 +611,11 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     setQuotaStatus: (s) => { currentQuotaStatus = s; },
   });
 
-  // Repositories API - project-level aggregated information with health and stats
-  api.get("/api/repositories", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projects = config.projects ?? [];
-
-      if (projects.length === 0) {
-        return c.json({
-          repositories: [],
-          summary: { total: 0, healthy: 0, warning: 0, error: 0, totalJobs: 0, checkedAt: new Date().toISOString() },
-        });
-      }
-
-      const gitPath = config.git?.gitPath ?? "git";
-
-      // Get health checks for all projects in parallel
-      const healthResults = await Promise.all(
-        projects.map(async (projectConfig) => {
-          const projectPath = resolve(rootDir, projectConfig.path);
-          const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck, worktreeCount] = await Promise.all([
-            checkGitRemoteAccess(projectPath, gitPath),
-            checkLocalPath(projectPath),
-            checkDiskSpace(projectPath),
-            checkDependencies(projectPath),
-            runCli(gitPath, ["worktree", "list", "--porcelain"], { cwd: projectPath }).then(result =>
-              result.exitCode === 0 ? result.stdout.trim().split('\n').filter(line => line.startsWith('worktree ')).length : 0
-            ).catch(() => 0), // Fall back to 0 if git worktree fails
-          ]);
-
-          let overallStatus: "healthy" | "warning" | "error" = "healthy";
-          if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-            overallStatus = "error";
-          } else if (
-            diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-            dependenciesCheck.status === "warning" || dependenciesCheck.status === "error"
-          ) {
-            overallStatus = "warning";
-          }
-
-          return {
-            repository: projectConfig.repo,
-            name: projectConfig.repo,
-            path: projectConfig.path,
-            status: overallStatus,
-            worktreeCount,
-            health: {
-              gitRemoteAccess: gitRemoteCheck,
-              localPath: localPathCheck,
-              diskSpace: diskSpaceCheck,
-              dependencies: dependenciesCheck,
-            },
-            lastChecked: new Date().toISOString(),
-          };
-        })
-      );
-
-      // Get project statistics
-      const projectStats = getProjectSummary(store.getAqDb());
-      const statsMap = new Map(projectStats.map(s => [s.repo, s]));
-
-      // Combine health results with statistics
-      const repositories = healthResults.map(result => {
-        const stats = statsMap.get(result.repository) ?? {
-          repo: result.repository,
-          total: 0,
-          successCount: 0,
-          failureCount: 0,
-          totalCostUsd: 0,
-          successRate: 0,
-          lastActivity: null,
-        };
-
-        return {
-          ...result,
-          stats: {
-            totalJobs: stats.total,
-            successJobs: stats.successCount,
-            failedJobs: stats.failureCount,
-            successRate: stats.successRate,
-            totalCostUsd: stats.totalCostUsd,
-            lastActivity: stats.lastActivity,
-          },
-        };
-      });
-
-      const summary = {
-        total: repositories.length,
-        healthy: repositories.filter(r => r.status === "healthy").length,
-        warning: repositories.filter(r => r.status === "warning").length,
-        error: repositories.filter(r => r.status === "error").length,
-        totalJobs: repositories.reduce((sum, r) => sum + r.stats.totalJobs, 0),
-        checkedAt: new Date().toISOString(),
-      };
-
-      return c.json({ repositories, summary });
-    } catch (error: unknown) {
-      const logger = getLogger();
-      logger.error(`Failed to fetch repositories: ${getErrorMessage(error)}`);
-      return c.json({ error: "Failed to fetch repositories" }, 500);
-    }
-  });
-
-  // Projects health check endpoint — all configured projects
-  api.get("/api/projects/health", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projects = config.projects ?? [];
-
-      if (projects.length === 0) {
-        return c.json({
-          projects: [],
-          summary: { total: 0, healthy: 0, warning: 0, error: 0, checkedAt: new Date().toISOString() },
-        });
-      }
-
-      const gitPath = config.git?.gitPath ?? "git";
-
-      const healthResults = await Promise.all(
-        projects.map(async (projectConfig) => {
-          const projectPath = resolve(rootDir, projectConfig.path);
-          const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
-            checkGitRemoteAccess(projectPath, gitPath),
-            checkLocalPath(projectPath),
-            checkDiskSpace(projectPath),
-            checkDependencies(projectPath),
-          ]);
-
-          let overallStatus: "healthy" | "warning" | "error" = "healthy";
-          if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-            overallStatus = "error";
-          } else if (
-            diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-            dependenciesCheck.status === "warning" || dependenciesCheck.status === "error"
-          ) {
-            overallStatus = "warning";
-          }
-
-          return {
-            project: projectConfig.repo,
-            status: overallStatus,
-            checks: {
-              gitRemoteAccess: gitRemoteCheck,
-              localPath: localPathCheck,
-              diskSpace: diskSpaceCheck,
-              dependencies: dependenciesCheck,
-            },
-            lastChecked: new Date().toISOString(),
-          };
-        })
-      );
-
-      const projectStats = getProjectSummary(store.getAqDb());
-      const statsMap = new Map(projectStats.map(s => [s.repo, s]));
-
-      const projectsWithStats = healthResults.map(result => ({
-        ...result,
-        stats: statsMap.get(result.project) ?? null,
-      }));
-
-      const summary = {
-        total: projectsWithStats.length,
-        healthy: projectsWithStats.filter(p => p.status === "healthy").length,
-        warning: projectsWithStats.filter(p => p.status === "warning").length,
-        error: projectsWithStats.filter(p => p.status === "error").length,
-        checkedAt: new Date().toISOString(),
-      };
-
-      return c.json({ projects: projectsWithStats, summary });
-    } catch (error: unknown) {
-      return c.json({ error: `Projects health check failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Health: 도메인 라우트 분할 (Plan C #C9) — repositories + projects/health + health
+  registerHealthRoutes(api, { store, configWatcher, rootDir });
 
   // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
   registerSetupRoutes(api, { rootDir });
-
-  // Health check endpoint
-  api.get("/api/health", async (c) => {
-    try {
-      const projectParam = c.req.query("project");
-      if (!projectParam) {
-        return c.json({ error: "project parameter is required" }, 400);
-      }
-
-      const project = decodeURIComponent(projectParam);
-
-      // Load configuration to get project path and git settings
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projectConfig = config.projects?.find(p => p.repo === project);
-
-      if (!projectConfig) {
-        return c.json({ error: `Project "${project}" not found in configuration` }, 404);
-      }
-
-      const projectPath = resolve(rootDir, projectConfig.path);
-      const gitPath = config.git?.gitPath || "git";
-
-      // Run health checks in parallel
-      const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
-        checkGitRemoteAccess(projectPath, gitPath),
-        checkLocalPath(projectPath),
-        checkDiskSpace(projectPath),
-        checkDependencies(projectPath)
-      ]);
-
-      // Determine overall status
-      let overallStatus: "healthy" | "warning" | "error" = "healthy";
-
-      if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-        overallStatus = "error";
-      } else if (diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-                 dependenciesCheck.status === "warning" || dependenciesCheck.status === "error") {
-        overallStatus = "warning";
-      }
-
-      const healthResponse: HealthCheckResponse = {
-        project,
-        status: overallStatus,
-        checks: {
-          gitRemoteAccess: gitRemoteCheck,
-          localPath: localPathCheck,
-          diskSpace: diskSpaceCheck,
-          dependencies: dependenciesCheck,
-        },
-        lastChecked: new Date().toISOString(),
-      };
-
-      return c.json(healthResponse);
-    } catch (error: unknown) {
-      return c.json({ error: `Health check failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
 
   // Create a new GitHub issue from dashboard
   api.post("/api/new-issue", zValidator('json', NewIssueRequestSchema, zodValidationHook), async (c) => {

--- a/src/server/health-checks.ts
+++ b/src/server/health-checks.ts
@@ -1,0 +1,111 @@
+import { resolve } from "path";
+import { existsSync, statSync } from "fs";
+import { runCli } from "../utils/cli-runner.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
+
+/**
+ * 프로젝트 헬스 체크 헬퍼 (Plan C #C9 — 9단계 분할 사전 작업).
+ *
+ * 이전: dashboard-api.ts 138-227 (4 헬퍼, ~95줄)에 인라인. /api/repositories,
+ *      /api/projects/health, /api/health 세 곳에서 중복 사용됐다.
+ * 이후: 본 모듈이 단일 진입점이 되어 라우트 파일 분할이 가능해진다.
+ */
+
+export async function checkGitRemoteAccess(
+  projectPath: string,
+  gitPath: string
+): Promise<{ status: "ok" | "error"; message?: string }> {
+  try {
+    const result = await runCli(gitPath, ["ls-remote", "--heads", "origin"], { cwd: projectPath, timeout: 10000 });
+    if (result.exitCode !== 0) {
+      return {
+        status: "error",
+        message: `Git remote not accessible: ${result.stderr || "Cannot connect to remote"}`,
+      };
+    }
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Git remote check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkLocalPath(
+  projectPath: string
+): Promise<{ status: "ok" | "error"; message?: string }> {
+  try {
+    if (!existsSync(projectPath)) {
+      return { status: "error", message: "Project path does not exist" };
+    }
+
+    const stats = statSync(projectPath);
+    if (!stats.isDirectory()) {
+      return { status: "error", message: "Project path is not a directory" };
+    }
+
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Local path check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkDiskSpace(
+  projectPath: string
+): Promise<{ status: "ok" | "warning" | "error"; message?: string; freeBytes?: number }> {
+  try {
+    const result = await runCli("df", ["-B1", projectPath], { timeout: 5000 });
+    if (result.exitCode !== 0) {
+      return { status: "warning", message: "Could not check disk space" };
+    }
+
+    const lines = result.stdout.trim().split("\n");
+    if (lines.length < 2) {
+      return { status: "warning", message: "Could not parse disk space output" };
+    }
+
+    const parts = lines[1].split(/\s+/);
+    const available = parseInt(parts[3] || "0", 10);
+
+    if (available === 0) {
+      return { status: "error", message: "No free disk space", freeBytes: available };
+    } else if (available < 1024 * 1024 * 1024) {
+      return { status: "warning", message: "Low disk space (< 1GB)", freeBytes: available };
+    }
+
+    return { status: "ok", freeBytes: available };
+  } catch (error: unknown) {
+    return {
+      status: "warning",
+      message: `Disk space check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkDependencies(
+  projectPath: string
+): Promise<{ status: "ok" | "warning" | "error"; message?: string }> {
+  try {
+    const packageJsonPath = resolve(projectPath, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      return { status: "warning", message: "No package.json found" };
+    }
+
+    const nodeModulesPath = resolve(projectPath, "node_modules");
+    if (!existsSync(nodeModulesPath)) {
+      return { status: "warning", message: "Dependencies not installed (no node_modules)" };
+    }
+
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Dependencies check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -1,0 +1,251 @@
+import type { Hono } from "hono";
+import { resolve } from "path";
+import type { JobStore } from "../../queue/job-store.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { HealthCheckResponse } from "../../types/api.js";
+import { safeError } from "../route-context.js";
+import { loadConfig } from "../../config/loader.js";
+import { getProjectSummary } from "../../store/queries.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import {
+  checkGitRemoteAccess,
+  checkLocalPath,
+  checkDiskSpace,
+  checkDependencies,
+} from "../health-checks.js";
+
+export interface HealthRouteContext {
+  store: JobStore;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+}
+
+/**
+ * 프로젝트 헬스 체크 결과 — repositories/projects-health/health 세 라우트가 공통으로 사용.
+ */
+type CheckResults = {
+  gitRemoteCheck: Awaited<ReturnType<typeof checkGitRemoteAccess>>;
+  localPathCheck: Awaited<ReturnType<typeof checkLocalPath>>;
+  diskSpaceCheck: Awaited<ReturnType<typeof checkDiskSpace>>;
+  dependenciesCheck: Awaited<ReturnType<typeof checkDependencies>>;
+};
+
+function deriveOverallStatus(c: CheckResults): "healthy" | "warning" | "error" {
+  if (c.gitRemoteCheck.status === "error" || c.localPathCheck.status === "error") {
+    return "error";
+  }
+  if (
+    c.diskSpaceCheck.status === "warning" ||
+    c.diskSpaceCheck.status === "error" ||
+    c.dependenciesCheck.status === "warning" ||
+    c.dependenciesCheck.status === "error"
+  ) {
+    return "warning";
+  }
+  return "healthy";
+}
+
+async function runProjectChecks(projectPath: string, gitPath: string): Promise<CheckResults> {
+  const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
+    checkGitRemoteAccess(projectPath, gitPath),
+    checkLocalPath(projectPath),
+    checkDiskSpace(projectPath),
+    checkDependencies(projectPath),
+  ]);
+  return { gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck };
+}
+
+/**
+ * /api/repositories, /api/projects/health, /api/health 라우트 등록 (Plan C #C9 — 9단계).
+ *
+ * 이전: dashboard-api.ts 711-940 (3 routes, ~230줄). 4개 검사 헬퍼는 인라인.
+ * 이후: 헬퍼는 src/server/health-checks.ts로 추출, 라우트는 본 파일로 응집.
+ *      runProjectChecks/deriveOverallStatus 헬퍼로 3개 라우트의 중복도 정리.
+ */
+export function registerHealthRoutes(api: Hono, ctx: HealthRouteContext): void {
+  const { store, configWatcher, rootDir } = ctx;
+
+  // Repositories — project-level aggregated info with health + stats
+  api.get("/api/repositories", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projects = config.projects ?? [];
+
+      if (projects.length === 0) {
+        return c.json({
+          repositories: [],
+          summary: { total: 0, healthy: 0, warning: 0, error: 0, totalJobs: 0, checkedAt: new Date().toISOString() },
+        });
+      }
+
+      const gitPath = config.git?.gitPath ?? "git";
+
+      const healthResults = await Promise.all(
+        projects.map(async (projectConfig) => {
+          const projectPath = resolve(rootDir, projectConfig.path);
+          const checks = await runProjectChecks(projectPath, gitPath);
+          const worktreeCount = await runCli(gitPath, ["worktree", "list", "--porcelain"], { cwd: projectPath })
+            .then((result) =>
+              result.exitCode === 0
+                ? result.stdout.trim().split("\n").filter((line) => line.startsWith("worktree ")).length
+                : 0
+            )
+            .catch(() => 0);
+
+          return {
+            repository: projectConfig.repo,
+            name: projectConfig.repo,
+            path: projectConfig.path,
+            status: deriveOverallStatus(checks),
+            worktreeCount,
+            health: {
+              gitRemoteAccess: checks.gitRemoteCheck,
+              localPath: checks.localPathCheck,
+              diskSpace: checks.diskSpaceCheck,
+              dependencies: checks.dependenciesCheck,
+            },
+            lastChecked: new Date().toISOString(),
+          };
+        })
+      );
+
+      const projectStats = getProjectSummary(store.getAqDb());
+      const statsMap = new Map(projectStats.map((s) => [s.repo, s]));
+
+      const repositories = healthResults.map((result) => {
+        const stats = statsMap.get(result.repository) ?? {
+          repo: result.repository,
+          total: 0,
+          successCount: 0,
+          failureCount: 0,
+          totalCostUsd: 0,
+          successRate: 0,
+          lastActivity: null,
+        };
+
+        return {
+          ...result,
+          stats: {
+            totalJobs: stats.total,
+            successJobs: stats.successCount,
+            failedJobs: stats.failureCount,
+            successRate: stats.successRate,
+            totalCostUsd: stats.totalCostUsd,
+            lastActivity: stats.lastActivity,
+          },
+        };
+      });
+
+      const summary = {
+        total: repositories.length,
+        healthy: repositories.filter((r) => r.status === "healthy").length,
+        warning: repositories.filter((r) => r.status === "warning").length,
+        error: repositories.filter((r) => r.status === "error").length,
+        totalJobs: repositories.reduce((sum, r) => sum + r.stats.totalJobs, 0),
+        checkedAt: new Date().toISOString(),
+      };
+
+      return c.json({ repositories, summary });
+    } catch (error: unknown) {
+      getLogger().error(`Failed to fetch repositories: ${getErrorMessage(error)}`);
+      return c.json({ error: "Failed to fetch repositories" }, 500);
+    }
+  });
+
+  // Projects health — all configured projects
+  api.get("/api/projects/health", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projects = config.projects ?? [];
+
+      if (projects.length === 0) {
+        return c.json({
+          projects: [],
+          summary: { total: 0, healthy: 0, warning: 0, error: 0, checkedAt: new Date().toISOString() },
+        });
+      }
+
+      const gitPath = config.git?.gitPath ?? "git";
+
+      const healthResults = await Promise.all(
+        projects.map(async (projectConfig) => {
+          const projectPath = resolve(rootDir, projectConfig.path);
+          const checks = await runProjectChecks(projectPath, gitPath);
+
+          return {
+            project: projectConfig.repo,
+            status: deriveOverallStatus(checks),
+            checks: {
+              gitRemoteAccess: checks.gitRemoteCheck,
+              localPath: checks.localPathCheck,
+              diskSpace: checks.diskSpaceCheck,
+              dependencies: checks.dependenciesCheck,
+            },
+            lastChecked: new Date().toISOString(),
+          };
+        })
+      );
+
+      const projectStats = getProjectSummary(store.getAqDb());
+      const statsMap = new Map(projectStats.map((s) => [s.repo, s]));
+
+      const projectsWithStats = healthResults.map((result) => ({
+        ...result,
+        stats: statsMap.get(result.project) ?? null,
+      }));
+
+      const summary = {
+        total: projectsWithStats.length,
+        healthy: projectsWithStats.filter((p) => p.status === "healthy").length,
+        warning: projectsWithStats.filter((p) => p.status === "warning").length,
+        error: projectsWithStats.filter((p) => p.status === "error").length,
+        checkedAt: new Date().toISOString(),
+      };
+
+      return c.json({ projects: projectsWithStats, summary });
+    } catch (error: unknown) {
+      return safeError(c, error, "Projects health check failed");
+    }
+  });
+
+  // Single project health (with ?project= query param)
+  api.get("/api/health", async (c) => {
+    try {
+      const projectParam = c.req.query("project");
+      if (!projectParam) {
+        return c.json({ error: "project parameter is required" }, 400);
+      }
+
+      const project = decodeURIComponent(projectParam);
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projectConfig = config.projects?.find((p) => p.repo === project);
+
+      if (!projectConfig) {
+        return c.json({ error: `Project "${project}" not found in configuration` }, 404);
+      }
+
+      const projectPath = resolve(rootDir, projectConfig.path);
+      const gitPath = config.git?.gitPath || "git";
+
+      const checks = await runProjectChecks(projectPath, gitPath);
+
+      const healthResponse: HealthCheckResponse = {
+        project,
+        status: deriveOverallStatus(checks),
+        checks: {
+          gitRemoteAccess: checks.gitRemoteCheck,
+          localPath: checks.localPathCheck,
+          diskSpace: checks.diskSpaceCheck,
+          dependencies: checks.dependenciesCheck,
+        },
+        lastChecked: new Date().toISOString(),
+      };
+
+      return c.json(healthResponse);
+    } catch (error: unknown) {
+      return safeError(c, error, "Health check failed");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/health-checks.ts` 신규 (111줄): 4개 헬퍼 추출
  - `checkGitRemoteAccess` / `checkLocalPath` / `checkDiskSpace` / `checkDependencies`
  - 세 라우트가 공통으로 사용하던 인라인 헬퍼를 단일 진입점으로
- `src/server/routes/health.ts` 신규 (251줄): 3개 라우트 캡슐화
  - `GET /api/repositories` (저장소 목록 + 헬스 + 통계)
  - `GET /api/projects/health` (전체 프로젝트 헬스)
  - `GET /api/health` (단일 프로젝트 헬스)
- `runProjectChecks` + `deriveOverallStatus` 내부 헬퍼로 3 라우트 간 중복 정리
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts unused import 정리: `existsSync` / `statSync` / `HealthCheckResponse` / `getProjectSummary`
- dashboard-api.ts 983 → 661줄 (**-322**) — 본 단계 누계 최대 감축

## 변경 파일
- 신규: `src/server/health-checks.ts` (111줄)
- 신규: `src/server/routes/health.ts` (251줄)
- 수정: `src/server/dashboard-api.ts` (-322)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (#826): -210
- 8단계 doctor (#827): -75
- 9단계 health (본 PR): -322
- **총 -1458줄, 2119 → 661**

남은 도메인: skip-events / sse / auth / new-issue