### PR TITLE
refactor(server): createDashboardRoutes 시그니처 정리 (Plan C #C12 — Plan C 종료)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -487,7 +487,17 @@ export async function startCommand(args: CliArgs): Promise<void> {
   }
 
   const patternStore = getPatternStore(dataDir);
-  const dashboardRoutes = createDashboardRoutes(store, queue, configWatcher, apiKey, host, effectiveConfig.general.dashboardAuth, wslReadOnly, patternStore, aqRoot);
+  const dashboardRoutes = createDashboardRoutes({
+    store,
+    queue,
+    aqRoot,
+    configWatcher,
+    patternStore,
+    apiKey,
+    hostname: host,
+    dashboardAuth: effectiveConfig.general.dashboardAuth,
+    readOnly: wslReadOnly,
+  });
   const healthRoutes = createHealthRoutes(queue, poller);
 
   let app: ReturnType<typeof createWebhookApp>;

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -181,7 +181,33 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
  * browser EventSource API, so they accept a short-lived session token via ?token=<token>.
  * Obtain a session token from POST /api/auth with the Bearer key.
  */
-export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWatcher?: ConfigWatcher, apiKey?: string, hostname?: string, dashboardAuth?: DashboardAuthConfig, readOnly?: boolean, patternStore?: PatternStore, aqRoot?: string): Hono {
+/**
+ * createDashboardRoutes 옵션 (Plan C #C12).
+ *
+ * 이전: 9개 positional 파라미터 (#808 사고처럼 위치 충돌 위험). cli.ts 1곳에서만 호출.
+ * 이후: 단일 객체 — 누락 시 컴파일 에러로 잡히고, 새 필드 추가 시 기존 호출 깨지지 않는다.
+ */
+export interface DashboardRoutesOptions {
+  store: JobStore;
+  queue: JobQueue;
+  /**
+   * AQM 설치 루트(=AQM_HOME 또는 ~/.ai-quartermaster) — 라우트 핸들러가 데이터/로그 경로 조립에 사용.
+   * 미지정 시 process.cwd() (테스트 호환). 프로덕션 진입(cli.ts)에서는 항상 명시 전달.
+   */
+  aqRoot?: string;
+  configWatcher?: ConfigWatcher;
+  patternStore?: PatternStore;
+  /** 설정 시 Bearer 인증 활성화. 미설정 시 hostname + readOnly에 따라 무인증 모드. */
+  apiKey?: string;
+  /** 서버 바인드 호스트 — 무인증+비-로컬 바인드 시 보안 경고 출력에 사용. */
+  hostname?: string;
+  dashboardAuth?: DashboardAuthConfig;
+  /** insecure 환경에서 mutation 차단용 플래그. */
+  readOnly?: boolean;
+}
+
+export function createDashboardRoutes(opts: DashboardRoutesOptions): Hono {
+  const { store, queue, configWatcher, apiKey, hostname, dashboardAuth, readOnly, patternStore, aqRoot } = opts;
   const rootDir = aqRoot ?? process.cwd();
   const api = new Hono();
 

--- a/tests/dashboard-api.test.ts
+++ b/tests/dashboard-api.test.ts
@@ -121,7 +121,7 @@ describe("PUT /api/config — automations 저장 확인", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
   });
 
   it("valid config 업데이트 시 updateConfigSection이 호출됨", async () => {

--- a/tests/doctor-heal.test.ts
+++ b/tests/doctor-heal.test.ts
@@ -136,7 +136,7 @@ describe('GET /api/doctor/run', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
   });
 
   it('runAllChecks 성공 시 200과 checks 배열을 반환한다', async () => {
@@ -256,7 +256,7 @@ describe('DoctorCheck 확장 필드 (healLevel / autoFixCommand)', () => {
     const checks: DoctorCheck[] = [makeCheck({ status: 'fail', fixSteps: ['수동으로 설치'] })];
     mockRunAllChecks.mockResolvedValue(checks);
 
-    const app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    const app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     const res = await app.request('/api/doctor/run');
 
     expect(res.status).toBe(200);
@@ -272,7 +272,7 @@ describe('DoctorCheck 확장 필드 (healLevel / autoFixCommand)', () => {
     };
     mockRunAllChecks.mockResolvedValue([extendedCheck as unknown as DoctorCheck]);
 
-    const app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    const app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     const res = await app.request('/api/doctor/run');
 
     expect(res.status).toBe(200);

--- a/tests/notification.test.ts
+++ b/tests/notification.test.ts
@@ -330,7 +330,7 @@ function makeApp(mockAqDb: MockAqDb): Hono {
     setProjectConcurrency: vi.fn(),
   } as unknown as JobQueue;
 
-  return createDashboardRoutes(mockJobStore, mockJobQueue);
+  return createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 }
 
 describe("Notification API 엔드포인트", () => {

--- a/tests/security/dashboard-auth.test.ts
+++ b/tests/security/dashboard-auth.test.ts
@@ -113,33 +113,33 @@ describe("Dashboard Auth — apiKey 미설정 시 쓰기 API 차단", () => {
   });
 
   it("apiKey 미설정 시 job cancel(POST)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     // readOnlyGuard 제거 — apiKey 없이도 모든 API 허용
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 job retry(POST)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/retry");
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 job delete(DELETE)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 project 관리(DELETE)는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     // projects 관리는 apiKey 없이도 허용 (403이 아님)
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 GET 읽기 요청은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "GET", "/api/jobs");
     // 403이 아님 (읽기는 허용)
     expect(res.status).not.toBe(403);
@@ -162,7 +162,7 @@ describe("Dashboard Auth — readOnly 모드", () => {
 
   // (1) readOnly=true 시 write 엔드포인트 403 확인
   it("readOnly=true 시 POST /api/jobs/:id/cancel은 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     expect(res.status).toBe(403);
     const body = await res.json() as { error: string };
@@ -170,75 +170,75 @@ describe("Dashboard Auth — readOnly 모드", () => {
   });
 
   it("readOnly=true 시 POST /api/jobs/:id/retry는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/jobs/job-123/retry");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 DELETE /api/jobs/:id는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 DELETE /api/projects/:id는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 POST /api/projects는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/projects");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 PUT /api/config는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "PUT", "/api/config");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 POST /api/update는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/update");
     expect(res.status).toBe(403);
   });
 
   // (2) readOnly=true 시 GET 엔드포인트는 허용 (200 확인)
   it("readOnly=true 시 GET /api/jobs는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/jobs");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=true 시 GET /api/stats는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/stats");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=true 시 GET /api/config는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/config");
     expect(res.status).not.toBe(403);
   });
 
   // (3) readOnly=false(기본) 시 기존 동작 유지 — write 엔드포인트가 403이 아님
   it("readOnly=false(기본) 시 POST /api/jobs/:id/cancel은 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=false(기본) 시 DELETE /api/jobs/:id는 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=false(기본) 시 DELETE /api/projects/:id는 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     expect(res.status).not.toBe(403);
   });
@@ -260,7 +260,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 Authorization 헤더 없으면 /api/jobs는 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs");
     expect(res.status).toBe(401);
     const body = await res.json() as { error: string };
@@ -268,7 +268,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("잘못된 API 키로 요청 시 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: "Bearer wrong-key",
     });
@@ -276,7 +276,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("올바른 Bearer 토큰으로 요청 시 통과한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -285,7 +285,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("Bearer 접두어 없이 키만 보내면 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: API_KEY,
     });
@@ -293,7 +293,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("POST /api/auth에서 올바른 키로 세션 토큰을 발급받는다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "POST", "/api/auth", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -305,7 +305,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("POST /api/auth에서 잘못된 키는 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "POST", "/api/auth", {
       Authorization: "Bearer bad-key",
     });
@@ -313,19 +313,19 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 /api/stats도 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/stats");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/config도 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/config");
     expect(res.status).toBe(401);
   });
 
   it("타이밍 어택 방어: 잘못된 키도 일정 시간 내 응답한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const start = Date.now();
     await request(app, "GET", "/api/jobs", {
       Authorization: "Bearer x",
@@ -337,43 +337,43 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 /api/metrics/throughput은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/throughput");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/metrics/success-rate은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/success-rate");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/skip-events/stats은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/skip-events/stats");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/claude-profile은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/claude-profile");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/repositories은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/repositories");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/projects/health은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/projects/health");
     expect(res.status).toBe(401);
   });
 
   it("올바른 Bearer 토큰으로 /api/metrics/throughput 요청 시 401이 아니다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/throughput", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -381,7 +381,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("올바른 Bearer 토큰으로 /api/claude-profile 요청 시 401이 아니다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/claude-profile", {
       Authorization: `Bearer ${API_KEY}`,
     });

--- a/tests/server/auth-rate-limit.test.ts
+++ b/tests/server/auth-rate-limit.test.ts
@@ -299,9 +299,14 @@ describe("POST /api/auth — rate-limit 통합 테스트", () => {
   let app: Hono;
 
   beforeEach(() => {
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey, undefined, {
+    app = createDashboardRoutes({
+      store: mockJobStore,
+      queue: mockJobQueue,
+      apiKey,
+      dashboardAuth: {
       rateLimit: { maxAttempts: 3, windowMs: 60_000, blockDurationMs: 60_000 },
       sessionTtlMs: 3_600_000,
+    },
     });
   });
 

--- a/tests/server/bind-security.test.ts
+++ b/tests/server/bind-security.test.ts
@@ -94,7 +94,7 @@ const mockQueue = {
 
 // Helper: createDashboardRoutes without apiKey, with given hostname
 function makeRoutes(hostname?: string) {
-  return createDashboardRoutes(mockStore, mockQueue, undefined, undefined, hostname);
+  return createDashboardRoutes({ store: mockStore, queue: mockQueue, hostname });
 }
 
 describe("isLocalBind detection (no API key)", () => {
@@ -198,7 +198,7 @@ describe("non-local bind + no API key: security warning", () => {
   });
 
   it("does not warn when API key is provided with non-local hostname", () => {
-    createDashboardRoutes(mockStore, mockQueue, undefined, "secure-api-key", "0.0.0.0");
+    createDashboardRoutes({ store: mockStore, queue: mockQueue, apiKey: "secure-api-key", hostname: "0.0.0.0" });
     expect(mockWarn).not.toHaveBeenCalledWith(
       expect.stringContaining("Non-local bind")
     );

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -122,7 +122,7 @@ describe("Dashboard API - /api/config", () => {
 
   describe("without API key", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("should return config without authentication", async () => {
@@ -164,7 +164,7 @@ describe("Dashboard API - /api/config", () => {
     const apiKey = "test-api-key-123";
 
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
     });
 
     it("should require Bearer token authentication", async () => {
@@ -264,7 +264,7 @@ describe("Dashboard API - PUT /api/config", () => {
 
   describe("without API key", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("should update config section successfully", async () => {
@@ -489,7 +489,7 @@ describe("Dashboard API - PUT /api/config", () => {
     const apiKey = "test-api-key-123";
 
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
     });
 
     it("should require Bearer token authentication", async () => {
@@ -605,7 +605,7 @@ describe("Dashboard API - SSE broadcast", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(mockStore, mockQueue);
+    app = createDashboardRoutes({ store: mockStore, queue: mockQueue });
   });
 
   it("should register SSE client and handle job deletion event", async () => {
@@ -690,7 +690,7 @@ describe("Dashboard API - Resource Management", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(mockStore, mockQueue, undefined, apiKey);
+    app = createDashboardRoutes({ store: mockStore, queue: mockQueue, apiKey });
   });
 
   it("should create SSE client with proper timestamps", async () => {
@@ -736,7 +736,7 @@ describe("Dashboard API - Projects Management", () => {
     vi.clearAllMocks();
     mockDetectProjectCommands.mockReturnValue({ language: "unknown", commands: {} });
     mockDetectBaseBranch.mockResolvedValue("main");
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
   });
 
   describe("POST /api/projects", () => {
@@ -1287,7 +1287,7 @@ describe("Dashboard API - Version Management", () => {
   describe("GET /api/version", () => {
     describe("without API key", () => {
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       it("should return version info with update check", async () => {
@@ -1406,7 +1406,7 @@ describe("Dashboard API - Version Management", () => {
       const apiKey = "test-api-key-123";
 
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       it("should require Bearer token authentication", async () => {
@@ -1450,7 +1450,7 @@ describe("Dashboard API - Version Management", () => {
   describe("POST /api/update", () => {
     describe("without API key", () => {
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       it("should perform update successfully when no jobs running", async () => {
@@ -1562,7 +1562,7 @@ describe("Dashboard API - Version Management", () => {
       const apiKey = "test-api-key-123";
 
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       it("should require Bearer token authentication", async () => {
@@ -1614,7 +1614,7 @@ describe("Dashboard API - Version Management", () => {
 
       beforeEach(() => {
         vi.clearAllMocks();
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       describe("GET /api/jobs with project filter", () => {
@@ -1777,7 +1777,7 @@ describe("Dashboard API - Version Management", () => {
 
       beforeEach(() => {
         vi.clearAllMocks();
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       describe("GET /api/jobs with project filter", () => {
@@ -1858,7 +1858,7 @@ describe("Dashboard API - GET /api/health (detailed)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockLoadConfig.mockReturnValue(mockConfig as any);
 
@@ -2012,7 +2012,7 @@ describe("Dashboard API - GET /api/projects/health", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -2172,7 +2172,7 @@ describe("Dashboard API - SSE Connection Management", () => {
       cancel: vi.fn(),
       retryJob: vi.fn(),
     } as any;
-    return createDashboardRoutes(store, queue);
+    return createDashboardRoutes({ store, queue });
   }
 
   beforeEach(() => {
@@ -2343,7 +2343,7 @@ describe("Dashboard API - SSE Connection Management", () => {
         cancel: vi.fn(),
         retryJob: vi.fn(),
       } as any;
-      const appWithError = createDashboardRoutes(throwingStore, throwingQueue);
+      const appWithError = createDashboardRoutes({ store: throwingStore, queue: throwingQueue });
 
       // Should not throw even when store.list() throws inside the stream
       const response = await appWithError.request("/api/events");
@@ -2402,7 +2402,7 @@ describe("Dashboard API - PUT /api/jobs/:id/priority", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(localStore, localQueue);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue });
   });
 
   it("should update job priority to high", async () => {
@@ -2560,7 +2560,7 @@ describe("Dashboard API - PUT /api/jobs/:id/priority", () => {
         retryJob: vi.fn(),
       } as any;
 
-      app = createDashboardRoutes(localStore, localQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: localStore, queue: localQueue, apiKey });
     });
 
     it("should return 401 without authentication", async () => {
@@ -2601,7 +2601,7 @@ describe("Dashboard API - GET /api/repositories", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -2794,7 +2794,7 @@ describe("Dashboard API - GET /api/claude-profile", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     mockLoadConfig.mockReturnValue(mockClaudeConfig as any);
   });
 
@@ -2883,7 +2883,7 @@ describe("Dashboard API - GET /api/jobs/:id/logs/stream", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(localStore, localQueue);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue });
   });
 
   it("should return SSE stream with correct headers", async () => {
@@ -2943,7 +2943,7 @@ describe("Dashboard API - GET /api/projects/health warning branch", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -3014,7 +3014,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3037,7 +3037,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3061,7 +3061,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3078,7 +3078,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     await app.request("/api/projects/my-org%2Fmy-repo/error-state");
     expect(localQueue.getProjectStatus).toHaveBeenCalledWith("my-org/my-repo");
@@ -3093,7 +3093,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
         throw new Error("Internal queue error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(500);
@@ -3116,7 +3116,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const before = Date.now();
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
@@ -3141,7 +3141,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3162,7 +3162,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3183,7 +3183,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3204,7 +3204,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3225,7 +3225,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3244,7 +3244,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
         throw new Error("Queue internal error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3270,7 +3270,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
       retryJob: vi.fn(),
       resumeProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/resume", {
       method: "POST",
@@ -3290,7 +3290,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
       retryJob: vi.fn(),
       resumeProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     await app.request("/api/projects/my-org%2Fmy-repo/resume", { method: "POST" });
     expect(localQueue.resumeProject).toHaveBeenCalledWith("my-org/my-repo");
@@ -3305,7 +3305,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
         throw new Error("Queue internal error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/resume", {
       method: "POST",
@@ -3336,7 +3336,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [
@@ -3362,7 +3362,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [{ repo: "org/repo1", path: "./repo1" }],
@@ -3382,7 +3382,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({ projects: [] } as any);
 
@@ -3405,7 +3405,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(pausedErrorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [{ repo: "org/paused-repo", path: "./paused-repo" }],
@@ -3438,7 +3438,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     const mockConfigWatcher = { current: mockCurrent } as any;
     mockMaskSensitiveConfig.mockReturnValue(mockConfig as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, mockConfigWatcher);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, configWatcher: mockConfigWatcher });
 
     await app.request("/api/config");
     await app.request("/api/config");
@@ -3462,7 +3462,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     const mockConfigWatcher = { current: mockCurrent } as any;
     mockMaskSensitiveConfig.mockImplementation((c) => c as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, mockConfigWatcher);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, configWatcher: mockConfigWatcher });
 
     const res1 = await app.request("/api/config");
     const result1 = await res1.json() as { config: { general: { projectName: string } } };
@@ -3482,7 +3482,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     mockLoadConfig.mockReturnValue(mockConfig as any);
     mockMaskSensitiveConfig.mockReturnValue(mockConfig as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     const response = await app.request("/api/config");
 
@@ -3516,7 +3516,7 @@ describe("Dashboard API - POST /api/jobs/:id/cancel", () => {
       retryJob: vi.fn(),
     };
 
-    app = createDashboardRoutes(localStore, localQueue as any);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue as any });
   });
 
   it("should return 400 for invalid JSON body", async () => {
@@ -3606,7 +3606,7 @@ describe("Dashboard API - POST /api/jobs/:id/retry", () => {
       retryJob: vi.fn(),
     };
 
-    app = createDashboardRoutes(localStore, localQueue as any);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue as any });
   });
 
   it("should return 400 for invalid JSON body", async () => {

--- a/tests/server/failure-reasons-api.test.ts
+++ b/tests/server/failure-reasons-api.test.ts
@@ -80,7 +80,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("카테고리별 집계", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("실패 잡이 있을 때 카테고리별 집계 결과를 반환한다", async () => {
@@ -208,7 +208,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
         formatForPrompt: vi.fn(),
       } as any;
 
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, undefined, undefined, undefined, undefined, mockPatternStore);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, patternStore: mockPatternStore });
 
       mockGetFailureReasons.mockReturnValue({
         reasons: [{ category: "TIMEOUT", count: 5, percentage: 100.0, recentErrors: [] }],
@@ -233,7 +233,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("유효하지 않은 파라미터", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("잘못된 window 값에 400을 반환한다", async () => {
@@ -263,7 +263,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("에러 핸들링", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("getFailureReasons가 예외를 던지면 500을 반환한다", async () => {

--- a/tests/server/new-issue-api.test.ts
+++ b/tests/server/new-issue-api.test.ts
@@ -112,7 +112,7 @@ describe("POST /api/new-issue", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     mockLoadTemplate.mockReturnValue("template {{what}}");
     mockRenderTemplate.mockReturnValue("rendered body");
     mockRunCli.mockResolvedValue({ exitCode: 0, stdout: "https://github.com/owner/repo/issues/42\n", stderr: "" });
@@ -236,10 +236,11 @@ describe("POST /api/new-issue", () => {
   });
 
   it("readOnly 모드에서 POST 요청을 403으로 거부한다", async () => {
-    const readOnlyApp = createDashboardRoutes(
-      mockJobStore, mockJobQueue,
-      undefined, undefined, undefined, undefined, true
-    );
+    const readOnlyApp = createDashboardRoutes({
+      store: mockJobStore,
+      queue: mockJobQueue,
+      readOnly: true,
+    });
 
     const response = await readOnlyApp.request("/api/new-issue", {
       method: "POST",

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -127,7 +127,7 @@ const mockJobQueue = {
 } as unknown as JobQueue;
 
 function makeApp() {
-  return createDashboardRoutes(mockJobStore, mockJobQueue);
+  return createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 }
 
 async function postJson(app: ReturnType<typeof makeApp>, path: string, body: unknown) {


### PR DESCRIPTION
## Summary
- `DashboardRoutesOptions` 인터페이스 도입: 9개 positional 파라미터 → **단일 객체**
- `aqRoot`는 옵셔널 + `process.cwd()` fallback (테스트 호환). 프로덕션 cli.ts는 항상 명시 전달
- cli.ts 호출부 1곳을 객체 형식으로 변경
- 테스트 80+ 호출부 일괄 변환 (positional → 객체 shorthand)

영향 테스트 파일 (10개):
- `dashboard-api.test.ts`, `doctor-heal.test.ts`, `notification.test.ts`
- `security/dashboard-auth.test.ts`, `server/auth-rate-limit.test.ts`
- `server/bind-security.test.ts`, `server/dashboard-api.test.ts`
- `server/failure-reasons-api.test.ts`, `server/new-issue-api.test.ts`, `server/setup-api.test.ts`

## 효과
**#808 사고**처럼 위치 충돌 위험 완전 제거 — 새 필드 추가 시 기존 호출이 깨지지 않는다.

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — 0 errors

## Plan C 전체 완료
- ✅ #C1 Clock
- ✅ #C2 ConfigProvider
- ✅ #C3 PatternStore Mutex
- ✅ #C4 Dead code 850줄 제거
- ✅ #C5 SSEManager + DashboardContext
- ✅ #C6 JobCleanup + ProjectErrorTracker
- ✅ #C7 plan-generator AST 분리
- ✅ #C8 phase-tracker 헬퍼
- ✅ #C9 dashboard-api.ts 12 도메인 분할 (#820~#831)
- ✅ #C10 JobQueue Facade (StuckMonitor + Lifecycle + Scheduler)
- ✅ #C11 runPhaseWithTracking 적용
- ✅ #C12 createDashboardRoutes 시그니처 (본 PR)

**dashboard-api.ts 2119 → 290줄 (86% 감축)**
**job-queue.ts 952 → 444줄 (53% 감축)**

다음 단계: develop → main 릴리스 PR + **v0.9.0** bump