### PR TITLE
refactor(server): /api/auth + 인증 미들웨어 분할 (Plan C #C9 12단계 — 마지막)

### DIFF
--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,5 +1,4 @@
-import { Hono, type Context, type Next } from "hono";
-import { timingSafeEqual } from "crypto";
+import { Hono, type Context } from "hono";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import type { JobStore, Job } from "../queue/job-store.js";
@@ -28,6 +27,7 @@ import { registerHealthRoutes } from "./routes/health.js";
 import { registerSkipEventsRoutes } from "./routes/skip-events.js";
 import { registerNewIssueRoute } from "./routes/new-issue.js";
 import { registerSSERoutes } from "./routes/sse.js";
+import { setupAuth } from "./routes/auth.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -102,10 +102,6 @@ export function cleanupDashboardResources(): void {
   cleanupAllSSEClients();
   sessionManager.revokeAll();
   loginRateLimiter?.destroy();
-}
-
-function isValidSessionToken(token: string): boolean {
-  return sessionManager.validate(token);
 }
 
 /**
@@ -231,122 +227,14 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  if (apiKey) {
-    // POST /api/auth — exchange Bearer key for a short-lived session token
-    api.post("/api/auth", (c) => {
-      const ip =
-        c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
-        (c.env as Record<string, unknown> | undefined)?.["remoteAddress"] as string | undefined ??
-        "unknown";
-
-      const rateLimitCheck = loginRateLimiter?.checkAndRecord(ip);
-      if (rateLimitCheck && !rateLimitCheck.allowed) {
-        const retryAfterSec = Math.ceil((rateLimitCheck.retryAfterMs ?? 900_000) / 1000);
-        getLogger().warn(`[Auth] Rate limit exceeded for IP ${ip}`);
-        return c.json(
-          { error: "Too Many Requests" },
-          429,
-          { "Retry-After": String(retryAfterSec) }
-        );
-      }
-
-      const auth = c.req.header("Authorization");
-      const expected = Buffer.from(`Bearer ${apiKey}`);
-      const actual = Buffer.from(auth ?? "");
-      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-
-      loginRateLimiter?.reset(ip);
-      const { token, expiresIn } = sessionManager.createToken();
-      return c.json({ token, expiresIn });
-    });
-
-    // Auth middleware for regular (non-SSE) API endpoints — Bearer header only
-    // Deny-by-default: all /api/* routes require auth except public and SSE paths
-    const bearerAuth = async (c: Context, next: Next) => {
-      const path = c.req.path;
-      // Public routes — no auth required
-      if (path === "/api/auth") {
-        await next();
-        return;
-      }
-      // SSE routes — handled by sseTokenAuth or healSseKeyAuth below
-      if (
-        path === "/api/events" ||
-        /^\/api\/jobs\/[^/]+\/logs\/stream$/.test(path) ||
-        /^\/api\/doctor\/heal\/[^/]+\/stream$/.test(path)
-      ) {
-        await next();
-        return;
-      }
-      const auth = c.req.header("Authorization");
-      const expected = Buffer.from(`Bearer ${apiKey}`);
-      const actual = Buffer.from(auth ?? "");
-      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-
-    api.use("/api/*", bearerAuth);
-
-    // SSE endpoints use short-lived session token from ?token= query param
-    const sseTokenAuth = async (c: Context, next: Next) => {
-      const token = c.req.query("token");
-      if (!token || !isValidSessionToken(token)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-
-    api.use("/api/events", sseTokenAuth);
-    api.use("/api/jobs/:id/logs/stream", sseTokenAuth);
-
-    // Doctor heal SSE uses raw API key via ?key= query param (EventSource cannot set headers)
-    const healSseKeyAuth = async (c: Context, next: Next) => {
-      const key = c.req.query("key");
-      if (!key) return c.json({ error: "Unauthorized" }, 401);
-      const expected = Buffer.from(apiKey);
-      const actual = Buffer.from(key);
-      if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-    api.use("/api/doctor/heal/:id/stream", healSseKeyAuth);
-  } else {
-    // apiKey 미설정: 바인드 호스트에 따라 로그 레벨 분기
-    const isLocalBind = !hostname || hostname === "127.0.0.1" || hostname === "localhost";
-    if (readOnly) {
-      // readOnly 모드: write 엔드포인트에 403 반환
-      const readOnlyGuard = async (c: Context, next: Next) => {
-        if (c.req.method !== "GET" && c.req.method !== "HEAD") {
-          return c.json({ error: "Forbidden: dashboard is in read-only mode" }, 403);
-        }
-        await next();
-      };
-      api.use("/api/config", readOnlyGuard);
-      api.use("/api/projects", readOnlyGuard);
-      api.use("/api/projects/*", readOnlyGuard);
-      api.use("/api/jobs/*", readOnlyGuard);
-      api.use("/api/update", readOnlyGuard);
-      api.use("/api/new-issue", readOnlyGuard);
-      getLogger().info(
-        "Dashboard is running in read-only mode. Write endpoints are disabled." +
-        (!isLocalBind ? " Non-local bind is permitted in read-only mode." : "")
-      );
-    } else if (isLocalBind) {
-      getLogger().info(
-        "Dashboard API key is not configured. All endpoints are accessible without authentication."
-      );
-    } else {
-      getLogger().warn(
-        "Dashboard API key is not configured. All endpoints are accessible without authentication. " +
-        "Non-local bind without API key is a security risk."
-      );
-    }
-  }
+  // Auth + readOnly guard: 도메인 라우트 분할 (Plan C #C9 12단계)
+  setupAuth(api, {
+    apiKey,
+    hostname,
+    readOnly: !!readOnly,
+    sessionManager,
+    loginRateLimiter,
+  });
 
   const configPath = `${rootDir}/config.yml`;
 

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,0 +1,151 @@
+import type { Hono, Context, Next } from "hono";
+import { timingSafeEqual } from "crypto";
+import type { SessionManager } from "../auth/session.js";
+import type { LoginRateLimiter } from "../auth/rate-limiter.js";
+import { getLogger } from "../../utils/logger.js";
+
+export interface AuthSetupContext {
+  /** 미설정이면 무인증 모드 (readOnly 또는 로컬 바인드 한정 권장). */
+  apiKey?: string;
+  /** 서버 바인드 호스트 — 무인증+비-로컬 바인드 시 경고 출력에 사용. */
+  hostname?: string;
+  readOnly: boolean;
+  sessionManager: SessionManager;
+  loginRateLimiter?: LoginRateLimiter;
+}
+
+/**
+ * 대시보드 인증 + readOnly 가드 셋업 (Plan C #C9 — 12단계).
+ *
+ * 이전: dashboard-api.ts 234-349 (~115줄). POST /api/auth 라우트 + 4개 미들웨어
+ *      (bearerAuth/sseTokenAuth/healSseKeyAuth/readOnlyGuard)가 if/else 블록에 섞여 있었다.
+ * 이후: 본 함수가 단일 진입점. dashboard-api.ts는 setupAuth(api, ctx) 한 줄로 위임.
+ *
+ * 동작:
+ *  - apiKey 설정 시: POST /api/auth(세션 토큰 발급) + bearerAuth(/api/*) +
+ *                    sseTokenAuth(/api/events, /api/jobs/:id/logs/stream) +
+ *                    healSseKeyAuth(/api/doctor/heal/:id/stream)
+ *  - apiKey 미설정 시:
+ *    - readOnly 모드: 쓰기 엔드포인트(config/projects/jobs/update/new-issue)에 readOnlyGuard
+ *    - readOnly 아님 + 로컬 바인드: 정보 로그
+ *    - readOnly 아님 + 비-로컬 바인드: 보안 위험 경고 로그
+ */
+export function setupAuth(api: Hono, ctx: AuthSetupContext): void {
+  const { apiKey, hostname, readOnly, sessionManager, loginRateLimiter } = ctx;
+
+  if (apiKey) {
+    // POST /api/auth — Bearer key를 짧은 수명 세션 토큰으로 교환
+    api.post("/api/auth", (c) => {
+      const ip =
+        c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+        ((c.env as Record<string, unknown> | undefined)?.["remoteAddress"] as string | undefined) ??
+        "unknown";
+
+      const rateLimitCheck = loginRateLimiter?.checkAndRecord(ip);
+      if (rateLimitCheck && !rateLimitCheck.allowed) {
+        const retryAfterSec = Math.ceil((rateLimitCheck.retryAfterMs ?? 900_000) / 1000);
+        getLogger().warn(`[Auth] Rate limit exceeded for IP ${ip}`);
+        return c.json(
+          { error: "Too Many Requests" },
+          429,
+          { "Retry-After": String(retryAfterSec) }
+        );
+      }
+
+      const auth = c.req.header("Authorization");
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      loginRateLimiter?.reset(ip);
+      const { token, expiresIn } = sessionManager.createToken();
+      return c.json({ token, expiresIn });
+    });
+
+    // Bearer 헤더 미들웨어 — 일반 (non-SSE) /api/* 라우트
+    // Deny-by-default: 공용 + SSE 경로 외 모든 요청에 인증 요구
+    const bearerAuth = async (c: Context, next: Next) => {
+      const path = c.req.path;
+      if (path === "/api/auth") {
+        await next();
+        return;
+      }
+      if (
+        path === "/api/events" ||
+        /^\/api\/jobs\/[^/]+\/logs\/stream$/.test(path) ||
+        /^\/api\/doctor\/heal\/[^/]+\/stream$/.test(path)
+      ) {
+        await next();
+        return;
+      }
+      const auth = c.req.header("Authorization");
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+
+    api.use("/api/*", bearerAuth);
+
+    // SSE 엔드포인트 — ?token= 쿼리 파람으로 짧은 수명 세션 토큰 검증
+    const sseTokenAuth = async (c: Context, next: Next) => {
+      const token = c.req.query("token");
+      if (!token || !sessionManager.validate(token)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+
+    api.use("/api/events", sseTokenAuth);
+    api.use("/api/jobs/:id/logs/stream", sseTokenAuth);
+
+    // Doctor heal SSE — EventSource는 헤더를 못 보내므로 ?key= 쿼리 파람으로 raw API key 검증
+    const healSseKeyAuth = async (c: Context, next: Next) => {
+      const key = c.req.query("key");
+      if (!key) return c.json({ error: "Unauthorized" }, 401);
+      const expected = Buffer.from(apiKey);
+      const actual = Buffer.from(key);
+      if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+    api.use("/api/doctor/heal/:id/stream", healSseKeyAuth);
+  } else {
+    // apiKey 미설정 — 바인드 호스트와 readOnly 여부에 따라 분기
+    const isLocalBind = !hostname || hostname === "127.0.0.1" || hostname === "localhost";
+
+    if (readOnly) {
+      // readOnly 모드: 쓰기 엔드포인트에 403 반환
+      const readOnlyGuard = async (c: Context, next: Next) => {
+        if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+          return c.json({ error: "Forbidden: dashboard is in read-only mode" }, 403);
+        }
+        await next();
+      };
+      api.use("/api/config", readOnlyGuard);
+      api.use("/api/projects", readOnlyGuard);
+      api.use("/api/projects/*", readOnlyGuard);
+      api.use("/api/jobs/*", readOnlyGuard);
+      api.use("/api/update", readOnlyGuard);
+      api.use("/api/new-issue", readOnlyGuard);
+      getLogger().info(
+        "Dashboard is running in read-only mode. Write endpoints are disabled." +
+        (!isLocalBind ? " Non-local bind is permitted in read-only mode." : "")
+      );
+    } else if (isLocalBind) {
+      getLogger().info(
+        "Dashboard API key is not configured. All endpoints are accessible without authentication."
+      );
+    } else {
+      getLogger().warn(
+        "Dashboard API key is not configured. All endpoints are accessible without authentication. " +
+        "Non-local bind without API key is a security risk."
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `src/server/routes/auth.ts` 신규 (151줄): `POST /api/auth` + 4개 미들웨어 캡슐화
  - `bearerAuth` — 일반 (non-SSE) /api/* 라우트 인증
  - `sseTokenAuth` — /api/events, /api/jobs/:id/logs/stream에 세션 토큰 검증
  - `healSseKeyAuth` — /api/doctor/heal/:id/stream에 raw API key 검증
  - `readOnlyGuard` — apiKey 미설정 + readOnly 모드일 때 쓰기 차단
- `setupAuth(api, ctx)` 단일 진입점 — apiKey 유무에 따른 분기 일원화
- `isValidSessionToken` 헬퍼 제거 (sessionManager.validate 직접 사용)
- dashboard-api.ts에서 `timingSafeEqual`, `Next` 타입 import 제거
- dashboard-api.ts 402 → 290줄 (**-112**)

## #C9 완료
**dashboard-api.ts 모든 라우트가 routes/* 모듈로 분할됨.**

## 변경 파일
- 신규: `src/server/routes/auth.ts` (151줄)
- 수정: `src/server/dashboard-api.ts` (-112)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — clean

## #C9 누계
- 1단계 notifications (#820): -142
- 2단계 version (#821): -119
- 3단계 projects (#822): -265
- 4단계 jobs (#823): -113
- 5단계 stats/metrics (#824): -135
- 6단계 config (#825): -77
- 7단계 setup (#826): -210
- 8단계 doctor (#827): -75
- 9단계 health (#828): -322
- 10단계 skip-events/new-issue (#829): -140
- 11단계 SSE (#830): -119
- 12단계 auth (본 PR): -112
- **총 -1829줄, 2119 → 290 (86% 감축)**

## 다음
- #C12 — `createDashboardRoutes` 시그니처 정리: 9개 파라미터 → `DashboardContext` + `authConfig` 객체화 (cli.ts 호출부 1곳만 수정)
- Plan C 종료 → develop → main 릴리스 PR + v0.9.0 bump