### PR TITLE
refactor(server): SSE 라우트 분할 (Plan C #C9 11단계)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context, type Next } from "hono";
-import { randomUUID, timingSafeEqual } from "crypto";
+import { timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import type { JobStore, Job } from "../queue/job-store.js";
@@ -27,6 +27,7 @@ import { registerDoctorRoutes } from "./routes/doctor.js";
 import { registerHealthRoutes } from "./routes/health.js";
 import { registerSkipEventsRoutes } from "./routes/skip-events.js";
 import { registerNewIssueRoute } from "./routes/new-issue.js";
+import { registerSSERoutes } from "./routes/sse.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -175,25 +176,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
       logger.info(`Automation rules updated: ${oldAutomations.length} → ${newAutomations.length} rules`);
     }
   }
-}
-
-const SSE_INITIAL_JOB_LIMIT = 20;
-
-/**
- * Returns jobs for SSE initial state:
- * - Excludes archived jobs
- * - Always includes running/queued jobs (regardless of position)
- * - Fills remaining slots with recent non-active jobs (up to SSE_INITIAL_JOB_LIMIT total)
- */
-function getInitialJobs(store: JobStore): Job[] {
-  // DB 레벨에서 active job 조회
-  const active = store.list({ statuses: ["running", "queued"] });
-  const remaining = Math.max(0, SSE_INITIAL_JOB_LIMIT - active.length);
-  // 나머지 슬롯은 최근 non-active, non-archived job으로 채움
-  const rest = remaining > 0
-    ? store.list({ statuses: ["success", "failure", "cancelled"], limit: remaining })
-    : [];
-  return [...active, ...rest];
 }
 
 /**
@@ -384,109 +366,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
   registerStatsRoutes(api, { store, patternStore });
 
-  // SSE stream for job logs
-  api.get("/api/jobs/:id/logs/stream", (c) => {
-    const id = c.req.param("id");
-    let lastLogCount = 0;
-    let intervalId: ReturnType<typeof setInterval> | undefined;
-
-    const stream = new ReadableStream({
-      start(controller) {
-        const encoder = new TextEncoder();
-        const send = () => {
-          try {
-            const job = store.get(id);
-            if (!job) {
-              controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ error: "Job not found" })}\n\n`));
-              clearInterval(intervalId);
-              try { controller.close(); } catch { /* already closed */ }
-              return;
-            }
-            const logs = job.logs || [];
-            if (logs.length > lastLogCount) {
-              const newLines = logs.slice(lastLogCount);
-              lastLogCount = logs.length;
-              for (const line of newLines) {
-                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line, status: job.status })}\n\n`));
-              }
-            }
-            // Send status update so client knows when job finishes
-            if (job.status !== "running" && job.status !== "queued") {
-              controller.enqueue(encoder.encode(`event: done\ndata: ${JSON.stringify({ status: job.status })}\n\n`));
-              clearInterval(intervalId);
-              try { controller.close(); } catch { /* already closed */ }
-            }
-          } catch {
-            // stream closed
-          }
-        };
-        send();
-        intervalId = setInterval(send, 1000);
-        setTimeout(() => {
-          clearInterval(intervalId);
-          try { controller.close(); } catch { /* already closed */ }
-        }, 300000); // 5 min max
-      },
-      cancel() {
-        clearInterval(intervalId);
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
-
-  // SSE endpoint for real-time updates
-  api.get("/api/events", (_c) => {
-    const clientId = randomUUID();
-    const encoder = new TextEncoder();
-    let intervalId: ReturnType<typeof setInterval> | undefined;
-
-    const stream = new ReadableStream({
-      start(controller) {
-        sseManager.addClient(controller, clientId);
-
-        // Send initial state
-        const sendInitialState = () => {
-          try {
-            const status = queue.getStatus();
-            const data = JSON.stringify({ jobs: getInitialJobs(store), queue: status });
-            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
-          } catch {
-            // stream closed
-          }
-        };
-
-        sendInitialState();
-
-        // Send periodic updates for fallback (reduced frequency since real-time events handle most updates)
-        intervalId = setInterval(sendInitialState, 10000); // 10 seconds instead of 2
-
-        // Auto-cleanup after 5 minutes
-        setTimeout(() => {
-          clearInterval(intervalId);
-          sseManager.removeClient(clientId);
-        }, 300000);
-      },
-      cancel() {
-        clearInterval(intervalId);
-        sseManager.removeClient(clientId);
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
+  // SSE: 도메인 라우트 분할 (Plan C #C9)
+  registerSSERoutes(api, { store, queue, sseManager });
 
   // Start periodic cleanup when dashboard routes are created
   startPeriodicCleanup();

--- a/src/server/routes/sse.ts
+++ b/src/server/routes/sse.ts
@@ -1,0 +1,142 @@
+import type { Hono } from "hono";
+import { randomUUID } from "crypto";
+import type { JobStore, Job } from "../../queue/job-store.js";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { SSEManager } from "../sse-manager.js";
+
+export interface SSERouteContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+}
+
+const SSE_INITIAL_JOB_LIMIT = 20;
+const SSE_MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const SSE_LOG_POLL_MS = 1000;
+const SSE_EVENT_POLL_MS = 10_000;
+
+/**
+ * SSE 초기 페이로드용 잡 목록.
+ * - archived 제외
+ * - running/queued는 항상 포함
+ * - 남은 슬롯은 최근 non-active job으로 채움 (총 SSE_INITIAL_JOB_LIMIT)
+ */
+function getInitialJobs(store: JobStore): Job[] {
+  const active = store.list({ statuses: ["running", "queued"] });
+  const remaining = Math.max(0, SSE_INITIAL_JOB_LIMIT - active.length);
+  const rest = remaining > 0
+    ? store.list({ statuses: ["success", "failure", "cancelled"], limit: remaining })
+    : [];
+  return [...active, ...rest];
+}
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  "Connection": "keep-alive",
+} as const;
+
+/**
+ * SSE 라우트 등록 (Plan C #C9 — 11단계).
+ *
+ * 이전: dashboard-api.ts 388-489 (2 routes, ~105줄).
+ *  - GET /api/jobs/:id/logs/stream — 단일 잡 로그 폴링 SSE
+ *  - GET /api/events — 글로벌 잡/큐 상태 SSE
+ *
+ * 클라이언트 풀(SSEManager)과 인증 미들웨어는 dashboard-api.ts에 그대로 남는다.
+ * 본 모듈은 라우트 핸들러만 응집한다.
+ */
+export function registerSSERoutes(api: Hono, ctx: SSERouteContext): void {
+  const { store, queue, sseManager } = ctx;
+
+  // 단일 잡 로그 SSE
+  api.get("/api/jobs/:id/logs/stream", (c) => {
+    const id = c.req.param("id");
+    let lastLogCount = 0;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        const send = () => {
+          try {
+            const job = store.get(id);
+            if (!job) {
+              controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ error: "Job not found" })}\n\n`));
+              clearInterval(intervalId);
+              try { controller.close(); } catch { /* already closed */ }
+              return;
+            }
+            const logs = job.logs || [];
+            if (logs.length > lastLogCount) {
+              const newLines = logs.slice(lastLogCount);
+              lastLogCount = logs.length;
+              for (const line of newLines) {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line, status: job.status })}\n\n`));
+              }
+            }
+            // status가 종료 상태면 done 이벤트 + 스트림 종료
+            if (job.status !== "running" && job.status !== "queued") {
+              controller.enqueue(encoder.encode(`event: done\ndata: ${JSON.stringify({ status: job.status })}\n\n`));
+              clearInterval(intervalId);
+              try { controller.close(); } catch { /* already closed */ }
+            }
+          } catch {
+            // stream closed
+          }
+        };
+        send();
+        intervalId = setInterval(send, SSE_LOG_POLL_MS);
+        setTimeout(() => {
+          clearInterval(intervalId);
+          try { controller.close(); } catch { /* already closed */ }
+        }, SSE_MAX_DURATION_MS);
+      },
+      cancel() {
+        clearInterval(intervalId);
+      },
+    });
+
+    return new Response(stream, { headers: SSE_HEADERS });
+  });
+
+  // 글로벌 잡/큐 상태 SSE
+  api.get("/api/events", (_c) => {
+    const clientId = randomUUID();
+    const encoder = new TextEncoder();
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stream = new ReadableStream({
+      start(controller) {
+        sseManager.addClient(controller, clientId);
+
+        const sendInitialState = () => {
+          try {
+            const status = queue.getStatus();
+            const data = JSON.stringify({ jobs: getInitialJobs(store), queue: status });
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          } catch {
+            // stream closed
+          }
+        };
+
+        sendInitialState();
+
+        // 실시간 이벤트가 대부분의 업데이트를 처리하므로 폴링은 fallback 용도(10초).
+        intervalId = setInterval(sendInitialState, SSE_EVENT_POLL_MS);
+
+        // Auto-cleanup after 5 minutes
+        setTimeout(() => {
+          clearInterval(intervalId);
+          sseManager.removeClient(clientId);
+        }, SSE_MAX_DURATION_MS);
+      },
+      cancel() {
+        clearInterval(intervalId);
+        sseManager.removeClient(clientId);
+      },
+    });
+
+    return new Response(stream, { headers: SSE_HEADERS });
+  });
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/sse.ts` 신규 (142줄): 2개 SSE 라우트 캡슐화
  - `GET /api/jobs/:id/logs/stream` (단일 잡 로그 폴링 SSE)
  - `GET /api/events` (글로벌 잡/큐 상태 SSE)
- `getInitialJobs` 헬퍼 + `SSE_INITIAL_JOB_LIMIT` 상수를 라우트 모듈로 이전
- SSE 공용 헤더/타이밍 상수화: `SSE_HEADERS`, `SSE_MAX_DURATION_MS`, `SSE_LOG_POLL_MS`, `SSE_EVENT_POLL_MS`
- dashboard-api.ts에서 `randomUUID` import 제거
- dashboard-api.ts 521 → 402줄 (**-119**)

## 변경 파일
- 신규: `src/server/routes/sse.ts` (142줄)
- 수정: `src/server/dashboard-api.ts` (-119)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (#826): -210
- 8단계 doctor (#827): -75
- 9단계 health (#828): -322
- 10단계 skip-events/new-issue (#829): -140
- 11단계 SSE (본 PR): -119
- **총 -1717줄, 2119 → 402**

남은: `POST /api/auth` + 인증 미들웨어 (#C12 또는 별도 PR에서 처리)