### PR TITLE
refactor(server): /api/skip-events + /api/new-issue 라우트 분할 (Plan C #C9 10단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -2,7 +2,6 @@ import { Hono, type Context, type Next } from "hono";
 import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
-import { resolve, join } from "path";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig } from "../config/loader.js";
@@ -10,16 +9,12 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { GetSkipEventsQuerySchema, formatZodError } from "../types/api.js";
+import { formatZodError } from "../types/api.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { runCli } from "../utils/cli-runner.js";
-import { getErrorMessage } from "../utils/error-utils.js";
-import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { statusToNotificationType } from "../types/pipeline.js";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
-import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
@@ -30,6 +25,8 @@ import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
 import { registerDoctorRoutes } from "./routes/doctor.js";
 import { registerHealthRoutes } from "./routes/health.js";
+import { registerSkipEventsRoutes } from "./routes/skip-events.js";
+import { registerNewIssueRoute } from "./routes/new-issue.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -181,16 +178,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
 }
 
 const SSE_INITIAL_JOB_LIMIT = 20;
-
-const NewIssueRequestSchema = z.object({
-  category: z.enum(["bug", "feature", "refactor", "docs"]),
-  title: z.string().min(1),
-  repo: z.string().min(1),
-  what: z.string().min(1),
-  where: z.string().default(""),
-  how: z.string().default(""),
-  files: z.string().default(""),
-});
 
 /**
  * Returns jobs for SSE initial state:
@@ -391,104 +378,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // (logs/stream은 SSE이므로 별도 처리)
   registerJobsRoutes(api, { store, queue, sseManager });
 
-  // Skip events stats (reasonCode별 집계)
-  api.get("/api/skip-events/stats", (c) => {
-    try {
-      const repo = c.req.query("repo");
-      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
-
-      const reasonCodeCounts: Record<string, number> = {};
-      for (const event of allEvents) {
-        reasonCodeCounts[event.reasonCode] = (reasonCodeCounts[event.reasonCode] ?? 0) + 1;
-      }
-
-      const stats = Object.entries(reasonCodeCounts)
-        .map(([reasonCode, count]) => ({ reasonCode, count }))
-        .sort((a, b) => b.count - a.count);
-
-      return c.json({ total: allEvents.length, stats });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch skip event stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // List skip events (flat 또는 issueNumber+repo+reasonCode 그룹)
-  api.get("/api/skip-events", (c) => {
-    try {
-      const groupParam = c.req.query("group");
-      const queryParams = {
-        repo: c.req.query("repo"),
-        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
-        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
-        group: groupParam === "true" ? true : groupParam === "false" ? false : undefined,
-      };
-
-      const parseResult = GetSkipEventsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const { repo, limit, offset, group } = parseResult.data;
-
-      // 그룹 뷰: 동일 이슈+reasonCode 중복 축약 (기본 대시보드 뷰)
-      if (group) {
-        const { groups, totalGroups } = store.listSkipEventsGrouped({ repo, limit, offset });
-        const start = offset ?? 0;
-        const end = limit !== undefined ? start + groups.length : totalGroups;
-        return c.json({
-          groups,
-          pagination: {
-            total: totalGroups,
-            offset: start,
-            limit: limit ?? totalGroups,
-            hasMore: end < totalGroups,
-          }
-        });
-      }
-
-      // Flat 뷰 (기존 API 호환)
-      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
-      const total = allEvents.length;
-      const start = offset ?? 0;
-      const end = limit !== undefined ? start + limit : total;
-      const events = allEvents.slice(start, end);
-
-      return c.json({
-        events,
-        pagination: {
-          total,
-          offset: start,
-          limit: limit ?? total,
-          hasMore: end < total,
-        }
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch skip events: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // 특정 그룹(issueNumber+repo+reasonCode) 전체 삭제
-  api.delete("/api/skip-events/group", async (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const body = await c.req.json<{ issueNumber?: unknown; repo?: unknown; reasonCode?: unknown }>();
-      const issueNumber = typeof body.issueNumber === "number" ? body.issueNumber : Number(body.issueNumber);
-      const repoVal = typeof body.repo === "string" ? body.repo : "";
-      const reasonCode = typeof body.reasonCode === "string" ? body.reasonCode : "";
-      if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !repoVal || !reasonCode) {
-        return c.json({ error: "issueNumber, repo, reasonCode 필수" }, 400);
-      }
-      const deleted = store.deleteSkipEventsByGroup(issueNumber, repoVal, reasonCode);
-      return c.json({ deleted });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete skip event group: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Skip events: 도메인 라우트 분할 (Plan C #C9)
+  registerSkipEventsRoutes(api, { store, readOnly: !!readOnly });
 
   // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
   registerStatsRoutes(api, { store, patternStore });
@@ -617,39 +508,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
   registerSetupRoutes(api, { rootDir });
 
-  // Create a new GitHub issue from dashboard
-  api.post("/api/new-issue", zValidator('json', NewIssueRequestSchema, zodValidationHook), async (c) => {
-    const logger = getLogger();
-    try {
-      const { category, title, repo, what, where, how, files } = c.req.valid('json');
-
-      const templatesDir = resolve(rootDir, "prompts/issue-templates");
-      const templatePath = resolve(templatesDir, `${category}.md`);
-      const template = loadTemplate(templatePath, templatesDir);
-      const body = renderTemplate(template, { what, where, how, files });
-
-      const result = await runCli("gh", [
-        "issue", "create",
-        "--repo", repo,
-        "--title", title,
-        "--body", body,
-        "--label", "aqm-by",
-      ]);
-
-      if (result.exitCode !== 0) {
-        return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(result.stderr)}` }, 500);
-      }
-
-      const url = result.stdout.trim();
-      const numberMatch = url.match(/\/issues\/(\d+)$/);
-      const number = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
-
-      logger.info(`New issue created: ${url}`);
-      return c.json({ url, number });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // New issue: 도메인 라우트 분할 (Plan C #C9)
+  registerNewIssueRoute(api, { rootDir });
 
   // Doctor: 도메인 라우트 분할 (Plan C #C9)
   registerDoctorRoutes(api);

--- a/src/server/routes/new-issue.ts
+++ b/src/server/routes/new-issue.ts
@@ -1,0 +1,67 @@
+import type { Hono } from "hono";
+import { resolve } from "path";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { safeError } from "../route-context.js";
+import { zodValidationHook } from "../dashboard-api.js";
+import { loadTemplate, renderTemplate } from "../../prompt/template-renderer.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+export interface NewIssueRouteContext {
+  rootDir: string;
+}
+
+const NewIssueRequestSchema = z.object({
+  category: z.enum(["bug", "feature", "refactor", "docs"]),
+  title: z.string().min(1),
+  repo: z.string().min(1),
+  what: z.string().min(1),
+  where: z.string().default(""),
+  how: z.string().default(""),
+  files: z.string().default(""),
+});
+
+/**
+ * POST /api/new-issue 라우트 등록 (Plan C #C9 — 10단계).
+ *
+ * 이전: dashboard-api.ts 621-652. 카테고리별 템플릿(prompts/issue-templates/*.md)을
+ *      렌더링한 뒤 `gh issue create`로 GitHub 이슈를 생성한다.
+ */
+export function registerNewIssueRoute(api: Hono, ctx: NewIssueRouteContext): void {
+  const { rootDir } = ctx;
+
+  api.post("/api/new-issue", zValidator("json", NewIssueRequestSchema, zodValidationHook), async (c) => {
+    const logger = getLogger();
+    try {
+      const { category, title, repo, what, where, how, files } = c.req.valid("json");
+
+      const templatesDir = resolve(rootDir, "prompts/issue-templates");
+      const templatePath = resolve(templatesDir, `${category}.md`);
+      const template = loadTemplate(templatePath, templatesDir);
+      const body = renderTemplate(template, { what, where, how, files });
+
+      const result = await runCli("gh", [
+        "issue", "create",
+        "--repo", repo,
+        "--title", title,
+        "--body", body,
+        "--label", "aqm-by",
+      ]);
+
+      if (result.exitCode !== 0) {
+        return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(result.stderr)}` }, 500);
+      }
+
+      const url = result.stdout.trim();
+      const numberMatch = url.match(/\/issues\/(\d+)$/);
+      const number = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
+
+      logger.info(`New issue created: ${url}`);
+      return c.json({ url, number });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to create issue");
+    }
+  });
+}

--- a/src/server/routes/skip-events.ts
+++ b/src/server/routes/skip-events.ts
@@ -1,0 +1,118 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import { safeError } from "../route-context.js";
+import { GetSkipEventsQuerySchema, formatZodError } from "../../types/api.js";
+
+export interface SkipEventsRouteContext {
+  store: JobStore;
+  readOnly: boolean;
+}
+
+/**
+ * /api/skip-events/* 라우트 등록 (Plan C #C9 — 10단계).
+ *
+ * 이전: dashboard-api.ts 395-491 (3 routes, ~95줄).
+ * 동일 이슈+reasonCode 중복 축약을 위한 그룹 뷰와 flat 뷰를 함께 제공한다.
+ */
+export function registerSkipEventsRoutes(api: Hono, ctx: SkipEventsRouteContext): void {
+  const { store, readOnly } = ctx;
+
+  // Skip events stats (reasonCode별 집계)
+  api.get("/api/skip-events/stats", (c) => {
+    try {
+      const repo = c.req.query("repo");
+      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
+
+      const reasonCodeCounts: Record<string, number> = {};
+      for (const event of allEvents) {
+        reasonCodeCounts[event.reasonCode] = (reasonCodeCounts[event.reasonCode] ?? 0) + 1;
+      }
+
+      const stats = Object.entries(reasonCodeCounts)
+        .map(([reasonCode, count]) => ({ reasonCode, count }))
+        .sort((a, b) => b.count - a.count);
+
+      return c.json({ total: allEvents.length, stats });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch skip event stats");
+    }
+  });
+
+  // List skip events (flat 또는 issueNumber+repo+reasonCode 그룹)
+  api.get("/api/skip-events", (c) => {
+    try {
+      const groupParam = c.req.query("group");
+      const queryParams = {
+        repo: c.req.query("repo"),
+        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
+        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
+        group: groupParam === "true" ? true : groupParam === "false" ? false : undefined,
+      };
+
+      const parseResult = GetSkipEventsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error),
+        }, 400);
+      }
+
+      const { repo, limit, offset, group } = parseResult.data;
+
+      // 그룹 뷰: 동일 이슈+reasonCode 중복 축약 (기본 대시보드 뷰)
+      if (group) {
+        const { groups, totalGroups } = store.listSkipEventsGrouped({ repo, limit, offset });
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + groups.length : totalGroups;
+        return c.json({
+          groups,
+          pagination: {
+            total: totalGroups,
+            offset: start,
+            limit: limit ?? totalGroups,
+            hasMore: end < totalGroups,
+          },
+        });
+      }
+
+      // Flat 뷰 (기존 API 호환)
+      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
+      const total = allEvents.length;
+      const start = offset ?? 0;
+      const end = limit !== undefined ? start + limit : total;
+      const events = allEvents.slice(start, end);
+
+      return c.json({
+        events,
+        pagination: {
+          total,
+          offset: start,
+          limit: limit ?? total,
+          hasMore: end < total,
+        },
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch skip events");
+    }
+  });
+
+  // 특정 그룹(issueNumber+repo+reasonCode) 전체 삭제
+  api.delete("/api/skip-events/group", async (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const body = await c.req.json<{ issueNumber?: unknown; repo?: unknown; reasonCode?: unknown }>();
+      const issueNumber = typeof body.issueNumber === "number" ? body.issueNumber : Number(body.issueNumber);
+      const repoVal = typeof body.repo === "string" ? body.repo : "";
+      const reasonCode = typeof body.reasonCode === "string" ? body.reasonCode : "";
+      if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !repoVal || !reasonCode) {
+        return c.json({ error: "issueNumber, repo, reasonCode 필수" }, 400);
+      }
+      const deleted = store.deleteSkipEventsByGroup(issueNumber, repoVal, reasonCode);
+      return c.json({ deleted });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete skip event group");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/skip-events.ts` 신규 (118줄): 3개 라우트 캡슐화
  - `GET /api/skip-events/stats` (reasonCode별 집계)
  - `GET /api/skip-events` (flat / 그룹 뷰 페이지네이션)
  - `DELETE /api/skip-events/group` (그룹 단위 일괄 삭제)
- `src/server/routes/new-issue.ts` 신규 (67줄): GitHub 이슈 생성 라우트
  - 인라인 `NewIssueRequestSchema`를 라우트 모듈로 이전
- `safeError(c, e, prefix)` 적용
- dashboard-api.ts 7개 unused import 정리:
  `resolve` / `join` / `runCli` / `sanitizeErrorMessage` / `getErrorMessage` / `loadTemplate` / `renderTemplate` / `GetSkipEventsQuerySchema`
- dashboard-api.ts 661 → 521줄 (**-140**)

## 변경 파일
- 신규: `src/server/routes/skip-events.ts` (118줄)
- 신규: `src/server/routes/new-issue.ts` (67줄)
- 수정: `src/server/dashboard-api.ts` (-140)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (#826): -210
- 8단계 doctor (#827): -75
- 9단계 health (#828): -322
- 10단계 skip-events/new-issue (본 PR): -140
- **총 -1598줄, 2119 → 521**

남은 도메인: sse / auth (대시보드가 thin assembler 진입)