### PR TITLE
release: v0.9.0 — Plan C 코드 품질 리팩터

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.8.10",
+      "version": "0.9.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -487,7 +487,17 @@ export async function startCommand(args: CliArgs): Promise<void> {
   }
 
   const patternStore = getPatternStore(dataDir);
-  const dashboardRoutes = createDashboardRoutes(store, queue, configWatcher, apiKey, host, effectiveConfig.general.dashboardAuth, wslReadOnly, patternStore, aqRoot);
+  const dashboardRoutes = createDashboardRoutes({
+    store,
+    queue,
+    aqRoot,
+    configWatcher,
+    patternStore,
+    apiKey,
+    hostname: host,
+    dashboardAuth: effectiveConfig.general.dashboardAuth,
+    readOnly: wslReadOnly,
+  });
   const healthRoutes = createHealthRoutes(queue, poller);
 
   let app: ReturnType<typeof createWebhookApp>;

--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -69,20 +69,19 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     checkpointFn({ plan: undefined, phaseResults: [...accumulatedPhaseResults] });
 
     // Phase 3: Core Loop Execution (Plan generation + Phase execution)
-    const coreResult = await executeCoreLoopPhase(
+    const coreResult = await executeCoreLoopPhase({
       input,
       runtime,
       issue,
-      setupResult.project,
+      project: setupResult.project,
       config,
-      setupResult.promptsDir,
-      setupResult.dataDir,
+      promptsDir: setupResult.promptsDir,
+      dataDir: setupResult.dataDir,
       envResult,
-      setupResult.timer,
+      timer: setupResult.timer,
       mode,
-      hookRegistry,
-      hookExecutor
-    );
+      hooks: { registry: hookRegistry, executor: hookExecutor },
+    });
 
     checkpointFn({ plan: coreResult.coreResult.plan, phaseResults: [...accumulatedPhaseResults, ...coreResult.coreResult.phaseResults] });
 

--- a/src/pipeline/phases/phase-tracker.ts
+++ b/src/pipeline/phases/phase-tracker.ts
@@ -1,0 +1,100 @@
+import type { Clock } from "../../utils/clock.js";
+import { systemClock } from "../../utils/clock.js";
+import type { PhaseResult } from "../../types/pipeline.js";
+import type { OrchestratorInput, PipelineRuntime } from "../core/pipeline-context.js";
+import type { GitHubIssue } from "../../github/issue-fetcher.js";
+import type { ResolvedProject } from "../../config/project-resolver.js";
+import type { AQConfig, PipelineMode } from "../../types/config.js";
+import type { PipelineTimer } from "../../safety/timeout-manager.js";
+import type { HookRegistry } from "../../hooks/hook-registry.js";
+import type { HookExecutor } from "../../hooks/hook-executor.js";
+import type { EnvironmentSetupResult } from "./pipeline-phases.js";
+import {
+  makePseudoPhaseSuccess,
+  makePseudoPhaseFailure,
+  type PseudoPhaseName,
+} from "../reporting/phase-result-helper.js";
+
+/**
+ * core-loop phase 실행 시 필요한 의존성을 묶은 context 객체.
+ * 파라미터 폭주(`executeCoreLoopPhase` 12개)를 단일 객체로 정리한다.
+ */
+export interface CoreLoopPhaseContext {
+  input: OrchestratorInput;
+  runtime: PipelineRuntime;
+  issue: GitHubIssue;
+  project: ResolvedProject;
+  config: AQConfig;
+  promptsDir: string;
+  dataDir: string;
+  envResult: EnvironmentSetupResult;
+  timer: PipelineTimer;
+  mode: PipelineMode;
+  hooks?: { registry: HookRegistry; executor: HookExecutor };
+  clock?: Clock;
+}
+
+export interface PhaseTrackingResult<T> {
+  result: T;
+  durationMs: number;
+  startedAt: string;
+  completedAt: string;
+}
+
+interface TrackablePhaseResult {
+  success: boolean;
+  error?: string;
+  costUsd?: number;
+}
+
+/**
+ * pseudo-phase의 측정·기록 패턴을 단일화한다.
+ *
+ * `runner`를 실행하면서 시작/종료 시각·소요시간을 측정하고, `accumulated`가 주어지면
+ * 결과의 `success` 값에 따라 PhaseResult를 누적 배열에 push한다. runner 내부 예외는
+ * 호출부가 처리하도록 그대로 throw한다 (성공/실패 분기는 결과 객체의 `success`를 통해 표현).
+ *
+ * @param phaseName pseudo-phase 식별자 (`makePseudoPhase*` 키와 동일)
+ * @param runner 측정 대상 비동기 작업
+ * @param accumulated 누적 PhaseResult 배열 (선택)
+ * @param clock 시간 주입 (테스트용, 생략 시 systemClock)
+ */
+export async function runPhaseWithTracking<T extends TrackablePhaseResult>(
+  phaseName: PseudoPhaseName,
+  runner: () => Promise<T>,
+  accumulated?: PhaseResult[],
+  clock: Clock = systemClock
+): Promise<PhaseTrackingResult<T>> {
+  const startedAt = clock.nowIso();
+  const startMs = clock.nowMs();
+  const result = await runner();
+  const durationMs = clock.nowMs() - startMs;
+  const completedAt = clock.nowIso();
+
+  if (accumulated) {
+    if (result.success) {
+      accumulated.push(
+        makePseudoPhaseSuccess(phaseName, durationMs, {
+          startedAt,
+          completedAt,
+          costUsd: result.costUsd,
+        })
+      );
+    } else {
+      accumulated.push(
+        makePseudoPhaseFailure(
+          phaseName,
+          durationMs,
+          result.error ?? `${phaseName} failed`,
+          {
+            startedAt,
+            completedAt,
+            costUsd: result.costUsd,
+          }
+        )
+      );
+    }
+  }
+
+  return { result, durationMs, startedAt, completedAt };
+}

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -24,6 +24,7 @@ import {
   PROGRESS_DONE
 } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
+import { runPhaseWithTracking } from "./phase-tracker.js";
 import type { CoreLoopPhaseContext } from "./phase-tracker.js";
 import type { AQConfig, PipelineMode, ExecutionMode, GitConfig } from "../../types/config.js";
 import type { SenderPermission } from "../../github/issue-fetcher.js";
@@ -461,31 +462,12 @@ export async function executePostProcessingPhases(
     checkpoint
   };
 
-  const reviewStartedAt = nowIso();
-  const reviewStartMs = Date.now();
-  const reviewResult = await runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState);
-  const reviewDurationMs = Date.now() - reviewStartMs;
-  const reviewCompletedAt = nowIso();
-
-  if (context.accumulatedPhaseResults) {
-    if (reviewResult.success) {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseSuccess("review:code", reviewDurationMs, {
-          startedAt: reviewStartedAt,
-          completedAt: reviewCompletedAt,
-          costUsd: reviewResult.costUsd,
-        })
-      );
-    } else {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseFailure("review:code", reviewDurationMs, reviewResult.error ?? "Review phase failed", {
-          startedAt: reviewStartedAt,
-          completedAt: reviewCompletedAt,
-          costUsd: reviewResult.costUsd,
-        })
-      );
-    }
-  }
+  const reviewTracking = await runPhaseWithTracking(
+    "review:code",
+    () => runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState),
+    context.accumulatedPhaseResults
+  );
+  const reviewResult = reviewTracking.result;
 
   if (!reviewResult.success) {
     const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
@@ -517,31 +499,12 @@ export async function executePostProcessingPhases(
       checkpoint
     };
 
-    const simplifyStartedAt = nowIso();
-    const simplifyStartMs = Date.now();
-    const simplifyResult = await runSimplifyPhase(simplifyContext, executionModePreset, runtime.state, isPastState);
-    const simplifyDurationMs = Date.now() - simplifyStartMs;
-    const simplifyCompletedAt = nowIso();
-
-    if (context.accumulatedPhaseResults) {
-      if (simplifyResult.success) {
-        context.accumulatedPhaseResults.push(
-          makePseudoPhaseSuccess("review:simplify", simplifyDurationMs, {
-            startedAt: simplifyStartedAt,
-            completedAt: simplifyCompletedAt,
-            costUsd: simplifyResult.costUsd,
-          })
-        );
-      } else {
-        context.accumulatedPhaseResults.push(
-          makePseudoPhaseFailure("review:simplify", simplifyDurationMs, simplifyResult.error ?? "Simplify phase failed", {
-            startedAt: simplifyStartedAt,
-            completedAt: simplifyCompletedAt,
-            costUsd: simplifyResult.costUsd,
-          })
-        );
-      }
-    }
+    const simplifyTracking = await runPhaseWithTracking(
+      "review:simplify",
+      () => runSimplifyPhase(simplifyContext, executionModePreset, runtime.state, isPastState),
+      context.accumulatedPhaseResults
+    );
+    const simplifyResult = simplifyTracking.result;
 
     if (!simplifyResult.success) {
       const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
@@ -567,43 +530,26 @@ export async function executePostProcessingPhases(
     baseline: coreResult.baseline,
   };
 
-  const validationStartedAt = nowIso();
-  const validationStartMs = Date.now();
-  const validationResult = await runValidationPhase(
-    validationContext,
-    timer,
-    (checkState: string) => isPastState(runtime.state, checkState as PipelineState),
-    preset.skipFinalValidation,
-    detectExecutionModeFromLabels(issue.labels, "standard"),
-    (overrides?: Partial<PipelineCheckpoint>) => checkpoint(overrides || { plan: coreResult.plan, phaseResults: coreResult.phaseResults }),
-    issueNumber,
-    repo,
-    startTime,
-    config,
-    project.commands,
-    aqRoot,
-    runtime.projectRoot
+  const validationTracking = await runPhaseWithTracking(
+    "validation:check",
+    () => runValidationPhase(
+      validationContext,
+      timer,
+      (checkState: string) => isPastState(runtime.state, checkState as PipelineState),
+      preset.skipFinalValidation,
+      detectExecutionModeFromLabels(issue.labels, "standard"),
+      (overrides?: Partial<PipelineCheckpoint>) => checkpoint(overrides || { plan: coreResult.plan, phaseResults: coreResult.phaseResults }),
+      issueNumber,
+      repo,
+      startTime,
+      config,
+      project.commands,
+      aqRoot,
+      runtime.projectRoot
+    ),
+    context.accumulatedPhaseResults
   );
-  const validationDurationMs = Date.now() - validationStartMs;
-  const validationCompletedAt = nowIso();
-
-  if (context.accumulatedPhaseResults) {
-    if (validationResult.success) {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseSuccess("validation:check", validationDurationMs, {
-          startedAt: validationStartedAt,
-          completedAt: validationCompletedAt,
-        })
-      );
-    } else {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseFailure("validation:check", validationDurationMs, validationResult.error ?? "Validation phase failed", {
-          startedAt: validationStartedAt,
-          completedAt: validationCompletedAt,
-        })
-      );
-    }
-  }
+  const validationResult = validationTracking.result;
 
   if (!validationResult.success) {
     throw new Error(validationResult.error || "Validation phase failed");
@@ -655,29 +601,12 @@ export async function executePostProcessingPhases(
     senderPermission: context.senderPermission,
   };
 
-  const publishStartedAt = nowIso();
-  const publishStartMs = Date.now();
-  const publishResult = await pushAndCreatePR(publishContext);
-  const publishDurationMs = Date.now() - publishStartMs;
-  const publishCompletedAt = nowIso();
-
-  if (context.accumulatedPhaseResults) {
-    if (publishResult.success) {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseSuccess("publish:pr", publishDurationMs, {
-          startedAt: publishStartedAt,
-          completedAt: publishCompletedAt,
-        })
-      );
-    } else {
-      context.accumulatedPhaseResults.push(
-        makePseudoPhaseFailure("publish:pr", publishDurationMs, publishResult.error ?? "Publish phase failed", {
-          startedAt: publishStartedAt,
-          completedAt: publishCompletedAt,
-        })
-      );
-    }
-  }
+  const publishTracking = await runPhaseWithTracking(
+    "publish:pr",
+    () => pushAndCreatePR(publishContext),
+    context.accumulatedPhaseResults
+  );
+  const publishResult = publishTracking.result;
 
   if (!publishResult.success) {
     throw new Error(publishResult.error || "Publish phase failed");

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -24,6 +24,7 @@ import {
   PROGRESS_DONE
 } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
+import type { CoreLoopPhaseContext } from "./phase-tracker.js";
 import type { AQConfig, PipelineMode, ExecutionMode, GitConfig } from "../../types/config.js";
 import type { SenderPermission } from "../../github/issue-fetcher.js";
 import type { PipelineState, PhaseResult } from "../../types/pipeline.js";
@@ -289,19 +290,11 @@ export async function executeEnvironmentSetup(
  * Execute core loop phase: Plan generation and phase execution
  */
 export async function executeCoreLoopPhase(
-  input: OrchestratorInput,
-  runtime: PipelineRuntime,
-  issue: GitHubIssue,
-  project: ResolvedProject,
-  config: AQConfig,
-  promptsDir: string,
-  dataDir: string,
-  envResult: EnvironmentSetupResult,
-  timer: PipelineTimer,
-  mode: PipelineMode,
-  hookRegistry?: HookRegistry,
-  hookExecutor?: HookExecutor
+  ctx: CoreLoopPhaseContext
 ): Promise<CoreLoopExecutionResult> {
+  const { input, runtime, issue, project, config, promptsDir, dataDir, envResult, timer, mode, hooks } = ctx;
+  const hookRegistry = hooks?.registry;
+  const hookExecutor = hooks?.executor;
   const { repo } = input;
   const jl = input.jobLogger;
 

--- a/src/queue/job-cleanup.ts
+++ b/src/queue/job-cleanup.ts
@@ -1,0 +1,97 @@
+import { resolve } from "path";
+import { loadCheckpoint, removeCheckpoint } from "../pipeline/errors/checkpoint.js";
+import { removeWorktree } from "../git/worktree-manager.js";
+import { deleteRemoteBranch } from "../git/branch-manager.js";
+import { loadConfig } from "../config/loader.js";
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+
+const logger = getLogger();
+
+/**
+ * 실패한 잡의 worktree, 원격 브랜치, 체크포인트 정리를 담당한다.
+ *
+ * Plan C #C6 이전: `JobQueue.cleanupFailedJobArtifacts`가 fire-and-forget
+ * (`Promise.resolve(...).catch()`)으로 worktree/브랜치 제거를 던지고 즉시 반환했다.
+ * 후속 enqueue/retry가 정리 완료 전에 시작되면 worktree 충돌이 발생할 수 있었다.
+ *
+ * 본 서비스는 모든 정리 작업을 `await Promise.allSettled`로 묶어 후속 작업이 시작되기 전에
+ * 정리 완료를 보장한다. 각 단계 실패는 로그만 남기고 다른 단계는 계속 진행한다.
+ */
+export class JobCleanupService {
+  /**
+   * @param aqRoot AQM root (cwd) 디렉토리
+   * @param configProvider git config 조회용. 미주입 시 `loadConfig(aqRoot)` fallback.
+   */
+  constructor(
+    private readonly aqRoot: string,
+    private readonly configProvider?: ConfigProvider
+  ) {}
+
+  /**
+   * 실패한 잡의 worktree·원격 브랜치·체크포인트를 정리한다.
+   *
+   * 호출 측은 본 메서드 완료 후 동일 issue의 enqueue/retry를 안전하게 시작할 수 있다.
+   */
+  async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    const dataDir = resolve(this.aqRoot, "data");
+
+    let checkpoint = null;
+    try {
+      checkpoint = loadCheckpoint(dataDir, issueNumber);
+    } catch (err: unknown) {
+      logger.warn(
+        `Failed to load checkpoint for cleanup of issue #${issueNumber}: ${getErrorMessage(err)}`
+      );
+    }
+
+    const tasks: Promise<unknown>[] = [];
+    if (checkpoint) {
+      const config = this.configProvider?.current() ?? loadConfig(this.aqRoot);
+
+      if (checkpoint.worktreePath) {
+        const worktreePath = checkpoint.worktreePath;
+        logger.info(`Cleaning up worktree: ${worktreePath}`);
+        tasks.push(
+          Promise.resolve(
+            removeWorktree(config.git, worktreePath, { cwd: this.aqRoot, force: true })
+          ).catch((err: unknown) => {
+            logger.warn(
+              `Failed to remove worktree ${worktreePath}: ${getErrorMessage(err)}`
+            );
+          })
+        );
+      }
+
+      if (checkpoint.branchName) {
+        const branchName = checkpoint.branchName;
+        logger.info(`Deleting remote branch: ${branchName}`);
+        tasks.push(
+          Promise.resolve(
+            deleteRemoteBranch(config.git, branchName, { cwd: this.aqRoot })
+          ).catch((err: unknown) => {
+            logger.warn(
+              `Failed to delete remote branch ${branchName}: ${getErrorMessage(err)}`
+            );
+          })
+        );
+      }
+    }
+
+    // 체크포인트 제거는 항상 동기 시도 — 로드 실패한 경우에도 stale 체크포인트가 남으면 안 된다.
+    // worktree/branch 정리(비동기)보다 먼저 실행해 후속 enqueue가 stale 체크포인트를 잡지 않도록 한다.
+    try {
+      logger.info(`Removing checkpoint for issue #${issueNumber}`);
+      removeCheckpoint(dataDir, issueNumber);
+    } catch (err: unknown) {
+      logger.warn(
+        `Failed to remove checkpoint for issue #${issueNumber}: ${getErrorMessage(err)}`
+      );
+    }
+
+    if (tasks.length > 0) {
+      await Promise.allSettled(tasks);
+    }
+  }
+}

--- a/src/queue/job-lifecycle.ts
+++ b/src/queue/job-lifecycle.ts
@@ -1,0 +1,134 @@
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { JobStore } from "./job-store.js";
+import type { Job, DiagnosisReport, UserSummary } from "../types/pipeline.js";
+import type { ProjectErrorTracker } from "./project-error-tracker.js";
+import type { TaskFactory } from "../tasks/task-factory.js";
+import type { AQMTask } from "../tasks/aqm-task.js";
+
+const logger = getLogger();
+
+export type JobHandler = (
+  job: Job
+) => Promise<{
+  prUrl?: string;
+  error?: string;
+  diagnosis?: DiagnosisReport;
+  userSummary?: UserSummary;
+}>;
+
+/**
+ * 잡 한 건의 실행/결과 처리 책임 (Plan C #C10 — Phase 2).
+ *
+ * 이전: `JobQueue.executeJob` private 메서드. handler 호출, store 갱신, project error
+ *      tracking, stuckAborted/cancelled 세트 정리, finally 단계의 running/repo 카운터
+ *      해제까지 한 메서드에서 담당했다.
+ * 이후: 본 클래스가 실행 흐름과 결과 분기만 담당한다. 공유 상태(running/runningByRepo
+ *      카운터, processNext 호출)는 `onJobFinished` 콜백을 통해 JobQueue가 책임진다.
+ */
+export interface JobLifecycleDeps {
+  store: JobStore;
+  handler: JobHandler;
+  taskFactory?: TaskFactory;
+  errorTracker: ProjectErrorTracker;
+  /** JobQueue가 소유하는 active task 추적 Map. cancel()이 동일 Map을 참조한다. */
+  activeTasks: Map<string, AQMTask>;
+  /** StuckJobMonitor 콜백/JobLifecycle 사이에서 공유되는 stuck-abort 플래그. */
+  stuckAborted: Set<string>;
+  /** JobQueue.cancel과 공유되는 cancel 플래그. */
+  cancelled: Set<string>;
+  /**
+   * 잡 종료 시(성공/실패/취소/예외 모두 포함) 호출. JobQueue가 running.delete +
+   * removeJobFromRepo + processNext schedule을 처리한다.
+   */
+  onJobFinished: (jobId: string, repo: string) => void;
+}
+
+export class JobLifecycle {
+  constructor(private readonly deps: JobLifecycleDeps) {}
+
+  async execute(job: Job): Promise<void> {
+    try {
+      // Stuck monitor가 이미 abort 신호를 보낸 잡은 handler를 돌리지 않는다.
+      if (this.deps.stuckAborted.has(job.id)) {
+        this.deps.stuckAborted.delete(job.id);
+        return;
+      }
+
+      let result: {
+        prUrl?: string;
+        error?: string;
+        diagnosis?: DiagnosisReport;
+        userSummary?: UserSummary;
+      };
+
+      if (this.deps.taskFactory) {
+        const task = this.deps.taskFactory.createTask(job);
+        this.deps.activeTasks.set(job.id, task);
+        try {
+          result = await (
+            task as unknown as {
+              run(): Promise<{ prUrl?: string; error?: string }>;
+            }
+          ).run();
+        } finally {
+          this.deps.activeTasks.delete(job.id);
+        }
+      } else {
+        result = await this.deps.handler(job);
+      }
+
+      // handler 실행 도중 stuck checker가 발화했을 수 있다 — 결과 적용 전 재확인.
+      const wasStuckAborted = this.deps.stuckAborted.has(job.id);
+      if (wasStuckAborted) {
+        this.deps.stuckAborted.delete(job.id);
+        logger.warn(
+          `Job ${job.id} handler completed after stuck-abort — updating status but not tracking project metrics`
+        );
+      }
+
+      if (this.deps.cancelled.has(job.id)) {
+        this.deps.cancelled.delete(job.id);
+        // cancel()이 이미 cancelled 상태로 update했으므로 추가 처리 없음.
+      } else if (result.error) {
+        this.deps.store.update(job.id, {
+          status: "failure",
+          completedAt: new Date().toISOString(),
+          error: result.error,
+          ...(result.diagnosis ? { diagnosis: result.diagnosis } : {}),
+          ...(result.userSummary ? { userSummary: result.userSummary } : {}),
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackFailure(job.repo);
+        }
+      } else if (result.prUrl) {
+        this.deps.store.update(job.id, {
+          status: "success",
+          completedAt: new Date().toISOString(),
+          prUrl: result.prUrl,
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackSuccess(job.repo);
+        }
+      } else {
+        this.deps.store.update(job.id, {
+          status: "failure",
+          completedAt: new Date().toISOString(),
+          error: "Pipeline completed but no PR was created",
+        });
+        if (!wasStuckAborted) {
+          this.deps.errorTracker.trackFailure(job.repo);
+        }
+      }
+    } catch (error: unknown) {
+      this.deps.store.update(job.id, {
+        status: "failure",
+        completedAt: new Date().toISOString(),
+        error: getErrorMessage(error),
+      });
+      this.deps.errorTracker.trackFailure(job.repo);
+    } finally {
+      this.deps.onJobFinished(job.id, job.repo);
+    }
+  }
+}

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -1,17 +1,14 @@
-import { resolve } from "path";
 import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
 import { areDependenciesMet } from "./dependency-resolver.js";
-import { removeCheckpoint, loadCheckpoint } from "../pipeline/errors/checkpoint.js";
 import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
-import { removeWorktree } from "../git/worktree-manager.js";
-import { deleteRemoteBranch } from "../git/branch-manager.js";
-import { loadConfig } from "../config/loader.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { checkJobStuck } from "./stuck-detector.js";
+import { JobCleanupService } from "./job-cleanup.js";
+import { ProjectErrorTracker } from "./project-error-tracker.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -110,7 +107,8 @@ export class JobQueue {
   private processingJobs: Set<string> = new Set(); // jobs temporarily removed during processNext
   private projectConcurrency: Map<string, number> = new Map(); // repo -> concurrency limit
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
-  private projectErrorState: Map<string, ProjectErrorState> = new Map(); // repo -> error state
+  private readonly errorTracker = new ProjectErrorTracker();
+  private cleanupService: JobCleanupService;
   private lastServedRepo: string | null = null; // round-robin: last repo that was served
   private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
@@ -118,22 +116,25 @@ export class JobQueue {
   private configProvider?: ConfigProvider;
 
   /**
-   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다.
+   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6).
    *
-   * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서만 호출하면
-   * 되며, 테스트는 호출하지 않아도 `process.cwd()` fallback으로 기존 동작이 유지된다.
+   * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서 호출하면
+   * `JobCleanupService`/`ProjectErrorTracker`가 활성화된다. 테스트는 호출하지 않으면
+   * cleanupService 미설정 → cleanup no-op, errorTracker는 configProvider 없이 기본 임계값으로 동작.
    *
-   * 이렇게 주입된 projectRoot는 `cleanupFailedJobArtifacts`의 data 경로와 `trackProjectFailure`의
-   * config 로드 기준점으로 사용된다. 서버가 다른 cwd에서 기동되는 환경에서 발생하던 경로 오탐
-   * (process.cwd() ≠ AQM root)을 제거한다.
+   * Plan C #C6에서 `process.cwd()` fallback과 `loadConfig` 직접 호출이 모두 제거됐다.
    */
   setDependencies(deps: { projectRoot?: string; configProvider?: ConfigProvider }): void {
     if (deps.projectRoot) this.projectRoot = deps.projectRoot;
-    if (deps.configProvider) this.configProvider = deps.configProvider;
-  }
-
-  private resolveProjectRoot(): string {
-    return this.projectRoot ?? process.cwd();
+    if (deps.configProvider) {
+      this.configProvider = deps.configProvider;
+      this.errorTracker.setConfigProvider(deps.configProvider);
+    }
+    // cleanupService는 항상 갱신해 최신 의존성을 사용한다.
+    this.cleanupService = new JobCleanupService(
+      this.projectRoot ?? process.cwd(),
+      this.configProvider
+    );
   }
 
   constructor(
@@ -157,6 +158,10 @@ export class JobQueue {
         this.projectConcurrency.set(repo, limit);
       });
     }
+
+    // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
+    // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
+    this.cleanupService = new JobCleanupService(process.cwd());
 
     // Periodically check for stuck jobs
     this.stuckChecker = setInterval(() => this.checkStuckJobs(), STUCK_CHECK_INTERVAL_MS);
@@ -264,8 +269,8 @@ export class JobQueue {
    */
   recover(): number {
     // 재시작 시 메모리 상태 초기화 — pause 상태 자동 해제
-    this.projectErrorState.clear();
-    logger.info("재시작: projectErrorState 초기화 완료 (project pause 해제)");
+    this.errorTracker.clear();
+    logger.info("재시작: project error tracker 초기화 완료 (project pause 해제)");
 
     const jobs = this.store.list();
     let recovered = 0;
@@ -294,49 +299,12 @@ export class JobQueue {
 
 
   /**
-   * Cleanup failed job artifacts including worktree, remote branch, and checkpoint.
-   * Each step is attempted independently and failures are logged but don't stop the process.
+   * 실패 잡 정리 — JobCleanupService에 위임 (Plan C #C6).
+   * 호출부는 fire-and-forget(`void this.cleanupFailedJobArtifacts(...)`) 또는
+   * await(retryJob의 race 차단) 형태로 사용한다.
    */
-  private cleanupFailedJobArtifacts(issueNumber: number): void {
-    const projectRoot = this.resolveProjectRoot();
-    const dataDir = resolve(projectRoot, "data");
-
-    let checkpoint = null;
-    try {
-      checkpoint = loadCheckpoint(dataDir, issueNumber);
-    } catch (checkpointErr: unknown) {
-      logger.warn(`Failed to load checkpoint for cleanup of issue #${issueNumber}: ${getErrorMessage(checkpointErr)}`);
-    }
-
-    if (checkpoint) {
-      const config = this.configProvider?.current() ?? loadConfig(projectRoot);
-
-      // Step 1: Remove worktree if exists
-      if (checkpoint.worktreePath) {
-        logger.info(`Cleaning up worktree: ${checkpoint.worktreePath}`);
-        Promise.resolve(removeWorktree(config.git, checkpoint.worktreePath, { cwd: projectRoot, force: true }))
-          .catch((worktreeErr: unknown) => {
-            logger.warn(`Failed to remove worktree ${checkpoint.worktreePath}: ${getErrorMessage(worktreeErr)}`);
-          });
-      }
-
-      // Step 2: Delete remote branch if exists
-      if (checkpoint.branchName) {
-        logger.info(`Deleting remote branch: ${checkpoint.branchName}`);
-        Promise.resolve(deleteRemoteBranch(config.git, checkpoint.branchName, { cwd: projectRoot }))
-          .catch((branchErr: unknown) => {
-            logger.warn(`Failed to delete remote branch ${checkpoint.branchName}: ${getErrorMessage(branchErr)}`);
-          });
-      }
-    }
-
-    // Step 3: Always attempt to remove checkpoint regardless of whether we could load it
-    try {
-      logger.info(`Removing checkpoint for issue #${issueNumber}`);
-      removeCheckpoint(dataDir, issueNumber);
-    } catch (err: unknown) {
-      logger.warn(`Failed to remove checkpoint for issue #${issueNumber}: ${getErrorMessage(err)}`);
-    }
+  private async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    await this.cleanupService.cleanupFailedJobArtifacts(issueNumber);
   }
 
   /**
@@ -356,7 +324,10 @@ export class JobQueue {
         this.store.archive(existing.id);
       } else if (isFailureJob(existing) || isCancelledJob(existing)) {
         logger.info(`Auto-archiving existing ${existing.status} job ${existing.id} for issue #${issueNumber} (${repo})`);
-        this.cleanupFailedJobArtifacts(issueNumber);
+        // Fire-and-forget: enqueue 응답을 차단하지 않는다. retryJob에서는 race 차단을 위해 await로 호출.
+        void this.cleanupFailedJobArtifacts(issueNumber).catch((err: unknown) => {
+          logger.warn(`Cleanup failed during enqueue for issue #${issueNumber}: ${getErrorMessage(err)}`);
+        });
         this.store.archive(existing.id);
       } else if (isActiveJob(existing)) {
         // queued/running statuses should still block
@@ -383,8 +354,11 @@ export class JobQueue {
 
   /**
    * Retries a failed or cancelled job by removing the old one and creating a new one.
+   *
+   * Plan C #C6: cleanup이 완료된 후에야 새 잡을 enqueue하도록 await로 동기화.
+   * 이전 fire-and-forget으로 인해 발생할 수 있던 worktree race를 차단한다.
    */
-  retryJob(jobId: string): Job | undefined {
+  async retryJob(jobId: string): Promise<Job | undefined> {
     const oldJob = this.store.get(jobId);
     if (!oldJob) return undefined;
     if (!isFailureJob(oldJob) && !isCancelledJob(oldJob)) return undefined;
@@ -412,7 +386,7 @@ export class JobQueue {
     }
 
     const { issueNumber, repo, phaseResults } = oldJob;
-    this.cleanupFailedJobArtifacts(issueNumber);
+    await this.cleanupFailedJobArtifacts(issueNumber);
     this.store.archive(jobId);
     return this.enqueue(issueNumber, repo, undefined, true, undefined, phaseResults);
   }
@@ -538,111 +512,49 @@ export class JobQueue {
     }
   }
 
+  // Plan C #C6: 프로젝트 실패 추적/일시 정지 로직은 ProjectErrorTracker로 응집됨.
+  // 외부 public API 시그니처를 보존하기 위해 위임 wrapper만 유지한다.
+
   /**
    * Checks if a project is currently paused due to consecutive failures.
    */
   isProjectPaused(repo: string): boolean {
-    const errorState = this.projectErrorState.get(repo);
-    if (!errorState || !errorState.pausedUntil) {
-      return false;
-    }
-
-    // Check if pause has expired
-    if (Date.now() >= errorState.pausedUntil) {
-      // Auto-resume expired pause
-      this.resumeProject(repo);
-      return false;
-    }
-
-    return true;
+    return this.errorTracker.isProjectPaused(repo);
   }
 
   /**
    * Manually pauses a project for the specified duration.
    */
   pauseProject(repo: string, durationMs: number): void {
-    const errorState = this.projectErrorState.get(repo) || {
-      consecutiveFailures: 0,
-      pausedUntil: null,
-      lastFailureAt: null,
-    };
-
-    errorState.pausedUntil = Date.now() + durationMs;
-    this.projectErrorState.set(repo, errorState);
-
-    logger.warn(`Project ${repo} manually paused for ${Math.round(durationMs / 1000)}s`);
+    this.errorTracker.pauseProject(repo, durationMs);
   }
 
   /**
    * Resumes a paused project.
    */
   resumeProject(repo: string): void {
-    const errorState = this.projectErrorState.get(repo);
-    if (errorState) {
-      errorState.pausedUntil = null;
-      this.projectErrorState.set(repo, errorState);
-      logger.info(`Project ${repo} resumed`);
-    }
+    this.errorTracker.resumeProject(repo);
   }
 
   /**
    * Gets the error status of a project.
    */
   getProjectStatus(repo: string): ProjectErrorState | null {
-    return this.projectErrorState.get(repo) || null;
+    return this.errorTracker.getProjectStatus(repo);
   }
 
   /**
    * Tracks a project failure and potentially pauses the project.
    */
   private trackProjectFailure(repo: string): void {
-    let project = undefined;
-    try {
-      const config = this.configProvider?.current() ?? loadConfig(this.resolveProjectRoot());
-      project = config?.projects?.find(p => p.repo === repo);
-    } catch (error: unknown) {
-      // If config loading fails (e.g. in test environment), use defaults
-      logger.debug(`Failed to load config for project failure tracking: ${getErrorMessage(error)}`);
-    }
-
-    const pauseThreshold = project?.pauseThreshold || 3;
-    const pauseDurationMs = project?.pauseDurationMs || 30 * 60 * 1000; // 30분 기본값
-
-    const errorState = this.projectErrorState.get(repo) || {
-      consecutiveFailures: 0,
-      pausedUntil: null,
-      lastFailureAt: null,
-    };
-
-    errorState.consecutiveFailures++;
-    errorState.lastFailureAt = Date.now();
-
-    if (errorState.consecutiveFailures >= pauseThreshold) {
-      errorState.pausedUntil = Date.now() + pauseDurationMs;
-      logger.error(
-        `Project ${repo} paused for ${Math.round(pauseDurationMs / 60000)}min after ${errorState.consecutiveFailures} consecutive failures`
-      );
-    } else {
-      logger.warn(
-        `Project ${repo} failure count: ${errorState.consecutiveFailures}/${pauseThreshold}`
-      );
-    }
-
-    this.projectErrorState.set(repo, errorState);
+    this.errorTracker.trackFailure(repo);
   }
 
   /**
    * Tracks a project success and resets failure count.
    */
   private trackProjectSuccess(repo: string): void {
-    const errorState = this.projectErrorState.get(repo);
-    if (errorState && errorState.consecutiveFailures > 0) {
-      logger.info(`Project ${repo} success - resetting failure count (was ${errorState.consecutiveFailures})`);
-      errorState.consecutiveFailures = 0;
-      errorState.lastFailureAt = null;
-      // Keep pausedUntil if manually set
-      this.projectErrorState.set(repo, errorState);
-    }
+    this.errorTracker.trackSuccess(repo);
   }
 
   /**
@@ -834,7 +746,7 @@ export class JobQueue {
 
         // Check if project is paused due to consecutive failures
         if (this.isProjectPaused(job.repo)) {
-          const errorState = this.projectErrorState.get(job.repo);
+          const errorState = this.errorTracker.getProjectStatus(job.repo);
           const remainingMs = errorState!.pausedUntil! - Date.now();
           logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
           this.processingJobs.delete(jobId);

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -2,13 +2,13 @@ import { getLogger } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
-import { areDependenciesMet } from "./dependency-resolver.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
 import { StuckJobMonitor } from "./stuck-monitor.js";
 import { JobLifecycle } from "./job-lifecycle.js";
+import { JobScheduler } from "./job-scheduler.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -91,39 +91,30 @@ function convertStoreJobToJob(storeJob: StoreJob): Job {
 const STUCK_CHECK_INTERVAL_MS = 60 * 1000; // check every minute
 
 export class JobQueue {
-  private pending: string[] = [];  // job IDs
-  private running: Set<string> = new Set();
   private store: JobStore;
-  private concurrency: number;
   private handler: JobHandler;
   private cancelled: Set<string> = new Set();
-  private readonly stuckMonitor: StuckJobMonitor;
-  private stuckTimeoutMs: number;
-  private stuckThresholds?: StuckThresholdConfig;
-  private shuttingDown: boolean = false;
   private stuckAborted: Set<string> = new Set();
-  private isProcessing: boolean = false;
-  private needsReprocess: boolean = false;
-  private processingJobs: Set<string> = new Set(); // jobs temporarily removed during processNext
-  private projectConcurrency: Map<string, number> = new Map(); // repo -> concurrency limit
-  private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
-  private readonly errorTracker = new ProjectErrorTracker();
-  private cleanupService: JobCleanupService;
-  private readonly lifecycle: JobLifecycle;
-  private lastServedRepo: string | null = null; // round-robin: last repo that was served
-  private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
+  private taskFactory?: TaskFactory;
+  private shuttingDown: boolean = false;
+  private readonly errorTracker = new ProjectErrorTracker();
+  private cleanupService?: JobCleanupService; // setDependencies 호출 후 활성화
+  private readonly scheduler: JobScheduler;
+  private readonly lifecycle: JobLifecycle;
+  private readonly stuckMonitor: StuckJobMonitor;
   private projectRoot?: string;
   private configProvider?: ConfigProvider;
 
   /**
-   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6).
+   * 런타임 의존성(projectRoot, ConfigProvider)을 주입한다 (Plan C #C2/#C6/#C10).
    *
    * 구성자 서명을 바꾸지 않기 위한 post-construction 주입. cli.ts 등 애플리케이션 코드에서 호출하면
    * `JobCleanupService`/`ProjectErrorTracker`가 활성화된다. 테스트는 호출하지 않으면
    * cleanupService 미설정 → cleanup no-op, errorTracker는 configProvider 없이 기본 임계값으로 동작.
    *
-   * Plan C #C6에서 `process.cwd()` fallback과 `loadConfig` 직접 호출이 모두 제거됐다.
+   * Plan C #C10 Phase 3에서 `process.cwd()` fallback이 완전히 제거됐다. 호출하지 않으면
+   * cleanup이 그냥 동작하지 않으며, 어떤 디렉터리도 가정하지 않는다.
    */
   setDependencies(deps: { projectRoot?: string; configProvider?: ConfigProvider }): void {
     if (deps.projectRoot) this.projectRoot = deps.projectRoot;
@@ -131,11 +122,9 @@ export class JobQueue {
       this.configProvider = deps.configProvider;
       this.errorTracker.setConfigProvider(deps.configProvider);
     }
-    // cleanupService는 항상 갱신해 최신 의존성을 사용한다.
-    this.cleanupService = new JobCleanupService(
-      this.projectRoot ?? process.cwd(),
-      this.configProvider
-    );
+    if (this.projectRoot) {
+      this.cleanupService = new JobCleanupService(this.projectRoot, this.configProvider);
+    }
   }
 
   constructor(
@@ -148,21 +137,22 @@ export class JobQueue {
     stuckThresholds?: StuckThresholdConfig
   ) {
     this.store = store;
-    this.concurrency = concurrency;
     this.handler = handler;
-    this.stuckTimeoutMs = stuckTimeoutMs;
-    this.stuckThresholds = stuckThresholds;
     this.taskFactory = taskFactory;
 
-    if (projectConcurrency) {
-      Object.entries(projectConcurrency).forEach(([repo, limit]) => {
-        this.projectConcurrency.set(repo, limit);
-      });
-    }
-
-    // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
-    // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
-    this.cleanupService = new JobCleanupService(process.cwd());
+    // 스케줄링 책임은 JobScheduler에 위임 (Plan C #C10 Phase 3)
+    this.scheduler = new JobScheduler({
+      store: this.store,
+      errorTracker: this.errorTracker,
+      concurrency,
+      projectConcurrency,
+      cancelledRef: this.cancelled,
+      onStartJob: (job) => {
+        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
+          logger.error(`Job ${job.id} unexpected error: ${getErrorMessage(err)}`);
+        });
+      },
+    });
 
     // 잡 실행/결과 처리는 JobLifecycle에 위임 (Plan C #C10 Phase 2)
     this.lifecycle = new JobLifecycle({
@@ -174,20 +164,17 @@ export class JobQueue {
       stuckAborted: this.stuckAborted,
       cancelled: this.cancelled,
       onJobFinished: (jobId, repo) => {
-        this.running.delete(jobId);
-        this.removeJobFromRepo(jobId, repo);
-        // Process next in queue (defer via setImmediate to avoid deep call stacks)
-        setImmediate(() => this.processNext());
+        this.scheduler.markJobFinished(jobId, repo);
       },
     });
 
-    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
+    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10 Phase 1)
     this.stuckMonitor = new StuckJobMonitor({
       store: this.store,
-      stuckTimeoutMs: this.stuckTimeoutMs,
-      stuckThresholds: this.stuckThresholds,
+      stuckTimeoutMs,
+      stuckThresholds,
       checkIntervalMs: STUCK_CHECK_INTERVAL_MS,
-      getRunningJobIds: () => this.running,
+      getRunningJobIds: () => this.scheduler.getRunningIds(),
       toJob: convertStoreJobToJob,
       onStuckDetected: (jobId, reason) => {
         this.store.update(jobId, {
@@ -196,8 +183,7 @@ export class JobQueue {
           error: reason,
         });
         this.stuckAborted.add(jobId);
-        this.running.delete(jobId);
-        setTimeout(() => this.processNext(), 0);
+        this.scheduler.markStuckAborted(jobId);
       },
     });
     this.stuckMonitor.start();
@@ -207,7 +193,7 @@ export class JobQueue {
    * Marks a job as stuck-aborted so executeJob can detect it after the handler returns.
    */
   abortJob(jobId: string): boolean {
-    if (this.running.has(jobId)) {
+    if (this.scheduler.isRunning(jobId)) {
       this.stuckAborted.add(jobId);
       return true;
     }
@@ -221,20 +207,20 @@ export class JobQueue {
   shutdown(timeoutMs: number = 30000): Promise<void> {
     this.shuttingDown = true;
     this.stuckMonitor.stop();
-    if (this.running.size === 0) {
+    if (this.scheduler.runningCount === 0) {
       return Promise.resolve();
     }
     return new Promise((resolve) => {
       const start = Date.now();
       const check = setInterval(() => {
-        if (this.running.size === 0) {
+        if (this.scheduler.runningCount === 0) {
           clearInterval(check);
           resolve();
           return;
         }
         if (Date.now() - start >= timeoutMs) {
           clearInterval(check);
-          logger.warn(`Shutdown timeout: ${this.running.size} job(s) still running after ${timeoutMs / 1000}s`);
+          logger.warn(`Shutdown timeout: ${this.scheduler.runningCount} job(s) still running after ${timeoutMs / 1000}s`);
           resolve();
         }
       }, 1000);
@@ -257,11 +243,11 @@ export class JobQueue {
       if (isRunningJob(job)) {
         // Was running when server died — reset to queued
         this.store.update(job.id, { status: "queued", startedAt: undefined });
-        this.pending.push(job.id);
+        this.scheduler.pushPending(job.id);
         recovered++;
         logger.info(`Job recovered (was running): ${job.id}`);
       } else if (isQueuedJob(job)) {
-        this.pending.push(job.id);
+        this.scheduler.pushPending(job.id);
         recovered++;
         logger.info(`Job recovered (was queued): ${job.id}`);
       }
@@ -269,7 +255,7 @@ export class JobQueue {
 
     if (recovered > 0) {
       logger.info(`Recovered ${recovered} job(s) from previous session`);
-      this.processNext();
+      void this.scheduler.processNext();
     }
 
     return recovered;
@@ -278,10 +264,10 @@ export class JobQueue {
 
   /**
    * 실패 잡 정리 — JobCleanupService에 위임 (Plan C #C6).
-   * 호출부는 fire-and-forget(`void this.cleanupFailedJobArtifacts(...)`) 또는
-   * await(retryJob의 race 차단) 형태로 사용한다.
+   * setDependencies 전에는 no-op (테스트 환경 호환).
    */
   private async cleanupFailedJobArtifacts(issueNumber: number): Promise<void> {
+    if (!this.cleanupService) return;
     await this.cleanupService.cleanupFailedJobArtifacts(issueNumber);
   }
 
@@ -319,13 +305,11 @@ export class JobQueue {
     }
 
     const job = this.store.create(issueNumber, repo, dependencies, isRetry, initialPhaseResults, priority, triggerReason);
-    // Convert StoreJob to discriminated union Job type
     const snapshot = convertStoreJobToJob(job);
-    this.pending.push(job.id);
-    logger.info(`Job enqueued: ${job.id} (pending: ${this.pending.length}, running: ${this.running.size})`);
+    const status = this.scheduler.getStatus();
+    logger.info(`Job enqueued: ${job.id} (pending: ${status.pending + 1}, running: ${status.running})`);
 
-    // Try to process next
-    this.processNext();
+    this.scheduler.enqueue(job.id);
 
     return snapshot;
   }
@@ -374,16 +358,14 @@ export class JobQueue {
    */
   cancel(jobId: string): boolean {
     // Remove from pending
-    const pendingIdx = this.pending.indexOf(jobId);
-    if (pendingIdx >= 0) {
-      this.pending.splice(pendingIdx, 1);
+    if (this.scheduler.removePending(jobId)) {
       this.store.update(jobId, { status: "cancelled", completedAt: new Date().toISOString() });
       logger.info(`Job cancelled (was pending): ${jobId}`);
       return true;
     }
 
     // Mark running job for cancellation
-    if (this.running.has(jobId)) {
+    if (this.scheduler.isRunning(jobId)) {
       this.cancelled.add(jobId);
       this.store.update(jobId, { status: "cancelled", completedAt: new Date().toISOString() });
       // Kill active task if tracked
@@ -411,20 +393,7 @@ export class JobQueue {
    * Sets the concurrency limit and immediately processes pending jobs if capacity allows.
    */
   setConcurrency(n: number): void {
-    if (n <= 0 || !Number.isInteger(n)) {
-      throw new Error("Concurrency must be a positive integer");
-    }
-
-    this.concurrency = n;
-    logger.info(`Concurrency updated to ${n}`);
-
-    // Trigger immediate processing if we now have more capacity
-    this.processNext();
-
-    // If processNext is already running (re-entrancy), ensure it gets called again
-    if (this.isProcessing && !this.needsReprocess) {
-      this.needsReprocess = true;
-    }
+    this.scheduler.setConcurrency(n);
   }
 
   /**
@@ -432,62 +401,14 @@ export class JobQueue {
    * Pass null to remove the project-specific limit.
    */
   setProjectConcurrency(repo: string, limit: number | null): void {
-    if (limit !== null && (limit <= 0 || !Number.isInteger(limit))) {
-      throw new Error("Project concurrency limit must be a positive integer");
-    }
-
-    if (limit === null) {
-      this.projectConcurrency.delete(repo);
-      logger.info(`Project concurrency limit removed for ${repo}`);
-    } else {
-      this.projectConcurrency.set(repo, limit);
-      logger.info(`Project concurrency limit for ${repo} set to ${limit}`);
-    }
-
-    // Trigger immediate processing in case capacity increased
-    this.processNext();
+    this.scheduler.setProjectConcurrency(repo, limit);
   }
 
   /**
    * Returns queue status.
    */
   getStatus(): { pending: number; running: number; concurrency: number } {
-    return {
-      pending: this.pending.length + this.processingJobs.size,
-      running: this.running.size,
-      concurrency: this.concurrency,
-    };
-  }
-
-  /**
-   * Checks if a new job can be started for the given repo based on project-specific concurrency limits.
-   */
-  private canStartJobForRepo(repo: string): boolean {
-    const projectLimit = this.projectConcurrency.get(repo);
-    if (!projectLimit) {
-      return true;
-    }
-    const currentRunning = this.runningByRepo.get(repo) ?? 0;
-    return currentRunning < projectLimit;
-  }
-
-  /**
-   * Increments the running count for a repo.
-   */
-  private addJobToRepo(jobId: string, repo: string): void {
-    this.runningByRepo.set(repo, (this.runningByRepo.get(repo) ?? 0) + 1);
-  }
-
-  /**
-   * Decrements the running count for a repo.
-   */
-  private removeJobFromRepo(jobId: string, repo: string): void {
-    const current = this.runningByRepo.get(repo) ?? 0;
-    if (current > 1) {
-      this.runningByRepo.set(repo, current - 1);
-    } else {
-      this.runningByRepo.delete(repo);
-    }
+    return this.scheduler.getStatus();
   }
 
   // Plan C #C6: 프로젝트 실패 추적/일시 정지 로직은 ProjectErrorTracker로 응집됨.
@@ -520,229 +441,4 @@ export class JobQueue {
   getProjectStatus(repo: string): ProjectErrorState | null {
     return this.errorTracker.getProjectStatus(repo);
   }
-
-  /**
-   * Gets the highest priority job from the pending queue and removes it.
-   * Priority order: high (0) > normal (1) > low (2)
-   * Within same priority: FIFO (earliest createdAt first)
-   * Missing priority defaults to 'normal'
-   */
-  private getNextPriorityJob(): string | null {
-    if (this.pending.length === 0) return null;
-
-    let bestIndex = -1;
-    let bestPriorityValue = 3; // Lower than 'low' (2)
-    let bestCreatedAt = '';
-
-    // Find the job with highest priority (lowest numeric value)
-    for (let i = 0; i < this.pending.length; i++) {
-      const jobId = this.pending[i];
-      const job = this.store.get(jobId);
-      if (!job) continue;
-
-      // Map priority to numeric value for comparison: high=0, normal=1, low=2
-      const priority = job.priority ?? 'normal';
-      const priorityValue = priority === 'high' ? 0 : priority === 'normal' ? 1 : 2;
-
-      // Select if higher priority, or same priority but earlier created, or first job
-      if (bestIndex === -1 ||
-          priorityValue < bestPriorityValue ||
-          (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)) {
-        bestIndex = i;
-        bestPriorityValue = priorityValue;
-        bestCreatedAt = job.createdAt;
-      }
-    }
-
-    if (bestIndex >= 0) {
-      return this.pending.splice(bestIndex, 1)[0];
-    }
-    return null;
-  }
-
-  /**
-   * Gets the next job using round-robin scheduling across projects.
-   * Cycles through repos starting after lastServedRepo, and within each repo
-   * selects the highest-priority job (FIFO within same priority).
-   */
-  private getNextRoundRobinJob(): string | null {
-    if (this.pending.length === 0) return null;
-
-    // Build ordered repo list and group jobs by repo (preserving insertion order)
-    const repoOrder: string[] = [];
-    const jobsByRepo = new Map<string, string[]>();
-    for (const jobId of this.pending) {
-      const job = this.store.get(jobId);
-      if (!job) continue;
-      if (!jobsByRepo.has(job.repo)) {
-        repoOrder.push(job.repo);
-        jobsByRepo.set(job.repo, []);
-      }
-      jobsByRepo.get(job.repo)!.push(jobId);
-    }
-
-    if (repoOrder.length === 0) return null;
-
-    // Determine starting index: one after lastServedRepo
-    let startIndex = 0;
-    if (this.lastServedRepo !== null) {
-      const lastIdx = repoOrder.indexOf(this.lastServedRepo);
-      if (lastIdx >= 0) {
-        startIndex = (lastIdx + 1) % repoOrder.length;
-      }
-    }
-
-    // Cycle through repos to find the next one with eligible jobs
-    for (let i = 0; i < repoOrder.length; i++) {
-      const repo = repoOrder[(startIndex + i) % repoOrder.length];
-      const repoJobs = jobsByRepo.get(repo);
-      if (!repoJobs || repoJobs.length === 0) continue;
-
-      // Select highest-priority job within this repo (FIFO within same priority)
-      let bestIndex = -1;
-      let bestPriorityValue = 3;
-      let bestCreatedAt = '';
-
-      for (let j = 0; j < repoJobs.length; j++) {
-        const jobId = repoJobs[j];
-        const job = this.store.get(jobId);
-        if (!job) continue;
-
-        const priority = job.priority ?? 'normal';
-        const priorityValue = priority === 'high' ? 0 : priority === 'normal' ? 1 : 2;
-
-        if (bestIndex === -1 ||
-            priorityValue < bestPriorityValue ||
-            (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)) {
-          bestIndex = j;
-          bestPriorityValue = priorityValue;
-          bestCreatedAt = job.createdAt;
-        }
-      }
-
-      if (bestIndex >= 0) {
-        const selectedJobId = repoJobs[bestIndex];
-        const pendingIdx = this.pending.indexOf(selectedJobId);
-        if (pendingIdx >= 0) {
-          this.pending.splice(pendingIdx, 1);
-        }
-        this.lastServedRepo = repo;
-        return selectedJobId;
-      }
-    }
-
-    return null;
-  }
-
-  private async processNext(): Promise<void> {
-    // Bail out if the store has been closed (e.g., during test teardown)
-    if (this.store.isClosed) return;
-
-    // Prevent re-entrancy
-    if (this.isProcessing) {
-      this.needsReprocess = true;
-      return;
-    }
-
-    this.isProcessing = true;
-    this.needsReprocess = false;
-
-    try {
-      // Collect job IDs that are skipped due to unmet dependencies (put back at end)
-      const deferred: string[] = [];
-
-      while (this.running.size < this.concurrency && this.pending.length > 0) {
-        const jobId = this.getNextRoundRobinJob();
-        if (!jobId) break; // No valid jobs available
-
-        // Track job as being processed
-        this.processingJobs.add(jobId);
-
-        if (this.cancelled.has(jobId)) {
-          this.cancelled.delete(jobId);
-          this.processingJobs.delete(jobId);
-          continue;
-        }
-
-        const job = this.store.get(jobId);
-        if (!job) {
-          this.processingJobs.delete(jobId);
-          continue;
-        }
-
-        // Check dependency readiness
-        if (job.dependencies && job.dependencies.length > 0) {
-          const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.store);
-          if (!met) {
-            // Check if any dependency has permanently failed — fail the dependent job immediately
-            let depFailed = false;
-            for (const depNum of job.dependencies) {
-              const depJob = this.store.findAnyByIssue(depNum, job.repo);
-              if (depJob && (isFailureJob(depJob) || isCancelledJob(depJob))) {
-                logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
-                this.store.update(jobId, {
-                  status: "failure",
-                  completedAt: new Date().toISOString(),
-                  error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
-                });
-                depFailed = true;
-                break;
-              }
-            }
-            if (!depFailed) {
-              logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
-              this.processingJobs.delete(jobId);
-              deferred.push(jobId);
-            } else {
-              this.processingJobs.delete(jobId);
-            }
-            continue;
-          }
-        }
-
-        // Check project-specific concurrency limits
-        if (!this.canStartJobForRepo(job.repo)) {
-          logger.info(`Job ${jobId} deferred due to project concurrency limit for repo ${job.repo}`);
-          this.processingJobs.delete(jobId);
-          deferred.push(jobId);
-          continue;
-        }
-
-        // Check if project is paused due to consecutive failures
-        if (this.isProjectPaused(job.repo)) {
-          const errorState = this.errorTracker.getProjectStatus(job.repo);
-          const remainingMs = errorState!.pausedUntil! - Date.now();
-          logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
-          this.processingJobs.delete(jobId);
-          deferred.push(jobId);
-          continue;
-        }
-
-        this.running.add(jobId);
-        this.addJobToRepo(jobId, job.repo);
-        this.processingJobs.delete(jobId);
-        this.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
-
-        logger.info(`Job started: ${jobId}`);
-
-        // Run async - don't await, let it run in background
-        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
-          logger.error(`Job ${jobId} unexpected error: ${getErrorMessage(err)}`);
-        });
-      }
-
-      // Re-append deferred jobs so they are retried on the next processNext() call
-      for (const jobId of deferred) {
-        this.pending.push(jobId);
-      }
-    } finally {
-      this.isProcessing = false;
-
-      // If another call was made while processing, handle it now
-      if (this.needsReprocess) {
-        setImmediate(() => this.processNext());
-      }
-    }
-  }
-
 }

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -3,12 +3,11 @@ import { getErrorMessage } from "../utils/error-utils.js";
 import { JobStore, Job as StoreJob } from "./job-store.js";
 import { Job, isQueuedJob, isRunningJob, isSuccessJob, isFailureJob, isCancelledJob, isActiveJob, PhaseResultInfo, DiagnosisReport, UserSummary } from "../types/pipeline.js";
 import { areDependenciesMet } from "./dependency-resolver.js";
-import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
 import type { ConfigProvider } from "../config/config-provider.js";
 import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
-import { checkJobStuck } from "./stuck-detector.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
+import { StuckJobMonitor } from "./stuck-monitor.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -97,7 +96,7 @@ export class JobQueue {
   private concurrency: number;
   private handler: JobHandler;
   private cancelled: Set<string> = new Set();
-  private stuckChecker: ReturnType<typeof setInterval> | undefined;
+  private readonly stuckMonitor: StuckJobMonitor;
   private stuckTimeoutMs: number;
   private stuckThresholds?: StuckThresholdConfig;
   private shuttingDown: boolean = false;
@@ -163,63 +162,26 @@ export class JobQueue {
     // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
     this.cleanupService = new JobCleanupService(process.cwd());
 
-    // Periodically check for stuck jobs
-    this.stuckChecker = setInterval(() => this.checkStuckJobs(), STUCK_CHECK_INTERVAL_MS);
-  }
-
-  private checkStuckJobs(): void {
-    const thresholds: StuckThresholdConfig = this.stuckThresholds ?? {
-      defaultMs: this.stuckTimeoutMs,
-      planGenerationMs: this.stuckTimeoutMs,
-      implementationMs: this.stuckTimeoutMs,
-      reviewMs: this.stuckTimeoutMs,
-      verificationMs: this.stuckTimeoutMs,
-      publishMs: this.stuckTimeoutMs,
-      activityThresholdMs: 5 * 60 * 1000,
-    };
-
-    const processAlive = isClaudeProcessAlive();
-    const lastActivityMs = getLastActivityMs();
-
-    for (const jobId of this.running) {
-      const storeJob = this.store.get(jobId);
-      if (!storeJob) continue;
-
-      const job = convertStoreJobToJob(storeJob);
-      const result = checkJobStuck(job, thresholds, { processAlive, lastActivityMs });
-
-      logger.debug(
-        `StuckCheck job=${jobId} step=${job.currentStep ?? "-"} category=${result.category} ` +
-        `elapsed=${result.elapsedMs}ms threshold=${result.thresholdMs}ms isStuck=${result.isStuck} reason=${result.reason}`
-      );
-
-      if (!result.isStuck && result.reason !== "임계값 이내") {
-        // Threshold exceeded but still working — extend lastUpdatedAt
-        if (result.reason.startsWith("Claude 활동 중")) {
-          logger.info(
-            `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과, ${result.reason} — 대기 연장`
-          );
-        } else {
-          logger.debug(
-            `Job ${jobId} (${result.category}): ${result.reason} — 대기 연장`
-          );
-        }
-        this.store.update(jobId, { lastUpdatedAt: new Date().toISOString() });
-      } else if (result.isStuck) {
-        logger.error(
-          `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과 — ${result.reason}`
-        );
+    // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
+    this.stuckMonitor = new StuckJobMonitor({
+      store: this.store,
+      stuckTimeoutMs: this.stuckTimeoutMs,
+      stuckThresholds: this.stuckThresholds,
+      checkIntervalMs: STUCK_CHECK_INTERVAL_MS,
+      getRunningJobIds: () => this.running,
+      toJob: convertStoreJobToJob,
+      onStuckDetected: (jobId, reason) => {
         this.store.update(jobId, {
           status: "failure",
           completedAt: new Date().toISOString(),
-          error: result.reason,
+          error: reason,
         });
         this.stuckAborted.add(jobId);
         this.running.delete(jobId);
         setTimeout(() => this.processNext(), 0);
-      }
-      // result.reason === "임계값 이내": threshold not yet exceeded, no action needed
-    }
+      },
+    });
+    this.stuckMonitor.start();
   }
 
   /**
@@ -239,10 +201,7 @@ export class JobQueue {
    */
   shutdown(timeoutMs: number = 30000): Promise<void> {
     this.shuttingDown = true;
-    if (this.stuckChecker !== undefined) {
-      clearInterval(this.stuckChecker);
-      this.stuckChecker = undefined;
-    }
+    this.stuckMonitor.stop();
     if (this.running.size === 0) {
       return Promise.resolve();
     }

--- a/src/queue/job-queue.ts
+++ b/src/queue/job-queue.ts
@@ -8,6 +8,7 @@ import { ProjectErrorState, StuckThresholdConfig } from "../types/config.js";
 import { JobCleanupService } from "./job-cleanup.js";
 import { ProjectErrorTracker } from "./project-error-tracker.js";
 import { StuckJobMonitor } from "./stuck-monitor.js";
+import { JobLifecycle } from "./job-lifecycle.js";
 import type { TaskFactory } from "../tasks/task-factory.js";
 import type { AQMTask } from "../tasks/aqm-task.js";
 
@@ -108,6 +109,7 @@ export class JobQueue {
   private runningByRepo: Map<string, number> = new Map(); // repo -> count of running jobs
   private readonly errorTracker = new ProjectErrorTracker();
   private cleanupService: JobCleanupService;
+  private readonly lifecycle: JobLifecycle;
   private lastServedRepo: string | null = null; // round-robin: last repo that was served
   private taskFactory?: TaskFactory;
   private activeTasks: Map<string, AQMTask> = new Map(); // jobId -> AQMTask
@@ -161,6 +163,23 @@ export class JobQueue {
     // cleanupService는 process.cwd 기준으로 즉시 활성화된다 (테스트 환경 호환).
     // setDependencies가 호출되면 정확한 projectRoot/configProvider를 가진 새 인스턴스로 교체된다.
     this.cleanupService = new JobCleanupService(process.cwd());
+
+    // 잡 실행/결과 처리는 JobLifecycle에 위임 (Plan C #C10 Phase 2)
+    this.lifecycle = new JobLifecycle({
+      store: this.store,
+      handler: this.handler,
+      taskFactory: this.taskFactory,
+      errorTracker: this.errorTracker,
+      activeTasks: this.activeTasks,
+      stuckAborted: this.stuckAborted,
+      cancelled: this.cancelled,
+      onJobFinished: (jobId, repo) => {
+        this.running.delete(jobId);
+        this.removeJobFromRepo(jobId, repo);
+        // Process next in queue (defer via setImmediate to avoid deep call stacks)
+        setImmediate(() => this.processNext());
+      },
+    });
 
     // Stuck 잡 탐지는 StuckJobMonitor에 위임 (Plan C #C10)
     this.stuckMonitor = new StuckJobMonitor({
@@ -503,20 +522,6 @@ export class JobQueue {
   }
 
   /**
-   * Tracks a project failure and potentially pauses the project.
-   */
-  private trackProjectFailure(repo: string): void {
-    this.errorTracker.trackFailure(repo);
-  }
-
-  /**
-   * Tracks a project success and resets failure count.
-   */
-  private trackProjectSuccess(repo: string): void {
-    this.errorTracker.trackSuccess(repo);
-  }
-
-  /**
    * Gets the highest priority job from the pending queue and removes it.
    * Priority order: high (0) > normal (1) > low (2)
    * Within same priority: FIFO (earliest createdAt first)
@@ -721,7 +726,7 @@ export class JobQueue {
         logger.info(`Job started: ${jobId}`);
 
         // Run async - don't await, let it run in background
-        this.executeJob(convertStoreJobToJob(job)).catch((err: unknown) => {
+        this.lifecycle.execute(convertStoreJobToJob(job)).catch((err: unknown) => {
           logger.error(`Job ${jobId} unexpected error: ${getErrorMessage(err)}`);
         });
       }
@@ -740,84 +745,4 @@ export class JobQueue {
     }
   }
 
-  private async executeJob(job: Job): Promise<void> {
-    try {
-      // Check if already aborted before running handler
-      if (this.stuckAborted.has(job.id)) {
-        this.stuckAborted.delete(job.id);
-        return;
-      }
-
-      let result: { prUrl?: string; error?: string; diagnosis?: DiagnosisReport; userSummary?: UserSummary };
-
-      if (this.taskFactory) {
-        // TaskFactory 경로: AQMTask 생성 후 run() 호출
-        const task = this.taskFactory.createTask(job);
-        this.activeTasks.set(job.id, task);
-        try {
-          result = await (task as unknown as { run(): Promise<{ prUrl?: string; error?: string }> }).run();
-        } finally {
-          this.activeTasks.delete(job.id);
-        }
-      } else {
-        result = await this.handler(job);
-      }
-
-      // Re-check after handler completes — stuck checker may have fired during execution
-      const wasStuckAborted = this.stuckAborted.has(job.id);
-      if (wasStuckAborted) {
-        this.stuckAborted.delete(job.id);
-        logger.warn(`Job ${job.id} handler completed after stuck-abort — updating status but not tracking project metrics`);
-      }
-
-      if (this.cancelled.has(job.id)) {
-        this.cancelled.delete(job.id);
-        // Already marked cancelled
-      } else if (result.error) {
-        this.store.update(job.id, {
-          status: "failure",
-          completedAt: new Date().toISOString(),
-          error: result.error,
-          ...(result.diagnosis ? { diagnosis: result.diagnosis } : {}),
-          ...(result.userSummary ? { userSummary: result.userSummary } : {}),
-        });
-        // Don't track project failure if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectFailure(job.repo);
-        }
-      } else if (result.prUrl) {
-        this.store.update(job.id, {
-          status: "success",
-          completedAt: new Date().toISOString(),
-          prUrl: result.prUrl,
-        });
-        // Don't track project success if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectSuccess(job.repo);
-        }
-      } else {
-        this.store.update(job.id, {
-          status: "failure",
-          completedAt: new Date().toISOString(),
-          error: "Pipeline completed but no PR was created",
-        });
-        // Don't track project failure if it was stuck aborted
-        if (!wasStuckAborted) {
-          this.trackProjectFailure(job.repo);
-        }
-      }
-    } catch (error: unknown) {
-      this.store.update(job.id, {
-        status: "failure",
-        completedAt: new Date().toISOString(),
-        error: getErrorMessage(error),
-      });
-      this.trackProjectFailure(job.repo);
-    } finally {
-      this.running.delete(job.id);
-      this.removeJobFromRepo(job.id, job.repo);
-      // Process next in queue (defer via setImmediate to avoid deep call stacks)
-      setImmediate(() => this.processNext());
-    }
-  }
 }

--- a/src/queue/job-scheduler.ts
+++ b/src/queue/job-scheduler.ts
@@ -1,0 +1,333 @@
+import { getLogger } from "../utils/logger.js";
+import type { JobStore, Job as StoreJob } from "./job-store.js";
+import { isFailureJob, isCancelledJob } from "../types/pipeline.js";
+import type { ProjectErrorTracker } from "./project-error-tracker.js";
+import { areDependenciesMet } from "./dependency-resolver.js";
+
+const logger = getLogger();
+
+/**
+ * 잡 스케줄링 책임 (Plan C #C10 — Phase 3).
+ *
+ * 이전: `JobQueue`가 pending/running/processingJobs/runningByRepo/lastServedRepo,
+ *      그리고 round-robin + 우선순위 + dependency/project concurrency/pause 가드
+ *      로직을 모두 보관했다.
+ * 이후: 본 클래스가 큐 상태와 스케줄링 알고리즘을 응집한다. JobQueue는
+ *      `onStartJob` 콜백을 통해 실제 잡 실행(`JobLifecycle`)으로 위임한다.
+ *
+ * cancelledRef는 `JobQueue.cancel()`이 set하고 scheduler가 processNext에서
+ * 한 번 소비하는 공유 set이다. lifecycle은 별도 cancelled set을 본다 (이중 클리어 안전).
+ */
+export interface JobSchedulerOptions {
+  store: JobStore;
+  errorTracker: ProjectErrorTracker;
+  concurrency: number;
+  projectConcurrency?: Record<string, number>;
+  /** scheduler가 잡을 시작하기로 결정했을 때 호출. JobQueue가 lifecycle.execute로 위임. */
+  onStartJob: (job: StoreJob) => void;
+  /** JobQueue.cancel()과 공유되는 cancel 플래그. processNext에서 소비. */
+  cancelledRef: Set<string>;
+}
+
+export class JobScheduler {
+  private readonly pending: string[] = [];
+  private readonly running: Set<string> = new Set();
+  private readonly processingJobs: Set<string> = new Set();
+  private readonly projectConcurrency: Map<string, number> = new Map();
+  private readonly runningByRepo: Map<string, number> = new Map();
+  private lastServedRepo: string | null = null;
+  private concurrency: number;
+  private isProcessing: boolean = false;
+  private needsReprocess: boolean = false;
+
+  constructor(private readonly opts: JobSchedulerOptions) {
+    this.concurrency = opts.concurrency;
+    if (opts.projectConcurrency) {
+      Object.entries(opts.projectConcurrency).forEach(([repo, limit]) => {
+        this.projectConcurrency.set(repo, limit);
+      });
+    }
+  }
+
+  // ─── queries ───────────────────────────────────────────────
+
+  get runningCount(): number {
+    return this.running.size;
+  }
+
+  isRunning(jobId: string): boolean {
+    return this.running.has(jobId);
+  }
+
+  /** stuck monitor가 매 체크마다 호출. 직접 set을 노출해 추가 복사를 피한다. */
+  getRunningIds(): Iterable<string> {
+    return this.running;
+  }
+
+  getStatus(): { pending: number; running: number; concurrency: number } {
+    return {
+      pending: this.pending.length + this.processingJobs.size,
+      running: this.running.size,
+      concurrency: this.concurrency,
+    };
+  }
+
+  // ─── pending/queue mutations ───────────────────────────────
+
+  /** 새 잡 진입. 즉시 processNext 호출. */
+  enqueue(jobId: string): void {
+    this.pending.push(jobId);
+    void this.processNext();
+  }
+
+  /** 재시작 복구용 — pending에 push만 하고 processNext는 caller가 결정. */
+  pushPending(jobId: string): void {
+    this.pending.push(jobId);
+  }
+
+  /** pending 큐에서 제거. cancel 처리에서 사용. */
+  removePending(jobId: string): boolean {
+    const idx = this.pending.indexOf(jobId);
+    if (idx >= 0) {
+      this.pending.splice(idx, 1);
+      return true;
+    }
+    return false;
+  }
+
+  // ─── concurrency knobs ─────────────────────────────────────
+
+  setConcurrency(n: number): void {
+    if (n <= 0 || !Number.isInteger(n)) {
+      throw new Error("Concurrency must be a positive integer");
+    }
+    this.concurrency = n;
+    logger.info(`Concurrency updated to ${n}`);
+    void this.processNext();
+    if (this.isProcessing && !this.needsReprocess) {
+      this.needsReprocess = true;
+    }
+  }
+
+  setProjectConcurrency(repo: string, limit: number | null): void {
+    if (limit !== null && (limit <= 0 || !Number.isInteger(limit))) {
+      throw new Error("Project concurrency limit must be a positive integer");
+    }
+    if (limit === null) {
+      this.projectConcurrency.delete(repo);
+      logger.info(`Project concurrency limit removed for ${repo}`);
+    } else {
+      this.projectConcurrency.set(repo, limit);
+      logger.info(`Project concurrency limit for ${repo} set to ${limit}`);
+    }
+    void this.processNext();
+  }
+
+  // ─── lifecycle hooks ───────────────────────────────────────
+
+  /** lifecycle 종료 시 호출 — running/runningByRepo 정리 + 다음 잡 처리. */
+  markJobFinished(jobId: string, repo: string): void {
+    this.running.delete(jobId);
+    this.removeJobFromRepo(repo);
+    setImmediate(() => this.processNext());
+  }
+
+  /**
+   * stuck-aborted 처리: running에서 즉시 제거 + 다음 처리 트리거.
+   * runningByRepo는 lifecycle finally의 markJobFinished가 처리하므로 여기서 건드리지 않는다
+   * (handler가 stuck 후에도 어쨌든 끝나면 lifecycle이 onJobFinished로 들어옴).
+   */
+  markStuckAborted(jobId: string): void {
+    this.running.delete(jobId);
+    setTimeout(() => this.processNext(), 0);
+  }
+
+  // ─── core scheduling ───────────────────────────────────────
+
+  async processNext(): Promise<void> {
+    if (this.opts.store.isClosed) return;
+
+    if (this.isProcessing) {
+      this.needsReprocess = true;
+      return;
+    }
+    this.isProcessing = true;
+    this.needsReprocess = false;
+
+    try {
+      const deferred: string[] = [];
+
+      while (this.running.size < this.concurrency && this.pending.length > 0) {
+        const jobId = this.getNextRoundRobinJob();
+        if (!jobId) break;
+
+        this.processingJobs.add(jobId);
+
+        if (this.opts.cancelledRef.has(jobId)) {
+          this.opts.cancelledRef.delete(jobId);
+          this.processingJobs.delete(jobId);
+          continue;
+        }
+
+        const job = this.opts.store.get(jobId);
+        if (!job) {
+          this.processingJobs.delete(jobId);
+          continue;
+        }
+
+        if (job.dependencies && job.dependencies.length > 0) {
+          const { met, pending } = areDependenciesMet(job.dependencies, job.repo, this.opts.store);
+          if (!met) {
+            let depFailed = false;
+            for (const depNum of job.dependencies) {
+              const depJob = this.opts.store.findAnyByIssue(depNum, job.repo);
+              if (depJob && (isFailureJob(depJob) || isCancelledJob(depJob))) {
+                logger.error(`Job ${jobId} dependency #${depNum} failed — failing dependent job`);
+                this.opts.store.update(jobId, {
+                  status: "failure",
+                  completedAt: new Date().toISOString(),
+                  error: `의존 이슈 #${depNum}이(가) 실패하여 실행 불가`,
+                });
+                depFailed = true;
+                break;
+              }
+            }
+            if (!depFailed) {
+              logger.info(`Job ${jobId} waiting for dependencies: #${pending.join(", #")}`);
+              this.processingJobs.delete(jobId);
+              deferred.push(jobId);
+            } else {
+              this.processingJobs.delete(jobId);
+            }
+            continue;
+          }
+        }
+
+        if (!this.canStartJobForRepo(job.repo)) {
+          logger.info(`Job ${jobId} deferred due to project concurrency limit for repo ${job.repo}`);
+          this.processingJobs.delete(jobId);
+          deferred.push(jobId);
+          continue;
+        }
+
+        if (this.opts.errorTracker.isProjectPaused(job.repo)) {
+          const errorState = this.opts.errorTracker.getProjectStatus(job.repo);
+          const remainingMs = errorState!.pausedUntil! - Date.now();
+          logger.info(`Job ${jobId} deferred due to project pause (${job.repo}). Resume in ${Math.round(remainingMs / 1000)}s`);
+          this.processingJobs.delete(jobId);
+          deferred.push(jobId);
+          continue;
+        }
+
+        this.running.add(jobId);
+        this.addJobToRepo(job.repo);
+        this.processingJobs.delete(jobId);
+        this.opts.store.update(jobId, { status: "running", startedAt: new Date().toISOString() });
+        logger.info(`Job started: ${jobId}`);
+        this.opts.onStartJob(job);
+      }
+
+      for (const jobId of deferred) {
+        this.pending.push(jobId);
+      }
+    } finally {
+      this.isProcessing = false;
+      if (this.needsReprocess) {
+        setImmediate(() => this.processNext());
+      }
+    }
+  }
+
+  // ─── private helpers ───────────────────────────────────────
+
+  private canStartJobForRepo(repo: string): boolean {
+    const projectLimit = this.projectConcurrency.get(repo);
+    if (!projectLimit) return true;
+    const currentRunning = this.runningByRepo.get(repo) ?? 0;
+    return currentRunning < projectLimit;
+  }
+
+  private addJobToRepo(repo: string): void {
+    this.runningByRepo.set(repo, (this.runningByRepo.get(repo) ?? 0) + 1);
+  }
+
+  private removeJobFromRepo(repo: string): void {
+    const current = this.runningByRepo.get(repo) ?? 0;
+    if (current > 1) {
+      this.runningByRepo.set(repo, current - 1);
+    } else {
+      this.runningByRepo.delete(repo);
+    }
+  }
+
+  /**
+   * Round-robin: 마지막에 서빙한 repo 다음부터 순환하며, 각 repo 내에서는
+   * priority(high>normal>low) → createdAt(FIFO) 순으로 선택한다.
+   */
+  private getNextRoundRobinJob(): string | null {
+    if (this.pending.length === 0) return null;
+
+    const repoOrder: string[] = [];
+    const jobsByRepo = new Map<string, string[]>();
+    for (const jobId of this.pending) {
+      const job = this.opts.store.get(jobId);
+      if (!job) continue;
+      if (!jobsByRepo.has(job.repo)) {
+        repoOrder.push(job.repo);
+        jobsByRepo.set(job.repo, []);
+      }
+      jobsByRepo.get(job.repo)!.push(jobId);
+    }
+
+    if (repoOrder.length === 0) return null;
+
+    let startIndex = 0;
+    if (this.lastServedRepo !== null) {
+      const lastIdx = repoOrder.indexOf(this.lastServedRepo);
+      if (lastIdx >= 0) {
+        startIndex = (lastIdx + 1) % repoOrder.length;
+      }
+    }
+
+    for (let i = 0; i < repoOrder.length; i++) {
+      const repo = repoOrder[(startIndex + i) % repoOrder.length];
+      const repoJobs = jobsByRepo.get(repo);
+      if (!repoJobs || repoJobs.length === 0) continue;
+
+      let bestIndex = -1;
+      let bestPriorityValue = 3;
+      let bestCreatedAt = "";
+
+      for (let j = 0; j < repoJobs.length; j++) {
+        const jobId = repoJobs[j];
+        const job = this.opts.store.get(jobId);
+        if (!job) continue;
+
+        const priority = job.priority ?? "normal";
+        const priorityValue = priority === "high" ? 0 : priority === "normal" ? 1 : 2;
+
+        if (
+          bestIndex === -1 ||
+          priorityValue < bestPriorityValue ||
+          (priorityValue === bestPriorityValue && job.createdAt < bestCreatedAt)
+        ) {
+          bestIndex = j;
+          bestPriorityValue = priorityValue;
+          bestCreatedAt = job.createdAt;
+        }
+      }
+
+      if (bestIndex >= 0) {
+        const selectedJobId = repoJobs[bestIndex];
+        const pendingIdx = this.pending.indexOf(selectedJobId);
+        if (pendingIdx >= 0) {
+          this.pending.splice(pendingIdx, 1);
+        }
+        this.lastServedRepo = repo;
+        return selectedJobId;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/queue/project-error-tracker.ts
+++ b/src/queue/project-error-tracker.ts
@@ -1,0 +1,153 @@
+import { getLogger } from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+import type { ProjectErrorState } from "../types/config.js";
+
+const logger = getLogger();
+
+const DEFAULT_PAUSE_THRESHOLD = 3;
+const DEFAULT_PAUSE_DURATION_MS = 30 * 60 * 1000; // 30분
+
+/**
+ * 프로젝트별 연속 실패를 추적하고, 임계값 초과 시 일시 정지(pause)를 적용한다.
+ *
+ * Plan C #C6에서 `JobQueue` module-level `projectErrorState` Map과 4개 메서드
+ * (isProjectPaused/pauseProject/resumeProject/getProjectStatus + private trackProjectFailure/Success)를
+ * 단일 클래스로 응집. ConfigProvider를 명시적으로 주입받아 `process.cwd()` 의존을 제거한다.
+ */
+export class ProjectErrorTracker {
+  private readonly state = new Map<string, ProjectErrorState>();
+  private configProvider?: ConfigProvider;
+
+  /**
+   * @param configProvider 프로젝트별 pause threshold/duration을 읽기 위한 의존성.
+   *                       미주입 시(테스트 환경 등) 기본값(threshold 3, duration 30분)을 사용한다.
+   *                       지연 주입은 `setConfigProvider`로 가능.
+   */
+  constructor(configProvider?: ConfigProvider) {
+    this.configProvider = configProvider;
+  }
+
+  /**
+   * 런타임 시점에 ConfigProvider를 주입한다. JobQueue가 post-construction
+   * setDependencies로 의존성을 주입하는 패턴을 지원한다.
+   */
+  setConfigProvider(provider: ConfigProvider): void {
+    this.configProvider = provider;
+  }
+
+  /**
+   * 프로젝트가 현재 일시 정지 상태인지 확인. 만료된 정지는 자동 해제한다.
+   */
+  isProjectPaused(repo: string): boolean {
+    const errorState = this.state.get(repo);
+    if (!errorState || !errorState.pausedUntil) {
+      return false;
+    }
+
+    if (Date.now() >= errorState.pausedUntil) {
+      this.resumeProject(repo);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 명시적으로 프로젝트를 일시 정지한다. 연속 실패 카운터에는 영향 없다.
+   */
+  pauseProject(repo: string, durationMs: number): void {
+    const errorState = this.state.get(repo) || this.createEmptyState();
+    errorState.pausedUntil = Date.now() + durationMs;
+    this.state.set(repo, errorState);
+    logger.warn(
+      `Project ${repo} manually paused for ${Math.round(durationMs / 1000)}s`
+    );
+  }
+
+  /**
+   * 일시 정지를 해제한다. 카운터는 유지되며 trackSuccess로 별도 리셋한다.
+   */
+  resumeProject(repo: string): void {
+    const errorState = this.state.get(repo);
+    if (errorState) {
+      errorState.pausedUntil = null;
+      this.state.set(repo, errorState);
+      logger.info(`Project ${repo} resumed`);
+    }
+  }
+
+  getProjectStatus(repo: string): ProjectErrorState | null {
+    return this.state.get(repo) || null;
+  }
+
+  /**
+   * 실패를 기록한다. 임계값 도달 시 자동으로 pause를 적용한다.
+   * pauseThreshold/pauseDurationMs는 config의 프로젝트 설정에서 가져온다.
+   */
+  trackFailure(repo: string): void {
+    let project: { pauseThreshold?: number; pauseDurationMs?: number } | undefined;
+    if (this.configProvider) {
+      try {
+        const config = this.configProvider.current();
+        project = config?.projects?.find(p => p.repo === repo);
+      } catch (error: unknown) {
+        // config 로딩 실패 시(테스트 환경 등) 기본값으로 진행
+        logger.debug(
+          `Failed to load config for project failure tracking: ${getErrorMessage(error)}`
+        );
+      }
+    }
+
+    const pauseThreshold = project?.pauseThreshold || DEFAULT_PAUSE_THRESHOLD;
+    const pauseDurationMs = project?.pauseDurationMs || DEFAULT_PAUSE_DURATION_MS;
+
+    const errorState = this.state.get(repo) || this.createEmptyState();
+    errorState.consecutiveFailures++;
+    errorState.lastFailureAt = Date.now();
+
+    if (errorState.consecutiveFailures >= pauseThreshold) {
+      errorState.pausedUntil = Date.now() + pauseDurationMs;
+      logger.error(
+        `Project ${repo} paused for ${Math.round(pauseDurationMs / 60000)}min after ${errorState.consecutiveFailures} consecutive failures`
+      );
+    } else {
+      logger.warn(
+        `Project ${repo} failure count: ${errorState.consecutiveFailures}/${pauseThreshold}`
+      );
+    }
+
+    this.state.set(repo, errorState);
+  }
+
+  /**
+   * 성공을 기록한다. 연속 실패 카운터를 리셋하며, 수동 pausedUntil은 유지한다.
+   */
+  trackSuccess(repo: string): void {
+    const errorState = this.state.get(repo);
+    if (errorState && errorState.consecutiveFailures > 0) {
+      logger.info(
+        `Project ${repo} success - resetting failure count (was ${errorState.consecutiveFailures})`
+      );
+      errorState.consecutiveFailures = 0;
+      errorState.lastFailureAt = null;
+      // pausedUntil은 그대로 두어 수동 pauseProject 효과를 보존
+      this.state.set(repo, errorState);
+    }
+  }
+
+  /**
+   * 모든 프로젝트 상태를 비운다. 데몬 재시작 시 사용.
+   */
+  clear(): void {
+    this.state.clear();
+  }
+
+  private createEmptyState(): ProjectErrorState {
+    return {
+      consecutiveFailures: 0,
+      pausedUntil: null,
+      lastFailureAt: null,
+    };
+  }
+}

--- a/src/queue/stuck-monitor.ts
+++ b/src/queue/stuck-monitor.ts
@@ -1,0 +1,109 @@
+import type { JobStore } from "./job-store.js";
+import type { StuckThresholdConfig } from "../types/config.js";
+import { isClaudeProcessAlive, getLastActivityMs } from "../claude/claude-runner.js";
+import { checkJobStuck } from "./stuck-detector.js";
+import { Job } from "../types/pipeline.js";
+import { getLogger } from "../utils/logger.js";
+
+const logger = getLogger();
+
+/**
+ * 주기적으로 stuck 잡을 탐지해 콜백을 호출한다 (Plan C #C10 — Phase 1).
+ *
+ * 이전: `JobQueue.checkStuckJobs` private 메서드. running Set / stuckAborted Set /
+ *      store / processNext에 깊이 얽혀 있었다.
+ * 이후: 본 모니터가 store + 외부 콜백 두 가지 의존성만 갖고, JobQueue는 콜백에서
+ *      자체 상태(running/stuckAborted)를 mutate한다.
+ */
+export interface StuckJobMonitorOptions {
+  store: JobStore;
+  stuckTimeoutMs: number;
+  stuckThresholds?: StuckThresholdConfig;
+  /** 현재 실행 중인 잡 ID iterable. 매 체크마다 호출되어 최신 상태를 가져온다. */
+  getRunningJobIds: () => Iterable<string>;
+  /** StoreJob → Job 변환기. JobQueue 내부 변환 헬퍼를 그대로 주입. */
+  toJob: (storeJob: import("./job-store.js").Job) => Job;
+  /** stuck으로 판정됐을 때 호출. JobQueue에서 store update + running 제거 + processNext schedule을 처리한다. */
+  onStuckDetected: (jobId: string, reason: string) => void;
+  /** 체크 주기. 기본 60초. */
+  checkIntervalMs?: number;
+}
+
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 1000;
+const DEFAULT_ACTIVITY_THRESHOLD_MS = 5 * 60 * 1000;
+
+export class StuckJobMonitor {
+  private interval?: ReturnType<typeof setInterval>;
+
+  constructor(private readonly opts: StuckJobMonitorOptions) {}
+
+  start(): void {
+    this.stop();
+    this.interval = setInterval(
+      () => this.checkStuckJobs(),
+      this.opts.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS
+    );
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+  }
+
+  /**
+   * 외부에서 명시적으로 한 차례 stuck 점검을 트리거한다 (테스트/긴급 점검).
+   */
+  runOnce(): void {
+    this.checkStuckJobs();
+  }
+
+  private checkStuckJobs(): void {
+    const thresholds: StuckThresholdConfig = this.opts.stuckThresholds ?? {
+      defaultMs: this.opts.stuckTimeoutMs,
+      planGenerationMs: this.opts.stuckTimeoutMs,
+      implementationMs: this.opts.stuckTimeoutMs,
+      reviewMs: this.opts.stuckTimeoutMs,
+      verificationMs: this.opts.stuckTimeoutMs,
+      publishMs: this.opts.stuckTimeoutMs,
+      activityThresholdMs: DEFAULT_ACTIVITY_THRESHOLD_MS,
+    };
+
+    const processAlive = isClaudeProcessAlive();
+    const lastActivityMs = getLastActivityMs();
+
+    for (const jobId of this.opts.getRunningJobIds()) {
+      const storeJob = this.opts.store.get(jobId);
+      if (!storeJob) continue;
+
+      const job = this.opts.toJob(storeJob);
+      const result = checkJobStuck(job, thresholds, { processAlive, lastActivityMs });
+
+      logger.debug(
+        `StuckCheck job=${jobId} step=${job.currentStep ?? "-"} category=${result.category} ` +
+        `elapsed=${result.elapsedMs}ms threshold=${result.thresholdMs}ms isStuck=${result.isStuck} reason=${result.reason}`
+      );
+
+      if (!result.isStuck && result.reason !== "임계값 이내") {
+        // 임계값은 초과했지만 아직 진행 중 — lastUpdatedAt 갱신으로 대기 연장
+        if (result.reason.startsWith("Claude 활동 중")) {
+          logger.info(
+            `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과, ${result.reason} — 대기 연장`
+          );
+        } else {
+          logger.debug(
+            `Job ${jobId} (${result.category}): ${result.reason} — 대기 연장`
+          );
+        }
+        this.opts.store.update(jobId, { lastUpdatedAt: new Date().toISOString() });
+      } else if (result.isStuck) {
+        logger.error(
+          `Job ${jobId} (${result.category}): ${Math.round(result.elapsedMs / 60000)}분 경과 — ${result.reason}`
+        );
+        this.opts.onStuckDetected(jobId, result.reason);
+      }
+      // result.reason === "임계값 이내": 임계값 미달, 액션 없음
+    }
+  }
+}

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -13,8 +13,6 @@ import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
 import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { runAllChecks } from "../doctor/checks.js";
-import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
 import { runCli } from "../utils/cli-runner.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
@@ -32,6 +30,7 @@ import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
+import { registerDoctorRoutes } from "./routes/doctor.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -974,82 +973,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  api.get("/api/doctor/run", async (c) => {
-    try {
-      const checks = await runAllChecks();
-      return c.json({ checks });
-    } catch (error: unknown) {
-      return c.json({ error: `Doctor run failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // POST /api/doctor/heal/stdin — stdin bridge for active Level2 process
-  // Declared before :id route so 'stdin' is not captured as checkId
-  api.post("/api/doctor/heal/stdin", async (c) => {
-    const body = await c.req.json().catch(() => null) as Record<string, unknown> | null;
-    const input = typeof body?.input === 'string' ? body.input : null;
-    if (input === null) {
-      return c.json({ error: "Missing 'input' field" }, 400);
-    }
-    const ok = writeToActiveHealProcess(input);
-    if (!ok) {
-      return c.json({ error: "No active heal process" }, 404);
-    }
-    return c.json({ ok: true });
-  });
-
-  // POST /api/doctor/heal/:id — Level1 auto-fix (runs autoFixCommand, waits for completion)
-  api.post("/api/doctor/heal/:id", async (c) => {
-    const checkId = c.req.param("id");
-    try {
-      const result = await healLevel1(checkId);
-      return c.json({ ok: true, stdout: result.stdout, stderr: result.stderr });
-    } catch (error: unknown) {
-      return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
-    }
-  });
-
-  // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
-  api.get("/api/doctor/heal/:id/stream", (c) => {
-    const checkId = c.req.param("id");
-    const encoder = new TextEncoder();
-
-    const stream = new ReadableStream({
-      start(controller) {
-        healLevel2(checkId, {
-          onData(chunk) {
-            try {
-              for (const line of chunk.split('\n')) {
-                if (line.length > 0) {
-                  controller.enqueue(encoder.encode(`data: ${line}\n\n`));
-                }
-              }
-            } catch { /* stream closed */ }
-          },
-          onDone() {
-            try {
-              controller.enqueue(encoder.encode(`event: done\ndata: \n\n`));
-              controller.close();
-            } catch { /* already closed */ }
-          },
-          onFail(msg) {
-            try {
-              controller.enqueue(encoder.encode(`event: fail\ndata: ${msg}\n\n`));
-              controller.close();
-            } catch { /* already closed */ }
-          },
-        });
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
+  // Doctor: 도메인 라우트 분할 (Plan C #C9)
+  registerDoctorRoutes(api);
 
   // Notifications: 도메인 라우트 분할 (Plan C #C9)
   registerNotificationsRoutes(api, { store, sseManager, readOnly: !!readOnly });

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -7,15 +7,12 @@ import { resolve, join } from "path";
 import { homedir } from "os";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
-import { loadConfig, updateConfigSection } from "../config/loader.js";
-import { maskSensitiveConfig } from "../utils/config-masker.js";
-import { getBasicFieldMetas } from "../config/schema-meta.js";
-import { getPresets } from "../config/presets.js";
+import { loadConfig } from "../config/loader.js";
 import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { UpdateConfigRequestSchema, GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runAllChecks } from "../doctor/checks.js";
@@ -35,6 +32,7 @@ import { registerVersionRoutes } from "./routes/version.js";
 import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
+import { registerConfigRoutes } from "./routes/config.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -520,85 +518,10 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   }
 
-  // Get configuration (masked for security)
-  api.get("/api/config", (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const maskedConfig = maskSensitiveConfig(config);
-      return c.json({ config: maskedConfig });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to load configuration: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Get Basic tab field metadata (type, default, min/max, options)
-  api.get("/api/config/schema-meta", (c) => {
-    return c.json({ fields: getBasicFieldMetas() });
-  });
-
-  // Get config presets list
-  api.get("/api/config/presets", (c) => {
-    return c.json({ presets: getPresets() });
-  });
-
   const configPath = `${rootDir}/config.yml`;
 
-  // Update configuration
-  api.put("/api/config", zValidator('json', UpdateConfigRequestSchema.passthrough(), zodValidationHook), async (c) => {
-    try {
-      const body = c.req.valid('json');
-
-      // Update configuration file
-      // Filter out undefined values and complex sections (projects)
-      // hooks is passed through via the passthrough schema and saved to config
-      const { projects, ...safeData } = body as Record<string, unknown>;
-      const cleanedData = Object.fromEntries(
-        Object.entries(safeData).map(([key, value]) => [
-          key,
-          typeof value === 'object' && value !== null
-            ? Object.fromEntries(Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined))
-            : value
-        ]).filter(([, v]) => v !== undefined)
-      ) as Partial<AQConfig>;
-
-      updateConfigSection(rootDir, cleanedData);
-      configWatcher?.refresh();
-
-      // Apply runtime changes if configWatcher is available
-      if (configWatcher) {
-        try {
-          // Load updated config for runtime application
-          const newConfig = configWatcher.current();
-
-          // Apply runtime changes immediately (force update)
-          if (body.general?.concurrency !== undefined) {
-            queue.setConcurrency(newConfig.general.concurrency);
-          }
-          if (body.general?.logLevel !== undefined) {
-            setGlobalLogLevel(newConfig.general.logLevel);
-          }
-
-          // Broadcast config change to SSE clients
-          broadcastToAllClients('configChanged', {
-            changes: body,
-            timestamp: new Date().toISOString()
-          });
-        } catch (runtimeError: unknown) {
-          // Log runtime application error but don't fail the request
-          const logger = getLogger();
-          logger.warn(`Failed to apply runtime config changes: ${getErrorMessage(runtimeError)}`);
-        }
-      }
-
-      return c.json({ success: true, message: "Configuration updated successfully" });
-    } catch (error: unknown) {
-      const rawMessage = getErrorMessage(error);
-      const isValidationError = rawMessage.includes("validation") || rawMessage.includes("Invalid") || rawMessage.includes("not found");
-      const status = isValidationError ? 400 : 500;
-      const prefix = isValidationError ? "Configuration validation failed" : "Failed to update configuration";
-      return c.json({ error: `${prefix}: ${sanitizeErrorMessage(rawMessage)}` }, status);
-    }
-  });
+  // Config: 도메인 라우트 분할 (Plan C #C9)
+  registerConfigRoutes(api, { queue, sseManager, configWatcher, rootDir });
 
   // Projects: 도메인 라우트 분할 (Plan C #C9)
   registerProjectsRoutes(api, { queue, configWatcher, rootDir, configPath });

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -181,7 +181,33 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
  * browser EventSource API, so they accept a short-lived session token via ?token=<token>.
  * Obtain a session token from POST /api/auth with the Bearer key.
  */
-export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWatcher?: ConfigWatcher, apiKey?: string, hostname?: string, dashboardAuth?: DashboardAuthConfig, readOnly?: boolean, patternStore?: PatternStore, aqRoot?: string): Hono {
+/**
+ * createDashboardRoutes 옵션 (Plan C #C12).
+ *
+ * 이전: 9개 positional 파라미터 (#808 사고처럼 위치 충돌 위험). cli.ts 1곳에서만 호출.
+ * 이후: 단일 객체 — 누락 시 컴파일 에러로 잡히고, 새 필드 추가 시 기존 호출 깨지지 않는다.
+ */
+export interface DashboardRoutesOptions {
+  store: JobStore;
+  queue: JobQueue;
+  /**
+   * AQM 설치 루트(=AQM_HOME 또는 ~/.ai-quartermaster) — 라우트 핸들러가 데이터/로그 경로 조립에 사용.
+   * 미지정 시 process.cwd() (테스트 호환). 프로덕션 진입(cli.ts)에서는 항상 명시 전달.
+   */
+  aqRoot?: string;
+  configWatcher?: ConfigWatcher;
+  patternStore?: PatternStore;
+  /** 설정 시 Bearer 인증 활성화. 미설정 시 hostname + readOnly에 따라 무인증 모드. */
+  apiKey?: string;
+  /** 서버 바인드 호스트 — 무인증+비-로컬 바인드 시 보안 경고 출력에 사용. */
+  hostname?: string;
+  dashboardAuth?: DashboardAuthConfig;
+  /** insecure 환경에서 mutation 차단용 플래그. */
+  readOnly?: boolean;
+}
+
+export function createDashboardRoutes(opts: DashboardRoutesOptions): Hono {
+  const { store, queue, configWatcher, apiKey, hostname, dashboardAuth, readOnly, patternStore, aqRoot } = opts;
   const rootDir = aqRoot ?? process.cwd();
   const api = new Hono();
 

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -36,6 +36,7 @@ import { z } from "zod";
 import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
+import { registerNotificationsRoutes } from "./routes/notifications.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -1969,151 +1970,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     });
   });
 
-  // Notifications: unread count
-  api.get("/api/notifications/unread-count", (c) => {
-    try {
-      const unreadCount = store.getAqDb().countUnreadNotifications();
-      return c.json({ unreadCount });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch unread count: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: list with pagination
-  api.get("/api/notifications", (c) => {
-    try {
-      const queryParams = {
-        isRead: c.req.query("isRead"),
-        type: c.req.query("type"),
-        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
-        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
-      };
-
-      const parseResult = GetNotificationsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const { isRead, type: typeFilter, limit, offset } = parseResult.data;
-      const aqDb = store.getAqDb();
-      const isReadFilter = isRead === "true" ? true : isRead === "false" ? false : undefined;
-      const notifFilter: { isRead?: boolean; type?: string } = {};
-      if (isReadFilter !== undefined) notifFilter.isRead = isReadFilter;
-      if (typeFilter !== undefined) notifFilter.type = typeFilter;
-      const notifications = aqDb.listNotifications({ ...notifFilter, limit, offset });
-      const total = aqDb.countNotifications(notifFilter);
-      const unreadCount = aqDb.countUnreadNotifications();
-      const start = offset ?? 0;
-
-      return c.json({
-        notifications,
-        total,
-        unreadCount,
-        pagination: {
-          total,
-          offset: start,
-          limit: limit ?? total,
-          hasMore: start + notifications.length < total,
-        },
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: mark all as read (static route before :id/read)
-  api.post("/api/notifications/read-all", (c) => {
-    try {
-      const count = store.getAqDb().markAllNotificationsRead();
-      broadcastToAllClients("notificationsReadAll", { count, timestamp: Date.now() });
-      return c.json({ status: "ok", count });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to mark all notifications as read: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: mark individual as read
-  api.post("/api/notifications/:id/read", (c) => {
-    try {
-      const idParam = c.req.param("id");
-      const id = parseInt(idParam, 10);
-      if (isNaN(id) || id <= 0) {
-        return c.json({ error: "Invalid notification id" }, 400);
-      }
-      const updated = store.getAqDb().markNotificationRead(id);
-      if (!updated) {
-        return c.json({ error: "Notification not found" }, 404);
-      }
-      return c.json({ status: "ok", id });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to mark notification as read: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: prune read notifications older than maxAgeDays (default 14)
-  api.post("/api/notifications/prune", async (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      let maxAgeDays = 14;
-      try {
-        const body = await c.req.json<{ maxAgeDays?: unknown }>();
-        if (typeof body?.maxAgeDays === "number" && body.maxAgeDays > 0) {
-          maxAgeDays = Math.floor(body.maxAgeDays);
-        }
-      } catch {
-        // body 없음 → 기본값 14일
-      }
-      const deleted = store.pruneReadNotifications(maxAgeDays);
-      broadcastToAllClients("notificationsPruned", { deleted, maxAgeDays, timestamp: Date.now() });
-      return c.json({ deleted, maxAgeDays });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to prune notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: delete all (옵션으로 isRead 필터)
-  api.delete("/api/notifications", (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const isReadParam = c.req.query("isRead");
-      const filter: { isRead?: boolean } = {};
-      if (isReadParam === "true") filter.isRead = true;
-      else if (isReadParam === "false") filter.isRead = false;
-      const deleted = store.deleteAllNotifications(filter);
-      broadcastToAllClients("notificationsDeleted", { deleted, timestamp: Date.now() });
-      return c.json({ deleted });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete notifications: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Notifications: delete single
-  api.delete("/api/notifications/:id", (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const idParam = c.req.param("id");
-      const id = parseInt(idParam, 10);
-      if (isNaN(id) || id <= 0) {
-        return c.json({ error: "Invalid notification id" }, 400);
-      }
-      const deleted = store.deleteNotification(id);
-      if (!deleted) {
-        return c.json({ error: "Notification not found" }, 404);
-      }
-      return c.json({ status: "ok", id });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete notification: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Notifications: 도메인 라우트 분할 (Plan C #C9)
+  registerNotificationsRoutes(api, { store, sseManager, readOnly: !!readOnly });
 
   return api;
 }

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1372,7 +1372,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     if (job.status !== "failure" && job.status !== "cancelled") {
       return c.json({ error: "Only failed or cancelled jobs can be retried" }, 400);
     }
-    const newJob = queue.retryJob(id);
+    const newJob = await queue.retryJob(id);
     if (!newJob) {
       return c.json({ error: "Failed to retry job" }, 500);
     }

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -3,8 +3,7 @@ import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
-import { fileURLToPath } from "url";
-import { resolve, normalize, basename, join } from "path";
+import { resolve, normalize, join } from "path";
 import { homedir } from "os";
 import type { JobStore, Job, ListJobsOptions } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
@@ -14,14 +13,12 @@ import { maskSensitiveConfig } from "../utils/config-masker.js";
 import { getBasicFieldMetas } from "../config/schema-meta.js";
 import { getPresets } from "../config/presets.js";
 import type { ProjectConfig, AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
-import { checkClaudeQuota } from "../claude/quota-checker.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
 import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, UpdateJobPriorityRequestSchema, UpdateProjectRequestSchema, GetMetricsQuerySchema, CancelJobRequestSchema, RetryJobRequestSchema, GetNotificationsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { SelfUpdater } from "../update/self-updater.js";
 import { isPathSafe } from "../utils/slug.js";
 import { runAllChecks } from "../doctor/checks.js";
 import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
@@ -37,6 +34,7 @@ import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
+import { registerVersionRoutes } from "./routes/version.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -1331,132 +1329,15 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Start periodic cleanup when dashboard routes are created
   startPeriodicCleanup();
 
-  // Helper to read current version from package.json
-  // import.meta.url 기준으로 설치 루트를 도출한다.
-  // process.cwd()는 서버 실행 디렉토리일 뿐 AQM 설치 루트와 다를 수 있어
-  // "ENOENT: package.json" 에러 → 대시보드 버전 표시 unknown 원인이 된다.
-  const getCurrentVersion = (): string => {
-    // src/server/dashboard-api.ts (dev) 또는 dist/server/dashboard-api.js (build)
-    // 둘 다 루트에서 2단계 위 → ../../package.json로 동일하게 접근 가능
-    const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-    return packageJson.version;
-  };
-
-  // Get version information (current version + update check)
-  api.get("/api/version", async (c) => {
-    try {
-      const currentVersion = getCurrentVersion();
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
-
-      try {
-        const updateInfo = await selfUpdater.checkForUpdates();
-        return c.json({
-          currentVersion,
-          currentHash: updateInfo.currentHash.substring(0, 8),
-          remoteHash: updateInfo.remoteHash.substring(0, 8),
-          hasUpdates: updateInfo.hasUpdates,
-          packageLockChanged: updateInfo.packageLockChanged,
-        });
-      } catch (updateError: unknown) {
-        getLogger().warn(`업데이트 확인 실패: ${getErrorMessage(updateError)}`);
-        return c.json({
-          currentVersion,
-          currentHash: "unknown",
-          remoteHash: "unknown",
-          hasUpdates: false,
-          packageLockChanged: false,
-          error: "업데이트 확인에 실패했습니다",
-        });
-      }
-    } catch (error: unknown) {
-      return c.json({ error: `버전 정보 조회 실패: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Claude profile
-  api.get("/api/claude-profile", async (c) => {
-    const configDir = process.env.CLAUDE_CONFIG_DIR || "";
-    const profile = configDir ? basename(configDir).replace(/^\.claude-?/, "") || "default" : "default";
-    const config = configWatcher?.current() ?? loadConfig(rootDir);
-    const models = config.commands.claudeCli.models;
-
-    let cliVersion = "unknown";
-    try {
-      const result = await runCli(config.commands.claudeCli.path, ["--version"], { timeout: 5000 });
-      if (result.exitCode === 0) cliVersion = result.stdout.trim();
-    } catch { /* 비차단 버전 조회 — 실패 무시 */ }
-
-    return c.json({
-      profile,
-      configDir,
-      cliVersion,
-      model: config.commands.claudeCli.model,
-      models: {
-        plan: models?.plan,
-        phase: models?.phase,
-        review: models?.review,
-        fallback: models?.fallback,
-      },
-      maxTurns: config.commands.claudeCli.maxTurns,
-      timeout: config.commands.claudeCli.timeout,
-      quotaStatus: currentQuotaStatus,
-    });
-  });
-
-  // Refresh Claude quota status
-  api.post("/api/claude-profile/refresh", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const status = await checkClaudeQuota(config.commands.claudeCli);
-      currentQuotaStatus = status;
-      return c.json({ quotaStatus: status });
-    } catch (error: unknown) {
-      return c.json({ error: `quota 재검사 실패: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Perform self-update
-  api.post("/api/update", async (c) => {
-    try {
-      const activeJobs = store.list().filter(job => job.status === "running" || job.status === "queued");
-      if (activeJobs.length > 0) {
-        getLogger().info(`업데이트 전 진행 중인 잡 ${activeJobs.length}개 취소 중`);
-        for (const job of activeJobs) {
-          queue.cancel(job.id);
-          getLogger().info(`잡 취소: ${job.id} (이슈 #${job.issueNumber}, 상태: ${job.status})`);
-        }
-      }
-
-      const config = loadConfig(rootDir);
-      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
-      getLogger().info("사용자 요청으로 업데이트 시작");
-
-      const result = await selfUpdater.performSelfUpdate();
-      if (result.updated) {
-        broadcastToAllClients('updateCompleted', {
-          updated: result.updated,
-          needsRestart: result.needsRestart,
-          timestamp: new Date().toISOString()
-        });
-      }
-
-      return c.json({
-        message: result.updated ? "업데이트가 완료되었습니다" : "이미 최신 버전입니다",
-        updated: result.updated,
-        needsRestart: result.needsRestart,
-      });
-    } catch (error: unknown) {
-      const rawMessage = getErrorMessage(error);
-      getLogger().error(`업데이트 실패: ${rawMessage}`);
-      const message = sanitizeErrorMessage(rawMessage);
-      broadcastToAllClients('updateFailed', {
-        error: message,
-        timestamp: new Date().toISOString()
-      });
-      return c.json({ error: `업데이트 실패: ${message}` }, 500);
-    }
+  // Version/update/claude-profile: 도메인 라우트 분할 (Plan C #C9)
+  registerVersionRoutes(api, {
+    store,
+    queue,
+    sseManager,
+    configWatcher,
+    rootDir,
+    getQuotaStatus: () => currentQuotaStatus,
+    setQuotaStatus: (s) => { currentQuotaStatus = s; },
   });
 
   // Repositories API - project-level aggregated information with health and stats

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -10,14 +10,12 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
-import { getProjectSummary } from "../store/queries.js";
+import { GetSkipEventsQuerySchema, formatZodError } from "../types/api.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runCli } from "../utils/cli-runner.js";
 import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { statusToNotificationType } from "../types/pipeline.js";
-import { existsSync, statSync } from "fs";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
@@ -31,6 +29,7 @@ import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
 import { registerDoctorRoutes } from "./routes/doctor.js";
+import { registerHealthRoutes } from "./routes/health.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -131,100 +130,6 @@ export function zodValidationHook(
 }
 
 export { zValidator };
-
-/**
- * Health check helper functions
- */
-async function checkGitRemoteAccess(projectPath: string, gitPath: string): Promise<{ status: "ok" | "error"; message?: string }> {
-  try {
-    const result = await runCli(gitPath, ["ls-remote", "--heads", "origin"], { cwd: projectPath, timeout: 10000 });
-    if (result.exitCode !== 0) {
-      return {
-        status: "error",
-        message: `Git remote not accessible: ${result.stderr || "Cannot connect to remote"}`
-      };
-    }
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Git remote check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkLocalPath(projectPath: string): Promise<{ status: "ok" | "error"; message?: string }> {
-  try {
-    if (!existsSync(projectPath)) {
-      return { status: "error", message: "Project path does not exist" };
-    }
-
-    const stats = statSync(projectPath);
-    if (!stats.isDirectory()) {
-      return { status: "error", message: "Project path is not a directory" };
-    }
-
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Local path check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkDiskSpace(projectPath: string): Promise<{ status: "ok" | "warning" | "error"; message?: string; freeBytes?: number }> {
-  try {
-    const result = await runCli("df", ["-B1", projectPath], { timeout: 5000 });
-    if (result.exitCode !== 0) {
-      return { status: "warning", message: "Could not check disk space" };
-    }
-
-    const lines = result.stdout.trim().split('\n');
-    if (lines.length < 2) {
-      return { status: "warning", message: "Could not parse disk space output" };
-    }
-
-    const parts = lines[1].split(/\s+/);
-    const available = parseInt(parts[3] || "0", 10);
-
-    if (available === 0) {
-      return { status: "error", message: "No free disk space", freeBytes: available };
-    } else if (available < 1024 * 1024 * 1024) { // Less than 1GB
-      return { status: "warning", message: "Low disk space (< 1GB)", freeBytes: available };
-    }
-
-    return { status: "ok", freeBytes: available };
-  } catch (error: unknown) {
-    return {
-      status: "warning",
-      message: `Disk space check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
-
-async function checkDependencies(projectPath: string): Promise<{ status: "ok" | "warning" | "error"; message?: string }> {
-  try {
-    // Check if package.json exists
-    const packageJsonPath = resolve(projectPath, "package.json");
-    if (!existsSync(packageJsonPath)) {
-      return { status: "warning", message: "No package.json found" };
-    }
-
-    // Check if node_modules exists
-    const nodeModulesPath = resolve(projectPath, "node_modules");
-    if (!existsSync(nodeModulesPath)) {
-      return { status: "warning", message: "Dependencies not installed (no node_modules)" };
-    }
-
-    return { status: "ok" };
-  } catch (error: unknown) {
-    return {
-      status: "error",
-      message: `Dependencies check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`
-    };
-  }
-}
 
 /**
  * Applies runtime configuration changes to system components.
@@ -706,238 +611,11 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     setQuotaStatus: (s) => { currentQuotaStatus = s; },
   });
 
-  // Repositories API - project-level aggregated information with health and stats
-  api.get("/api/repositories", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projects = config.projects ?? [];
-
-      if (projects.length === 0) {
-        return c.json({
-          repositories: [],
-          summary: { total: 0, healthy: 0, warning: 0, error: 0, totalJobs: 0, checkedAt: new Date().toISOString() },
-        });
-      }
-
-      const gitPath = config.git?.gitPath ?? "git";
-
-      // Get health checks for all projects in parallel
-      const healthResults = await Promise.all(
-        projects.map(async (projectConfig) => {
-          const projectPath = resolve(rootDir, projectConfig.path);
-          const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck, worktreeCount] = await Promise.all([
-            checkGitRemoteAccess(projectPath, gitPath),
-            checkLocalPath(projectPath),
-            checkDiskSpace(projectPath),
-            checkDependencies(projectPath),
-            runCli(gitPath, ["worktree", "list", "--porcelain"], { cwd: projectPath }).then(result =>
-              result.exitCode === 0 ? result.stdout.trim().split('\n').filter(line => line.startsWith('worktree ')).length : 0
-            ).catch(() => 0), // Fall back to 0 if git worktree fails
-          ]);
-
-          let overallStatus: "healthy" | "warning" | "error" = "healthy";
-          if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-            overallStatus = "error";
-          } else if (
-            diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-            dependenciesCheck.status === "warning" || dependenciesCheck.status === "error"
-          ) {
-            overallStatus = "warning";
-          }
-
-          return {
-            repository: projectConfig.repo,
-            name: projectConfig.repo,
-            path: projectConfig.path,
-            status: overallStatus,
-            worktreeCount,
-            health: {
-              gitRemoteAccess: gitRemoteCheck,
-              localPath: localPathCheck,
-              diskSpace: diskSpaceCheck,
-              dependencies: dependenciesCheck,
-            },
-            lastChecked: new Date().toISOString(),
-          };
-        })
-      );
-
-      // Get project statistics
-      const projectStats = getProjectSummary(store.getAqDb());
-      const statsMap = new Map(projectStats.map(s => [s.repo, s]));
-
-      // Combine health results with statistics
-      const repositories = healthResults.map(result => {
-        const stats = statsMap.get(result.repository) ?? {
-          repo: result.repository,
-          total: 0,
-          successCount: 0,
-          failureCount: 0,
-          totalCostUsd: 0,
-          successRate: 0,
-          lastActivity: null,
-        };
-
-        return {
-          ...result,
-          stats: {
-            totalJobs: stats.total,
-            successJobs: stats.successCount,
-            failedJobs: stats.failureCount,
-            successRate: stats.successRate,
-            totalCostUsd: stats.totalCostUsd,
-            lastActivity: stats.lastActivity,
-          },
-        };
-      });
-
-      const summary = {
-        total: repositories.length,
-        healthy: repositories.filter(r => r.status === "healthy").length,
-        warning: repositories.filter(r => r.status === "warning").length,
-        error: repositories.filter(r => r.status === "error").length,
-        totalJobs: repositories.reduce((sum, r) => sum + r.stats.totalJobs, 0),
-        checkedAt: new Date().toISOString(),
-      };
-
-      return c.json({ repositories, summary });
-    } catch (error: unknown) {
-      const logger = getLogger();
-      logger.error(`Failed to fetch repositories: ${getErrorMessage(error)}`);
-      return c.json({ error: "Failed to fetch repositories" }, 500);
-    }
-  });
-
-  // Projects health check endpoint — all configured projects
-  api.get("/api/projects/health", async (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projects = config.projects ?? [];
-
-      if (projects.length === 0) {
-        return c.json({
-          projects: [],
-          summary: { total: 0, healthy: 0, warning: 0, error: 0, checkedAt: new Date().toISOString() },
-        });
-      }
-
-      const gitPath = config.git?.gitPath ?? "git";
-
-      const healthResults = await Promise.all(
-        projects.map(async (projectConfig) => {
-          const projectPath = resolve(rootDir, projectConfig.path);
-          const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
-            checkGitRemoteAccess(projectPath, gitPath),
-            checkLocalPath(projectPath),
-            checkDiskSpace(projectPath),
-            checkDependencies(projectPath),
-          ]);
-
-          let overallStatus: "healthy" | "warning" | "error" = "healthy";
-          if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-            overallStatus = "error";
-          } else if (
-            diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-            dependenciesCheck.status === "warning" || dependenciesCheck.status === "error"
-          ) {
-            overallStatus = "warning";
-          }
-
-          return {
-            project: projectConfig.repo,
-            status: overallStatus,
-            checks: {
-              gitRemoteAccess: gitRemoteCheck,
-              localPath: localPathCheck,
-              diskSpace: diskSpaceCheck,
-              dependencies: dependenciesCheck,
-            },
-            lastChecked: new Date().toISOString(),
-          };
-        })
-      );
-
-      const projectStats = getProjectSummary(store.getAqDb());
-      const statsMap = new Map(projectStats.map(s => [s.repo, s]));
-
-      const projectsWithStats = healthResults.map(result => ({
-        ...result,
-        stats: statsMap.get(result.project) ?? null,
-      }));
-
-      const summary = {
-        total: projectsWithStats.length,
-        healthy: projectsWithStats.filter(p => p.status === "healthy").length,
-        warning: projectsWithStats.filter(p => p.status === "warning").length,
-        error: projectsWithStats.filter(p => p.status === "error").length,
-        checkedAt: new Date().toISOString(),
-      };
-
-      return c.json({ projects: projectsWithStats, summary });
-    } catch (error: unknown) {
-      return c.json({ error: `Projects health check failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Health: 도메인 라우트 분할 (Plan C #C9) — repositories + projects/health + health
+  registerHealthRoutes(api, { store, configWatcher, rootDir });
 
   // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
   registerSetupRoutes(api, { rootDir });
-
-  // Health check endpoint
-  api.get("/api/health", async (c) => {
-    try {
-      const projectParam = c.req.query("project");
-      if (!projectParam) {
-        return c.json({ error: "project parameter is required" }, 400);
-      }
-
-      const project = decodeURIComponent(projectParam);
-
-      // Load configuration to get project path and git settings
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-      const projectConfig = config.projects?.find(p => p.repo === project);
-
-      if (!projectConfig) {
-        return c.json({ error: `Project "${project}" not found in configuration` }, 404);
-      }
-
-      const projectPath = resolve(rootDir, projectConfig.path);
-      const gitPath = config.git?.gitPath || "git";
-
-      // Run health checks in parallel
-      const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
-        checkGitRemoteAccess(projectPath, gitPath),
-        checkLocalPath(projectPath),
-        checkDiskSpace(projectPath),
-        checkDependencies(projectPath)
-      ]);
-
-      // Determine overall status
-      let overallStatus: "healthy" | "warning" | "error" = "healthy";
-
-      if (gitRemoteCheck.status === "error" || localPathCheck.status === "error") {
-        overallStatus = "error";
-      } else if (diskSpaceCheck.status === "warning" || diskSpaceCheck.status === "error" ||
-                 dependenciesCheck.status === "warning" || dependenciesCheck.status === "error") {
-        overallStatus = "warning";
-      }
-
-      const healthResponse: HealthCheckResponse = {
-        project,
-        status: overallStatus,
-        checks: {
-          gitRemoteAccess: gitRemoteCheck,
-          localPath: localPathCheck,
-          diskSpace: diskSpaceCheck,
-          dependencies: dependenciesCheck,
-        },
-        lastChecked: new Date().toISOString(),
-      };
-
-      return c.json(healthResponse);
-    } catch (error: unknown) {
-      return c.json({ error: `Health check failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
 
   // Create a new GitHub issue from dashboard
   api.post("/api/new-issue", zValidator('json', NewIssueRequestSchema, zodValidationHook), async (c) => {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -2,7 +2,6 @@ import { Hono, type Context, type Next } from "hono";
 import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
-import { resolve, join } from "path";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig } from "../config/loader.js";
@@ -10,16 +9,12 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { GetSkipEventsQuerySchema, formatZodError } from "../types/api.js";
+import { formatZodError } from "../types/api.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { runCli } from "../utils/cli-runner.js";
-import { getErrorMessage } from "../utils/error-utils.js";
-import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { statusToNotificationType } from "../types/pipeline.js";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
-import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
@@ -30,6 +25,8 @@ import { registerConfigRoutes } from "./routes/config.js";
 import { registerSetupRoutes } from "./routes/setup.js";
 import { registerDoctorRoutes } from "./routes/doctor.js";
 import { registerHealthRoutes } from "./routes/health.js";
+import { registerSkipEventsRoutes } from "./routes/skip-events.js";
+import { registerNewIssueRoute } from "./routes/new-issue.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -181,16 +178,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
 }
 
 const SSE_INITIAL_JOB_LIMIT = 20;
-
-const NewIssueRequestSchema = z.object({
-  category: z.enum(["bug", "feature", "refactor", "docs"]),
-  title: z.string().min(1),
-  repo: z.string().min(1),
-  what: z.string().min(1),
-  where: z.string().default(""),
-  how: z.string().default(""),
-  files: z.string().default(""),
-});
 
 /**
  * Returns jobs for SSE initial state:
@@ -391,104 +378,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // (logs/stream은 SSE이므로 별도 처리)
   registerJobsRoutes(api, { store, queue, sseManager });
 
-  // Skip events stats (reasonCode별 집계)
-  api.get("/api/skip-events/stats", (c) => {
-    try {
-      const repo = c.req.query("repo");
-      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
-
-      const reasonCodeCounts: Record<string, number> = {};
-      for (const event of allEvents) {
-        reasonCodeCounts[event.reasonCode] = (reasonCodeCounts[event.reasonCode] ?? 0) + 1;
-      }
-
-      const stats = Object.entries(reasonCodeCounts)
-        .map(([reasonCode, count]) => ({ reasonCode, count }))
-        .sort((a, b) => b.count - a.count);
-
-      return c.json({ total: allEvents.length, stats });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch skip event stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // List skip events (flat 또는 issueNumber+repo+reasonCode 그룹)
-  api.get("/api/skip-events", (c) => {
-    try {
-      const groupParam = c.req.query("group");
-      const queryParams = {
-        repo: c.req.query("repo"),
-        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
-        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
-        group: groupParam === "true" ? true : groupParam === "false" ? false : undefined,
-      };
-
-      const parseResult = GetSkipEventsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const { repo, limit, offset, group } = parseResult.data;
-
-      // 그룹 뷰: 동일 이슈+reasonCode 중복 축약 (기본 대시보드 뷰)
-      if (group) {
-        const { groups, totalGroups } = store.listSkipEventsGrouped({ repo, limit, offset });
-        const start = offset ?? 0;
-        const end = limit !== undefined ? start + groups.length : totalGroups;
-        return c.json({
-          groups,
-          pagination: {
-            total: totalGroups,
-            offset: start,
-            limit: limit ?? totalGroups,
-            hasMore: end < totalGroups,
-          }
-        });
-      }
-
-      // Flat 뷰 (기존 API 호환)
-      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
-      const total = allEvents.length;
-      const start = offset ?? 0;
-      const end = limit !== undefined ? start + limit : total;
-      const events = allEvents.slice(start, end);
-
-      return c.json({
-        events,
-        pagination: {
-          total,
-          offset: start,
-          limit: limit ?? total,
-          hasMore: end < total,
-        }
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch skip events: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // 특정 그룹(issueNumber+repo+reasonCode) 전체 삭제
-  api.delete("/api/skip-events/group", async (c) => {
-    if (readOnly) {
-      return c.json({ error: "Read-only mode" }, 403);
-    }
-    try {
-      const body = await c.req.json<{ issueNumber?: unknown; repo?: unknown; reasonCode?: unknown }>();
-      const issueNumber = typeof body.issueNumber === "number" ? body.issueNumber : Number(body.issueNumber);
-      const repoVal = typeof body.repo === "string" ? body.repo : "";
-      const reasonCode = typeof body.reasonCode === "string" ? body.reasonCode : "";
-      if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !repoVal || !reasonCode) {
-        return c.json({ error: "issueNumber, repo, reasonCode 필수" }, 400);
-      }
-      const deleted = store.deleteSkipEventsByGroup(issueNumber, repoVal, reasonCode);
-      return c.json({ deleted });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to delete skip event group: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Skip events: 도메인 라우트 분할 (Plan C #C9)
+  registerSkipEventsRoutes(api, { store, readOnly: !!readOnly });
 
   // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
   registerStatsRoutes(api, { store, patternStore });
@@ -617,39 +508,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
   registerSetupRoutes(api, { rootDir });
 
-  // Create a new GitHub issue from dashboard
-  api.post("/api/new-issue", zValidator('json', NewIssueRequestSchema, zodValidationHook), async (c) => {
-    const logger = getLogger();
-    try {
-      const { category, title, repo, what, where, how, files } = c.req.valid('json');
-
-      const templatesDir = resolve(rootDir, "prompts/issue-templates");
-      const templatePath = resolve(templatesDir, `${category}.md`);
-      const template = loadTemplate(templatePath, templatesDir);
-      const body = renderTemplate(template, { what, where, how, files });
-
-      const result = await runCli("gh", [
-        "issue", "create",
-        "--repo", repo,
-        "--title", title,
-        "--body", body,
-        "--label", "aqm-by",
-      ]);
-
-      if (result.exitCode !== 0) {
-        return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(result.stderr)}` }, 500);
-      }
-
-      const url = result.stdout.trim();
-      const numberMatch = url.match(/\/issues\/(\d+)$/);
-      const number = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
-
-      logger.info(`New issue created: ${url}`);
-      return c.json({ url, number });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // New issue: 도메인 라우트 분할 (Plan C #C9)
+  registerNewIssueRoute(api, { rootDir });
 
   // Doctor: 도메인 라우트 분할 (Plan C #C9)
   registerDoctorRoutes(api);

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -15,8 +15,8 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { UpdateConfigRequestSchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, GetMetricsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
-import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
+import { UpdateConfigRequestSchema, GetSkipEventsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { getProjectSummary } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runAllChecks } from "../doctor/checks.js";
 import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
@@ -34,6 +34,7 @@ import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
 import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
+import { registerStatsRoutes } from "./routes/stats.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -705,144 +706,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  // Aggregate stats
-  api.get("/api/stats", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "7d",
-      };
-
-      const parseResult = GetStatsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const stats = getJobStats(store.getAqDb(), parseResult.data);
-      return c.json(stats);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Cost stats
-  api.get("/api/stats/costs", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        timeRange: c.req.query("timeRange") || "30d",
-        groupBy: c.req.query("groupBy") || "project",
-      };
-
-      const parseResult = GetCostsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const costs = getCostStats(store.getAqDb(), parseResult.data);
-      return c.json(costs);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch cost stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Project stats (success rate + cost per project)
-  api.get("/api/stats/projects", (c) => {
-    try {
-      const queryParams = {
-        timeRange: c.req.query("timeRange") || "7d",
-      };
-
-      const parseResult = GetProjectStatsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: parseResult.error
-        }, 400);
-      }
-
-      const stats = getProjectStatsWithTimeRange(store.getAqDb(), parseResult.data);
-      return c.json(stats);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch project stats: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Failure reason top-N analysis
-  api.get("/api/metrics/failure-reasons", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window"),
-        top: c.req.query("top"),
-      };
-
-      const parseResult = GetFailureReasonsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const result = getFailureReasons(store.getAqDb(), parseResult.data, patternStore);
-      return c.json(result);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch failure reasons: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Throughput time series
-  api.get("/api/metrics/throughput", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window") || "7d",
-      };
-
-      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const data = getThroughputTimeSeries(store.getAqDb(), parseResult.data);
-      return c.json(data);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch throughput metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Success rate metrics
-  api.get("/api/metrics/success-rate", (c) => {
-    try {
-      const queryParams = {
-        project: c.req.query("project"),
-        window: c.req.query("window") || "7d",
-      };
-
-      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const data = getSuccessRate(store.getAqDb(), parseResult.data);
-      return c.json(data);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch success rate metrics: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
+  registerStatsRoutes(api, { store, patternStore });
 
   // SSE stream for job logs
   api.get("/api/jobs/:id/logs/stream", (c) => {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -5,7 +5,7 @@ import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
 import { resolve, join } from "path";
 import { homedir } from "os";
-import type { JobStore, Job, ListJobsOptions } from "../queue/job-store.js";
+import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig, updateConfigSection } from "../config/loader.js";
 import { maskSensitiveConfig } from "../utils/config-masker.js";
@@ -15,7 +15,7 @@ import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, UpdateJobPriorityRequestSchema, GetMetricsQuerySchema, CancelJobRequestSchema, RetryJobRequestSchema, GetNotificationsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { UpdateConfigRequestSchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, GetMetricsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
 import { runAllChecks } from "../doctor/checks.js";
@@ -33,6 +33,7 @@ import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
 import { registerProjectsRoutes } from "./routes/projects.js";
+import { registerJobsRoutes } from "./routes/jobs.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -601,108 +602,9 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Projects: 도메인 라우트 분할 (Plan C #C9)
   registerProjectsRoutes(api, { queue, configWatcher, rootDir, configPath });
 
-  // List all jobs (exclude archived by default, ?include=archived to show)
-  api.get("/api/jobs", (c) => {
-    try {
-      // Parse query parameters using Zod schema
-      const queryParamsForValidation = {
-        project: c.req.query("project"),
-        status: c.req.query("status"),
-        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
-        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
-      };
-      const includeArchived = c.req.query("include") === "archived";
-
-      // Validate query parameters (excluding the legacy 'include' parameter)
-      const parseResult = GetJobsQuerySchema.safeParse(queryParamsForValidation);
-      if (!parseResult.success) {
-        return c.json({
-          error: "Invalid query parameters",
-          details: formatZodError(parseResult.error)
-        }, 400);
-      }
-
-      const { project, status, limit, offset } = parseResult.data;
-
-      // DB 레벨 필터 옵션 구성
-      const baseOptions: ListJobsOptions = {};
-      if (!includeArchived) baseOptions.excludeStatus = "archived";
-      if (project) baseOptions.repo = project;
-
-      // API status → 내부 JobStatus 매핑
-      if (status === "pending") {
-        baseOptions.status = "queued";
-      } else if (status === "running") {
-        baseOptions.status = "running";
-      } else if (status === "completed") {
-        baseOptions.status = "success";
-      } else if (status === "failed") {
-        baseOptions.statuses = ["failure", "cancelled"];
-      }
-
-      // DB 레벨에서 총 개수 조회 (페이지네이션 없이)
-      const totalJobs = store.list(baseOptions).length;
-
-      // DB 레벨에서 페이지네이션 적용하여 결과 조회
-      const jobs = store.list({ ...baseOptions, limit, offset });
-
-      const queueStatus = queue.getStatus();
-      return c.json({
-        jobs,
-        queue: queueStatus,
-        pagination: {
-          total: totalJobs,
-          offset: offset ?? 0,
-          limit: limit ?? totalJobs,
-          hasMore: (offset ?? 0) + (limit ?? totalJobs) < totalJobs
-        }
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch jobs: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Get single job
-  api.get("/api/jobs/:id", (c) => {
-    const job = store.get(c.req.param("id"));
-    if (!job) return c.json({ error: "Job not found" }, 404);
-    return c.json(job);
-  });
-
-  // Cancel a job
-  api.post("/api/jobs/:id/cancel", zValidator('json', CancelJobRequestSchema, zodValidationHook), (c) => {
-    const id = c.req.param("id") ?? "";
-    const cancelled = queue.cancel(id);
-    if (!cancelled) return c.json({ error: "Job not found or not cancellable" }, 404);
-    return c.json({ status: "cancelled", id });
-  });
-
-  // Update job priority
-  api.put("/api/jobs/:id/priority", zValidator('json', UpdateJobPriorityRequestSchema, zodValidationHook), async (c) => {
-    const id = c.req.param("id") ?? "";
-    const job = store.get(id);
-    if (!job) return c.json({ error: "Job not found" }, 404);
-
-    const { priority } = c.req.valid('json');
-    const updatedJob = store.update(id, { priority });
-    if (!updatedJob) return c.json({ error: "Failed to update priority" }, 500);
-
-    broadcastToAllClients("job-updated", updatedJob);
-    return c.json(updatedJob);
-  });
-
-  // Delete a completed/failed job
-  api.delete("/api/jobs/:id", (c) => {
-    const id = c.req.param("id");
-    const job = store.get(id);
-    if (!job) return c.json({ error: "Job not found" }, 404);
-    if (job.status === "queued" || job.status === "running") {
-      return c.json({ error: "Cannot delete active job. Cancel it first." }, 400);
-    }
-    const deleted = store.remove(id);
-    if (!deleted) return c.json({ error: "Failed to delete" }, 500);
-    return c.json({ status: "deleted", id });
-  });
+  // Jobs CRUD + cancel/priority/retry: 도메인 라우트 분할 (Plan C #C9)
+  // (logs/stream은 SSE이므로 별도 처리)
+  registerJobsRoutes(api, { store, queue, sseManager });
 
   // Skip events stats (reasonCode별 집계)
   api.get("/api/skip-events/stats", (c) => {
@@ -997,21 +899,6 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
         "Connection": "keep-alive",
       },
     });
-  });
-
-  // Retry a failed job
-  api.post("/api/jobs/:id/retry", zValidator('json', RetryJobRequestSchema, zodValidationHook), async (c) => {
-    const id = c.req.param("id") ?? "";
-    const job = store.get(id);
-    if (!job) return c.json({ error: "Job not found" }, 404);
-    if (job.status !== "failure" && job.status !== "cancelled") {
-      return c.json({ error: "Only failed or cancelled jobs can be retried" }, 400);
-    }
-    const newJob = await queue.retryJob(id);
-    if (!newJob) {
-      return c.json({ error: "Failed to retry job" }, 500);
-    }
-    return c.json({ status: "queued", id: newJob.id });
   });
 
   // SSE endpoint for real-time updates

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -3,23 +3,21 @@ import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
-import { resolve, normalize, join } from "path";
+import { resolve, join } from "path";
 import { homedir } from "os";
 import type { JobStore, Job, ListJobsOptions } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
-import { loadConfig, updateConfigSection, addProjectToConfig, removeProjectFromConfig, updateProjectInConfig } from "../config/loader.js";
-import { validateConfig } from "../config/validator.js";
+import { loadConfig, updateConfigSection } from "../config/loader.js";
 import { maskSensitiveConfig } from "../utils/config-masker.js";
 import { getBasicFieldMetas } from "../config/schema-meta.js";
 import { getPresets } from "../config/presets.js";
-import type { ProjectConfig, AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
+import type { AQConfig, DashboardAuthConfig, QuotaStatus } from "../types/config.js";
 import type { ConfigWatcher } from "../config/config-watcher.js";
 import type { AutomationScheduler } from "../automation/scheduler.js";
 import { setGlobalLogLevel, getLogger } from "../utils/logger.js";
-import { CreateProjectRequestSchema, UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, UpdateJobPriorityRequestSchema, UpdateProjectRequestSchema, GetMetricsQuerySchema, CancelJobRequestSchema, RetryJobRequestSchema, GetNotificationsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
+import { UpdateConfigRequestSchema, GetJobsQuerySchema, GetStatsQuerySchema, GetCostsQuerySchema, GetProjectStatsQuerySchema, GetSkipEventsQuerySchema, GetFailureReasonsQuerySchema, UpdateJobPriorityRequestSchema, GetMetricsQuerySchema, CancelJobRequestSchema, RetryJobRequestSchema, GetNotificationsQuerySchema, formatZodError, type HealthCheckResponse } from "../types/api.js";
 import { getJobStats, getCostStats, getProjectSummary, getProjectStatsWithTimeRange, getFailureReasons, getThroughputTimeSeries, getSuccessRate } from "../store/queries.js";
 import type { PatternStore } from "../learning/pattern-store.js";
-import { isPathSafe } from "../utils/slug.js";
 import { runAllChecks } from "../doctor/checks.js";
 import { healLevel1, healLevel2, writeToActiveHealProcess } from "../doctor/heal.js";
 import { runCli } from "../utils/cli-runner.js";
@@ -27,7 +25,6 @@ import { getErrorMessage } from "../utils/error-utils.js";
 import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
 import { statusToNotificationType } from "../types/pipeline.js";
 import { existsSync, statSync } from "fs";
-import { detectProjectCommands, detectBaseBranch } from "../config/project-detector.js";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
@@ -35,6 +32,7 @@ import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
 import { SSEManager } from "./sse-manager.js";
 import { registerNotificationsRoutes } from "./routes/notifications.js";
 import { registerVersionRoutes } from "./routes/version.js";
+import { registerProjectsRoutes } from "./routes/projects.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -135,27 +133,6 @@ export function zodValidationHook(
 }
 
 export { zValidator };
-
-/**
- * Validates and normalizes path parameters to prevent path traversal attacks.
- */
-function validateAndNormalizePath(path: string, paramName: string): string {
-  if (!path || typeof path !== 'string') {
-    throw new Error(`${paramName} is required and must be a string`);
-  }
-
-  const trimmedPath = path.trim();
-
-  // Check for path safety BEFORE normalization to catch patterns that normalize() might clean up
-  if (!isPathSafe(trimmedPath)) {
-    throw new Error(`${paramName} contains unsafe characters or path traversal patterns`);
-  }
-
-  // Normalize path after safety check
-  const normalizedPath = normalize(trimmedPath);
-
-  return normalizedPath;
-}
 
 /**
  * Health check helper functions
@@ -621,250 +598,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  // Get projects list
-  api.get("/api/projects", (c) => {
-    try {
-      const config = configWatcher?.current() ?? loadConfig(rootDir);
-
-      if (!config.projects || config.projects.length === 0) {
-        return c.json({ projects: [] });
-      }
-
-      const projects = config.projects.map(project => ({
-        ...project,
-        errorState: queue.getProjectStatus(project.repo),
-      }));
-
-      return c.json({ projects });
-    } catch (error: unknown) {
-      const logger = getLogger();
-      logger.error(`Failed to load projects: ${getErrorMessage(error)}`);
-      return c.json({ error: "Failed to load projects" }, 500);
-    }
-  });
-
-  // Add project to configuration
-  api.post("/api/projects", zValidator('json', CreateProjectRequestSchema, zodValidationHook), async (c) => {
-    try {
-      const { repo, path, baseBranch, mode, commands } = c.req.valid('json');
-
-      // Validate and normalize path
-      let normalizedPath: string;
-      try {
-        normalizedPath = validateAndNormalizePath(path, "path");
-      } catch (error: unknown) {
-        return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
-      }
-
-      // Auto-detect commands and baseBranch if not explicitly provided
-      const detection = detectProjectCommands(normalizedPath);
-      const resolvedBaseBranch = baseBranch?.trim() || await detectBaseBranch(normalizedPath);
-
-      const project: ProjectConfig = {
-        repo: repo.trim(),
-        path: normalizedPath,
-        baseBranch: resolvedBaseBranch,
-        mode,
-        commands: commands ?? detection.commands,
-      };
-
-      try {
-        const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
-        if (currentConfig.projects?.find(p => p.repo === project.repo)) {
-          return c.json({ error: `Project "${project.repo}" already exists` }, 409);
-        }
-      } catch (error: unknown) {
-        // Config doesn't exist yet, proceed
-      }
-
-      addProjectToConfig(configPath, project);
-      configWatcher?.refresh();
-
-      try {
-        validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
-      } catch (error: unknown) {
-        return c.json({ error: `Configuration validation failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 400);
-      }
-
-      return c.json({
-        message: "Project added successfully",
-        project,
-        detectedLanguage: detection.language,
-      }, 201);
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to add project: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Remove project from configuration
-  api.delete("/api/projects/:repo", (c) => {
-    try {
-      const repo = decodeURIComponent(c.req.param("repo"));
-
-      if (!repo || repo.trim() === "") {
-        return c.json({ error: "repo parameter is required" }, 400);
-      }
-
-      try {
-        const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
-        if (!currentConfig.projects?.find(p => p.repo === repo)) {
-          return c.json({ error: `Project "${repo}" not found` }, 404);
-        }
-      } catch (error: unknown) {
-        return c.json({ error: `Failed to load configuration: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-      }
-
-      removeProjectFromConfig(configPath, repo);
-      configWatcher?.refresh();
-
-      try {
-        validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
-      } catch (error: unknown) {
-        return c.json({ error: `Configuration validation failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 400);
-      }
-
-      return c.json({
-        message: "Project removed successfully",
-        repo
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to remove project: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Update project in configuration
-  api.put("/api/projects/:repo", zValidator('json', UpdateProjectRequestSchema, zodValidationHook), async (c) => {
-    try {
-      const repo = decodeURIComponent(c.req.param("repo") ?? "");
-
-      if (!repo || repo.trim() === "") {
-        return c.json({ error: "repo parameter is required" }, 400);
-      }
-
-      // Validate that project exists
-      try {
-        const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
-        if (!currentConfig.projects?.find(p => p.repo === repo)) {
-          return c.json({ error: `Project "${repo}" not found` }, 404);
-        }
-      } catch (error: unknown) {
-        return c.json({ error: `Failed to load configuration: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-      }
-
-      const { path, baseBranch, mode, commands } = c.req.valid('json');
-      const updates: Partial<Pick<ProjectConfig, 'path' | 'baseBranch' | 'mode' | 'commands'>> = {};
-
-      if (path !== undefined) {
-        try {
-          updates.path = validateAndNormalizePath(path, "path");
-        } catch (error: unknown) {
-          return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
-        }
-      }
-
-      if (baseBranch !== undefined) {
-        updates.baseBranch = baseBranch?.trim() || undefined;
-      }
-
-      if (mode !== undefined) {
-        updates.mode = mode ?? undefined;
-      }
-
-      if (commands !== undefined) {
-        updates.commands = commands;
-      }
-
-      // Check if any fields to update
-      if (Object.keys(updates).length === 0) {
-        return c.json({ error: "No valid fields to update" }, 400);
-      }
-
-      updateProjectInConfig(configPath, repo, updates);
-      configWatcher?.refresh();
-
-      try {
-        validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
-      } catch (error: unknown) {
-        return c.json({ error: `Configuration validation failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 400);
-      }
-
-      return c.json({
-        message: "Project updated successfully",
-        repo,
-        updates
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to update project: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Get project error state
-  api.get("/api/projects/:repo/error-state", (c) => {
-    try {
-      const repo = decodeURIComponent(c.req.param("repo"));
-
-      if (!repo || repo.trim() === "") {
-        return c.json({ error: "repo parameter is required" }, 400);
-      }
-
-      const errorState = queue.getProjectStatus(repo);
-      return c.json({ repo, errorState });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to get error state: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Manually pause a project
-  api.post("/api/projects/:repo/pause", async (c) => {
-    try {
-      const repo = decodeURIComponent(c.req.param("repo"));
-
-      if (!repo || repo.trim() === "") {
-        return c.json({ error: "repo parameter is required" }, 400);
-      }
-
-      let durationMs: number | undefined;
-      try {
-        const body = await c.req.json() as Record<string, unknown>;
-        if (body.durationMs !== undefined) {
-          if (typeof body.durationMs !== "number" || body.durationMs <= 0) {
-            return c.json({ error: "durationMs must be a positive number" }, 400);
-          }
-          durationMs = body.durationMs;
-        }
-      } catch (err: unknown) {
-        getLogger().debug(`Optional body parse failed — using default: ${getErrorMessage(err)}`);
-      }
-
-      // Default: 30 minutes
-      const effectiveDuration = durationMs ?? 30 * 60 * 1000;
-      queue.pauseProject(repo, effectiveDuration);
-
-      return c.json({
-        message: `Project "${repo}" paused for ${Math.round(effectiveDuration / 1000)}s`,
-        repo,
-        pausedUntil: Date.now() + effectiveDuration,
-      });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to pause project: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Manually resume a paused project
-  api.post("/api/projects/:repo/resume", (c) => {
-    try {
-      const repo = decodeURIComponent(c.req.param("repo"));
-
-      if (!repo || repo.trim() === "") {
-        return c.json({ error: "repo parameter is required" }, 400);
-      }
-
-      queue.resumeProject(repo);
-      return c.json({ message: `Project "${repo}" resumed`, repo });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to resume project: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Projects: 도메인 라우트 분할 (Plan C #C9)
+  registerProjectsRoutes(api, { queue, configWatcher, rootDir, configPath });
 
   // List all jobs (exclude archived by default, ?include=archived to show)
   api.get("/api/jobs", (c) => {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -35,6 +35,7 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { ZodError } from "zod";
 import { loadTemplate, renderTemplate } from "../prompt/template-renderer.js";
+import { SSEManager } from "./sse-manager.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -53,126 +54,36 @@ export function getQuotaStatus(): QuotaStatus | null {
   return currentQuotaStatus;
 }
 
-// SSE client management
-interface SSEClient {
-  id: string;
-  controller: ReadableStreamDefaultController<Uint8Array>;
-  connectedAt: number;
-  lastHeartbeat: number;
-}
+// SSE 클라이언트 풀과 heartbeat 루프는 SSEManager로 캡슐화 (Plan C #C5).
+// dashboard-api는 단일 인스턴스를 보유하고, 외부 export는 위임 함수로 유지한다.
+const sseManager = new SSEManager({
+  maxClients: 50,
+  heartbeatMs: 30_000,
+  clientTimeoutMs: 120_000,
+});
 
-
-const sseClients = new Map<string, SSEClient>();
-const encoder = new TextEncoder();
-
-// Periodic cleanup intervals
+// Token cleanup interval (sessionManager TTL 가지치기). SSE heartbeat과는 독립.
 let tokenCleanupInterval: ReturnType<typeof setInterval> | undefined;
-let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-
-// Cleanup constants
 const TOKEN_CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-const HEARTBEAT_INTERVAL_MS = 30 * 1000; // 30 seconds
-const CLIENT_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
-const MAX_SSE_CLIENTS = 50; // Maximum concurrent SSE connections
-
-function removeStaleClients(): void {
-  const now = Date.now();
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    if (now - client.lastHeartbeat > CLIENT_TIMEOUT_MS) {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    try {
-      const client = sseClients.get(clientId);
-      client?.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-    sseClients.delete(clientId);
-  }
-}
 
 export function getSSEClientCount(): number {
-  return sseClients.size;
-}
-
-function evictOldestClients(targetCount: number): void {
-  if (sseClients.size <= targetCount) return;
-
-  // Sort by connectedAt ascending (oldest first)
-  const sorted = [...sseClients.entries()].sort(([, a], [, b]) => a.connectedAt - b.connectedAt);
-  const toEvict = sorted.slice(0, sseClients.size - targetCount);
-
-  for (const [clientId, client] of toEvict) {
-    try {
-      client.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-    sseClients.delete(clientId);
-  }
+  return sseManager.clientCount;
 }
 
 function broadcastToAllClients(event: string, data: unknown): void {
-  const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-  const now = Date.now();
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    if (now - client.lastHeartbeat > CLIENT_TIMEOUT_MS) {
-      clientsToRemove.push(clientId);
-      continue;
-    }
-
-    try {
-      client.controller.enqueue(encoder.encode(message));
-      client.lastHeartbeat = now;
-    } catch {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    sseClients.delete(clientId);
-  }
-}
-
-
-function sendHeartbeat(): void {
-  const heartbeatMessage = `event: heartbeat\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`;
-  const clientsToRemove: string[] = [];
-
-  for (const [clientId, client] of sseClients) {
-    try {
-      client.controller.enqueue(encoder.encode(heartbeatMessage));
-    } catch {
-      clientsToRemove.push(clientId);
-    }
-  }
-
-  for (const clientId of clientsToRemove) {
-    sseClients.delete(clientId);
-  }
+  sseManager.broadcast(event, data);
 }
 
 function startPeriodicCleanup(): void {
   // Stop existing intervals if any
   stopPeriodicCleanup();
 
-  // Start token cleanup interval
+  // Token cleanup은 SSE와 독립적으로 운영.
   tokenCleanupInterval = setInterval(() => {
     sessionManager.pruneExpired();
   }, TOKEN_CLEANUP_INTERVAL_MS);
 
-  // Start heartbeat interval
-  heartbeatInterval = setInterval(() => {
-    sendHeartbeat();
-    removeStaleClients();
-  }, HEARTBEAT_INTERVAL_MS);
+  sseManager.startHeartbeat();
 }
 
 export function stopPeriodicCleanup(): void {
@@ -180,24 +91,14 @@ export function stopPeriodicCleanup(): void {
     clearInterval(tokenCleanupInterval);
     tokenCleanupInterval = undefined;
   }
-  if (heartbeatInterval) {
-    clearInterval(heartbeatInterval);
-    heartbeatInterval = undefined;
-  }
+  sseManager.stopHeartbeat();
 }
 
 /**
  * Clean up all active SSE clients by closing their connections.
  */
 export function cleanupAllSSEClients(): void {
-  for (const [, client] of sseClients) {
-    try {
-      client.controller.close();
-    } catch {
-      // Ignore errors when closing already closed streams
-    }
-  }
-  sseClients.clear();
+  sseManager.cleanupAll();
 }
 
 /**
@@ -1382,23 +1283,12 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // SSE endpoint for real-time updates
   api.get("/api/events", (_c) => {
     const clientId = randomUUID();
+    const encoder = new TextEncoder();
     let intervalId: ReturnType<typeof setInterval> | undefined;
 
     const stream = new ReadableStream({
       start(controller) {
-        // Enforce connection limit — evict oldest clients before registering new one
-        if (sseClients.size >= MAX_SSE_CLIENTS) {
-          evictOldestClients(MAX_SSE_CLIENTS - 1);
-        }
-
-        // Register client with timestamps
-        const now = Date.now();
-        sseClients.set(clientId, {
-          id: clientId,
-          controller,
-          connectedAt: now,
-          lastHeartbeat: now
-        });
+        sseManager.addClient(controller, clientId);
 
         // Send initial state
         const sendInitialState = () => {
@@ -1419,13 +1309,12 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
         // Auto-cleanup after 5 minutes
         setTimeout(() => {
           clearInterval(intervalId);
-          sseClients.delete(clientId);
-          try { controller.close(); } catch { /* already closed */ }
+          sseManager.removeClient(clientId);
         }, 300000);
       },
       cancel() {
         clearInterval(intervalId);
-        sseClients.delete(clientId);
+        sseManager.removeClient(clientId);
       },
     });
 
@@ -2041,6 +1930,7 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
   api.get("/api/doctor/heal/:id/stream", (c) => {
     const checkId = c.req.param("id");
+    const encoder = new TextEncoder();
 
     const stream = new ReadableStream({
       start(controller) {

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,5 +1,4 @@
-import { Hono, type Context, type Next } from "hono";
-import { timingSafeEqual } from "crypto";
+import { Hono, type Context } from "hono";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import type { JobStore, Job } from "../queue/job-store.js";
@@ -28,6 +27,7 @@ import { registerHealthRoutes } from "./routes/health.js";
 import { registerSkipEventsRoutes } from "./routes/skip-events.js";
 import { registerNewIssueRoute } from "./routes/new-issue.js";
 import { registerSSERoutes } from "./routes/sse.js";
+import { setupAuth } from "./routes/auth.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -102,10 +102,6 @@ export function cleanupDashboardResources(): void {
   cleanupAllSSEClients();
   sessionManager.revokeAll();
   loginRateLimiter?.destroy();
-}
-
-function isValidSessionToken(token: string): boolean {
-  return sessionManager.validate(token);
 }
 
 /**
@@ -231,122 +227,14 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  if (apiKey) {
-    // POST /api/auth — exchange Bearer key for a short-lived session token
-    api.post("/api/auth", (c) => {
-      const ip =
-        c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
-        (c.env as Record<string, unknown> | undefined)?.["remoteAddress"] as string | undefined ??
-        "unknown";
-
-      const rateLimitCheck = loginRateLimiter?.checkAndRecord(ip);
-      if (rateLimitCheck && !rateLimitCheck.allowed) {
-        const retryAfterSec = Math.ceil((rateLimitCheck.retryAfterMs ?? 900_000) / 1000);
-        getLogger().warn(`[Auth] Rate limit exceeded for IP ${ip}`);
-        return c.json(
-          { error: "Too Many Requests" },
-          429,
-          { "Retry-After": String(retryAfterSec) }
-        );
-      }
-
-      const auth = c.req.header("Authorization");
-      const expected = Buffer.from(`Bearer ${apiKey}`);
-      const actual = Buffer.from(auth ?? "");
-      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-
-      loginRateLimiter?.reset(ip);
-      const { token, expiresIn } = sessionManager.createToken();
-      return c.json({ token, expiresIn });
-    });
-
-    // Auth middleware for regular (non-SSE) API endpoints — Bearer header only
-    // Deny-by-default: all /api/* routes require auth except public and SSE paths
-    const bearerAuth = async (c: Context, next: Next) => {
-      const path = c.req.path;
-      // Public routes — no auth required
-      if (path === "/api/auth") {
-        await next();
-        return;
-      }
-      // SSE routes — handled by sseTokenAuth or healSseKeyAuth below
-      if (
-        path === "/api/events" ||
-        /^\/api\/jobs\/[^/]+\/logs\/stream$/.test(path) ||
-        /^\/api\/doctor\/heal\/[^/]+\/stream$/.test(path)
-      ) {
-        await next();
-        return;
-      }
-      const auth = c.req.header("Authorization");
-      const expected = Buffer.from(`Bearer ${apiKey}`);
-      const actual = Buffer.from(auth ?? "");
-      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-
-    api.use("/api/*", bearerAuth);
-
-    // SSE endpoints use short-lived session token from ?token= query param
-    const sseTokenAuth = async (c: Context, next: Next) => {
-      const token = c.req.query("token");
-      if (!token || !isValidSessionToken(token)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-
-    api.use("/api/events", sseTokenAuth);
-    api.use("/api/jobs/:id/logs/stream", sseTokenAuth);
-
-    // Doctor heal SSE uses raw API key via ?key= query param (EventSource cannot set headers)
-    const healSseKeyAuth = async (c: Context, next: Next) => {
-      const key = c.req.query("key");
-      if (!key) return c.json({ error: "Unauthorized" }, 401);
-      const expected = Buffer.from(apiKey);
-      const actual = Buffer.from(key);
-      if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
-        return c.json({ error: "Unauthorized" }, 401);
-      }
-      await next();
-    };
-    api.use("/api/doctor/heal/:id/stream", healSseKeyAuth);
-  } else {
-    // apiKey 미설정: 바인드 호스트에 따라 로그 레벨 분기
-    const isLocalBind = !hostname || hostname === "127.0.0.1" || hostname === "localhost";
-    if (readOnly) {
-      // readOnly 모드: write 엔드포인트에 403 반환
-      const readOnlyGuard = async (c: Context, next: Next) => {
-        if (c.req.method !== "GET" && c.req.method !== "HEAD") {
-          return c.json({ error: "Forbidden: dashboard is in read-only mode" }, 403);
-        }
-        await next();
-      };
-      api.use("/api/config", readOnlyGuard);
-      api.use("/api/projects", readOnlyGuard);
-      api.use("/api/projects/*", readOnlyGuard);
-      api.use("/api/jobs/*", readOnlyGuard);
-      api.use("/api/update", readOnlyGuard);
-      api.use("/api/new-issue", readOnlyGuard);
-      getLogger().info(
-        "Dashboard is running in read-only mode. Write endpoints are disabled." +
-        (!isLocalBind ? " Non-local bind is permitted in read-only mode." : "")
-      );
-    } else if (isLocalBind) {
-      getLogger().info(
-        "Dashboard API key is not configured. All endpoints are accessible without authentication."
-      );
-    } else {
-      getLogger().warn(
-        "Dashboard API key is not configured. All endpoints are accessible without authentication. " +
-        "Non-local bind without API key is a security risk."
-      );
-    }
-  }
+  // Auth + readOnly guard: 도메인 라우트 분할 (Plan C #C9 12단계)
+  setupAuth(api, {
+    apiKey,
+    hostname,
+    readOnly: !!readOnly,
+    sessionManager,
+    loginRateLimiter,
+  });
 
   const configPath = `${rootDir}/config.yml`;
 

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context, type Next } from "hono";
-import { randomUUID, timingSafeEqual } from "crypto";
+import { timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
 import type { JobStore, Job } from "../queue/job-store.js";
@@ -27,6 +27,7 @@ import { registerDoctorRoutes } from "./routes/doctor.js";
 import { registerHealthRoutes } from "./routes/health.js";
 import { registerSkipEventsRoutes } from "./routes/skip-events.js";
 import { registerNewIssueRoute } from "./routes/new-issue.js";
+import { registerSSERoutes } from "./routes/sse.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -175,25 +176,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
       logger.info(`Automation rules updated: ${oldAutomations.length} → ${newAutomations.length} rules`);
     }
   }
-}
-
-const SSE_INITIAL_JOB_LIMIT = 20;
-
-/**
- * Returns jobs for SSE initial state:
- * - Excludes archived jobs
- * - Always includes running/queued jobs (regardless of position)
- * - Fills remaining slots with recent non-active jobs (up to SSE_INITIAL_JOB_LIMIT total)
- */
-function getInitialJobs(store: JobStore): Job[] {
-  // DB 레벨에서 active job 조회
-  const active = store.list({ statuses: ["running", "queued"] });
-  const remaining = Math.max(0, SSE_INITIAL_JOB_LIMIT - active.length);
-  // 나머지 슬롯은 최근 non-active, non-archived job으로 채움
-  const rest = remaining > 0
-    ? store.list({ statuses: ["success", "failure", "cancelled"], limit: remaining })
-    : [];
-  return [...active, ...rest];
 }
 
 /**
@@ -384,109 +366,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
   // Stats + metrics: 도메인 라우트 분할 (Plan C #C9)
   registerStatsRoutes(api, { store, patternStore });
 
-  // SSE stream for job logs
-  api.get("/api/jobs/:id/logs/stream", (c) => {
-    const id = c.req.param("id");
-    let lastLogCount = 0;
-    let intervalId: ReturnType<typeof setInterval> | undefined;
-
-    const stream = new ReadableStream({
-      start(controller) {
-        const encoder = new TextEncoder();
-        const send = () => {
-          try {
-            const job = store.get(id);
-            if (!job) {
-              controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ error: "Job not found" })}\n\n`));
-              clearInterval(intervalId);
-              try { controller.close(); } catch { /* already closed */ }
-              return;
-            }
-            const logs = job.logs || [];
-            if (logs.length > lastLogCount) {
-              const newLines = logs.slice(lastLogCount);
-              lastLogCount = logs.length;
-              for (const line of newLines) {
-                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line, status: job.status })}\n\n`));
-              }
-            }
-            // Send status update so client knows when job finishes
-            if (job.status !== "running" && job.status !== "queued") {
-              controller.enqueue(encoder.encode(`event: done\ndata: ${JSON.stringify({ status: job.status })}\n\n`));
-              clearInterval(intervalId);
-              try { controller.close(); } catch { /* already closed */ }
-            }
-          } catch {
-            // stream closed
-          }
-        };
-        send();
-        intervalId = setInterval(send, 1000);
-        setTimeout(() => {
-          clearInterval(intervalId);
-          try { controller.close(); } catch { /* already closed */ }
-        }, 300000); // 5 min max
-      },
-      cancel() {
-        clearInterval(intervalId);
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
-
-  // SSE endpoint for real-time updates
-  api.get("/api/events", (_c) => {
-    const clientId = randomUUID();
-    const encoder = new TextEncoder();
-    let intervalId: ReturnType<typeof setInterval> | undefined;
-
-    const stream = new ReadableStream({
-      start(controller) {
-        sseManager.addClient(controller, clientId);
-
-        // Send initial state
-        const sendInitialState = () => {
-          try {
-            const status = queue.getStatus();
-            const data = JSON.stringify({ jobs: getInitialJobs(store), queue: status });
-            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
-          } catch {
-            // stream closed
-          }
-        };
-
-        sendInitialState();
-
-        // Send periodic updates for fallback (reduced frequency since real-time events handle most updates)
-        intervalId = setInterval(sendInitialState, 10000); // 10 seconds instead of 2
-
-        // Auto-cleanup after 5 minutes
-        setTimeout(() => {
-          clearInterval(intervalId);
-          sseManager.removeClient(clientId);
-        }, 300000);
-      },
-      cancel() {
-        clearInterval(intervalId);
-        sseManager.removeClient(clientId);
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
-      },
-    });
-  });
+  // SSE: 도메인 라우트 분할 (Plan C #C9)
+  registerSSERoutes(api, { store, queue, sseManager });
 
   // Start periodic cleanup when dashboard routes are created
   startPeriodicCleanup();

--- a/src/server/dashboard-api.ts
+++ b/src/server/dashboard-api.ts
@@ -2,9 +2,7 @@ import { Hono, type Context, type Next } from "hono";
 import { randomUUID, timingSafeEqual } from "crypto";
 import { SessionManager } from "./auth/session.js";
 import { LoginRateLimiter } from "./auth/rate-limiter.js";
-import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
 import { resolve, join } from "path";
-import { homedir } from "os";
 import type { JobStore, Job } from "../queue/job-store.js";
 import type { JobQueue } from "../queue/job-queue.js";
 import { loadConfig } from "../config/loader.js";
@@ -33,6 +31,7 @@ import { registerProjectsRoutes } from "./routes/projects.js";
 import { registerJobsRoutes } from "./routes/jobs.js";
 import { registerStatsRoutes } from "./routes/stats.js";
 import { registerConfigRoutes } from "./routes/config.js";
+import { registerSetupRoutes } from "./routes/setup.js";
 
 // Session manager: in-memory token store with TTL and periodic pruning
 const sessionManager = new SessionManager();
@@ -278,48 +277,6 @@ export function applyConfigChanges(oldConfig: AQConfig, newConfig: AQConfig, que
 }
 
 const SSE_INITIAL_JOB_LIMIT = 20;
-
-const SetupPreviewBodySchema = z.object({
-  repo: z.string().min(1),
-  repoPath: z.string().min(1),
-  baseBranch: z.string().optional(),
-  mode: z.string().optional(),
-  token: z.string().optional(),
-});
-
-const SetupLabelsBodySchema = z.object({
-  repo: z.string().min(1),
-  token: z.string().min(1),
-  labels: z.array(z.string().min(1)).default(["aqm-by"]),
-});
-
-function generateSetupYaml(repo: string, repoPath: string, baseBranch?: string, mode?: string): string {
-  const projectLines = [
-    `  - repo: "${repo}"`,
-    `    path: "${repoPath}"`,
-  ];
-  if (baseBranch) projectLines.push(`    baseBranch: "${baseBranch}"`);
-  if (mode) projectLines.push(`    mode: "${mode}"`);
-  return `# AI Quartermaster 설정 파일\n# 전체 옵션은 docs/config-schema.md 참조\n\nprojects:\n${projectLines.join('\n')}\n`;
-}
-
-function computeYamlDiff(
-  existingYaml: string | null,
-  newYaml: string
-): { added: string[]; removed: string[]; unchanged: string[] } {
-  const newLines = newYaml.split('\n').filter(l => l.trim());
-  if (!existingYaml) {
-    return { added: newLines, removed: [], unchanged: [] };
-  }
-  const existingLines = existingYaml.split('\n').filter(l => l.trim());
-  const existingSet = new Set(existingLines);
-  const newSet = new Set(newLines);
-  return {
-    added: newLines.filter(l => !existingSet.has(l)),
-    removed: existingLines.filter(l => !newSet.has(l)),
-    unchanged: newLines.filter(l => existingSet.has(l)),
-  };
-}
 
 const NewIssueRequestSchema = z.object({
   category: z.enum(["bug", "feature", "refactor", "docs"]),
@@ -923,175 +880,8 @@ export function createDashboardRoutes(store: JobStore, queue: JobQueue, configWa
     }
   });
 
-  // Setup wizard: validate GitHub personal access token
-  api.get("/api/setup/validate-token", async (c) => {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
-    }
-
-    const token = authHeader.slice("Bearer ".length).trim();
-    if (!token) {
-      return c.json({ error: "Token must not be empty" }, 400);
-    }
-
-    try {
-      const response = await fetch("https://api.github.com/user", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "AI-Quartermaster",
-        },
-      });
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          return c.json({ error: "Invalid GitHub token" }, 401);
-        }
-        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
-      }
-
-      const data = (await response.json()) as Record<string, unknown>;
-      const username = typeof data.login === "string" ? data.login : null;
-      const avatarUrl = typeof data.avatar_url === "string" ? data.avatar_url : null;
-      const publicRepos = typeof data.public_repos === "number" ? data.public_repos : null;
-
-      return c.json({ username, avatar_url: avatarUrl, public_repos: publicRepos });
-    } catch (error: unknown) {
-      return c.json({ error: `Token validation failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: fetch authenticated user's GitHub repos
-  api.get("/api/setup/repos", async (c) => {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
-    }
-    const token = authHeader.slice("Bearer ".length).trim();
-    if (!token) {
-      return c.json({ error: "Token must not be empty" }, 400);
-    }
-
-    try {
-      const response = await fetch(
-        "https://api.github.com/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator",
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "AI-Quartermaster",
-          },
-        }
-      );
-
-      if (!response.ok) {
-        if (response.status === 401) {
-          return c.json({ error: "Invalid GitHub token" }, 401);
-        }
-        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
-      }
-
-      const data = (await response.json()) as Array<Record<string, unknown>>;
-      const repos = data
-        .filter((r) => typeof r.full_name === "string")
-        .map((r) => ({
-          full_name: r.full_name as string,
-          private: Boolean(r.private),
-          description: typeof r.description === "string" ? r.description : null,
-        }));
-      return c.json({ repos });
-    } catch (error: unknown) {
-      return c.json({ error: `Failed to fetch repos: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: auto-create AQM labels in the target repository
-  api.post("/api/setup/labels", zValidator('json', SetupLabelsBodySchema, zodValidationHook), async (c) => {
-    const { repo, token, labels } = c.req.valid('json');
-
-    const ghHeaders: Record<string, string> = {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "AI-Quartermaster",
-      "Content-Type": "application/json",
-    };
-
-    const results: Array<{ label: string; status: "created" | "skipped" | "failed" }> = [];
-
-    for (const label of labels) {
-      try {
-        const checkResp = await fetch(
-          `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(label)}`,
-          { headers: ghHeaders }
-        );
-
-        if (checkResp.status === 200) {
-          results.push({ label, status: "skipped" });
-          continue;
-        }
-
-        if (checkResp.status !== 404) {
-          results.push({ label, status: "failed" });
-          continue;
-        }
-
-        // Label doesn't exist — create it
-        const createResp = await fetch(`https://api.github.com/repos/${repo}/labels`, {
-          method: "POST",
-          headers: ghHeaders,
-          body: JSON.stringify({ name: label, color: "0075ca", description: "AI Quartermaster task" }),
-        });
-        results.push({ label, status: createResp.ok ? "created" : "failed" });
-      } catch {
-        results.push({ label, status: "failed" });
-      }
-    }
-
-    return c.json({ results });
-  });
-
-  // Setup wizard: preview YAML diff before applying
-  api.post("/api/setup/preview", zValidator('json', SetupPreviewBodySchema, zodValidationHook), async (c) => {
-    try {
-      const { repo, repoPath, baseBranch, mode } = c.req.valid('json');
-      const configPath = resolve(rootDir, "config.yml");
-      const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
-      const existingYaml = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
-      const diff = computeYamlDiff(existingYaml, newYaml);
-      return c.json({ yaml: newYaml, existingYaml, diff });
-    } catch (error: unknown) {
-      return c.json({ error: `Preview failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
-
-  // Setup wizard: apply config.yml with backup
-  api.post("/api/setup/apply", zValidator('json', SetupPreviewBodySchema, zodValidationHook), async (c) => {
-    try {
-      const { repo, repoPath, baseBranch, mode, token } = c.req.valid('json');
-      const configPath = resolve(rootDir, "config.yml");
-      let backupPath: string | null = null;
-      if (existsSync(configPath)) {
-        // 타임스탬프 접미사로 이전 백업을 보존한다 (여러 번 apply 해도 직전 상태로 롤백 가능)
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        backupPath = `${configPath}.bak.${timestamp}`;
-        copyFileSync(configPath, backupPath);
-      }
-      const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
-      writeFileSync(configPath, newYaml, 'utf-8');
-      if (token) {
-        const credentialsDir = join(homedir(), '.aqm');
-        mkdirSync(credentialsDir, { recursive: true });
-        writeFileSync(join(credentialsDir, 'credentials'), `GITHUB_TOKEN=${token}\n`, { mode: 0o600 });
-      }
-      return c.json({ success: true, configPath, backupPath });
-    } catch (error: unknown) {
-      return c.json({ error: `Apply failed: ${sanitizeErrorMessage(getErrorMessage(error))}` }, 500);
-    }
-  });
+  // Setup wizard: 도메인 라우트 분할 (Plan C #C9)
+  registerSetupRoutes(api, { rootDir });
 
   // Health check endpoint
   api.get("/api/health", async (c) => {

--- a/src/server/health-checks.ts
+++ b/src/server/health-checks.ts
@@ -1,0 +1,111 @@
+import { resolve } from "path";
+import { existsSync, statSync } from "fs";
+import { runCli } from "../utils/cli-runner.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
+
+/**
+ * 프로젝트 헬스 체크 헬퍼 (Plan C #C9 — 9단계 분할 사전 작업).
+ *
+ * 이전: dashboard-api.ts 138-227 (4 헬퍼, ~95줄)에 인라인. /api/repositories,
+ *      /api/projects/health, /api/health 세 곳에서 중복 사용됐다.
+ * 이후: 본 모듈이 단일 진입점이 되어 라우트 파일 분할이 가능해진다.
+ */
+
+export async function checkGitRemoteAccess(
+  projectPath: string,
+  gitPath: string
+): Promise<{ status: "ok" | "error"; message?: string }> {
+  try {
+    const result = await runCli(gitPath, ["ls-remote", "--heads", "origin"], { cwd: projectPath, timeout: 10000 });
+    if (result.exitCode !== 0) {
+      return {
+        status: "error",
+        message: `Git remote not accessible: ${result.stderr || "Cannot connect to remote"}`,
+      };
+    }
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Git remote check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkLocalPath(
+  projectPath: string
+): Promise<{ status: "ok" | "error"; message?: string }> {
+  try {
+    if (!existsSync(projectPath)) {
+      return { status: "error", message: "Project path does not exist" };
+    }
+
+    const stats = statSync(projectPath);
+    if (!stats.isDirectory()) {
+      return { status: "error", message: "Project path is not a directory" };
+    }
+
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Local path check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkDiskSpace(
+  projectPath: string
+): Promise<{ status: "ok" | "warning" | "error"; message?: string; freeBytes?: number }> {
+  try {
+    const result = await runCli("df", ["-B1", projectPath], { timeout: 5000 });
+    if (result.exitCode !== 0) {
+      return { status: "warning", message: "Could not check disk space" };
+    }
+
+    const lines = result.stdout.trim().split("\n");
+    if (lines.length < 2) {
+      return { status: "warning", message: "Could not parse disk space output" };
+    }
+
+    const parts = lines[1].split(/\s+/);
+    const available = parseInt(parts[3] || "0", 10);
+
+    if (available === 0) {
+      return { status: "error", message: "No free disk space", freeBytes: available };
+    } else if (available < 1024 * 1024 * 1024) {
+      return { status: "warning", message: "Low disk space (< 1GB)", freeBytes: available };
+    }
+
+    return { status: "ok", freeBytes: available };
+  } catch (error: unknown) {
+    return {
+      status: "warning",
+      message: `Disk space check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}
+
+export async function checkDependencies(
+  projectPath: string
+): Promise<{ status: "ok" | "warning" | "error"; message?: string }> {
+  try {
+    const packageJsonPath = resolve(projectPath, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      return { status: "warning", message: "No package.json found" };
+    }
+
+    const nodeModulesPath = resolve(projectPath, "node_modules");
+    if (!existsSync(nodeModulesPath)) {
+      return { status: "warning", message: "Dependencies not installed (no node_modules)" };
+    }
+
+    return { status: "ok" };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: `Dependencies check failed: ${sanitizeErrorMessage(getErrorMessage(error))}`,
+    };
+  }
+}

--- a/src/server/route-context.ts
+++ b/src/server/route-context.ts
@@ -1,0 +1,47 @@
+import type { Context } from "hono";
+import type { JobStore } from "../queue/job-store.js";
+import type { JobQueue } from "../queue/job-queue.js";
+import type { ConfigProvider } from "../config/config-provider.js";
+import type { PatternStore } from "../learning/pattern-store.js";
+import type { SSEManager } from "./sse-manager.js";
+import { getErrorMessage } from "../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../utils/error-sanitizer.js";
+
+/**
+ * 대시보드 라우트 핸들러가 공유하는 의존성 컨테이너.
+ *
+ * Plan C #C5에서 정의되며, 실제 `createDashboardRoutes` 시그니처 적용은 #C9·#C12에서
+ * 라우트 파일 분할과 함께 진행한다. 본 인터페이스는 그 사전 계약이다.
+ */
+export interface DashboardContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configProvider: ConfigProvider;
+  patternStore?: PatternStore;
+  /** AQM 설치 루트(=AQM_HOME 또는 ~/.ai-quartermaster) — 라우트 핸들러가 데이터/로그 경로 조립에 사용. */
+  rootDir: string;
+  /** insecure 환경에서 mutation 차단용 플래그. */
+  readOnly: boolean;
+}
+
+/**
+ * 라우트 핸들러에서 던져진 예외를 표준 JSON 에러 응답으로 변환한다.
+ * `sanitizeErrorMessage(getErrorMessage(...))` 42회 반복 패턴의 단일화 헬퍼.
+ *
+ * @param c Hono Context
+ * @param error catch 블록의 unknown 에러
+ * @param prefix 사용자 노출용 접두 메시지(예: "Failed to fetch jobs")
+ * @param status HTTP 상태 코드 (기본 500)
+ */
+export function safeError(
+  c: Context,
+  error: unknown,
+  prefix: string,
+  status: number = 500
+): Response {
+  const message = sanitizeErrorMessage(getErrorMessage(error));
+  // Hono의 status 파라미터는 ContentfulStatusCode union이지만, safeError는
+  // 일반 number를 받고 호출부 편의성을 우선한다 (4xx/5xx 범위 가정).
+  return c.json({ error: `${prefix}: ${message}` }, status as Parameters<typeof c.json>[1]);
+}

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,0 +1,151 @@
+import type { Hono, Context, Next } from "hono";
+import { timingSafeEqual } from "crypto";
+import type { SessionManager } from "../auth/session.js";
+import type { LoginRateLimiter } from "../auth/rate-limiter.js";
+import { getLogger } from "../../utils/logger.js";
+
+export interface AuthSetupContext {
+  /** 미설정이면 무인증 모드 (readOnly 또는 로컬 바인드 한정 권장). */
+  apiKey?: string;
+  /** 서버 바인드 호스트 — 무인증+비-로컬 바인드 시 경고 출력에 사용. */
+  hostname?: string;
+  readOnly: boolean;
+  sessionManager: SessionManager;
+  loginRateLimiter?: LoginRateLimiter;
+}
+
+/**
+ * 대시보드 인증 + readOnly 가드 셋업 (Plan C #C9 — 12단계).
+ *
+ * 이전: dashboard-api.ts 234-349 (~115줄). POST /api/auth 라우트 + 4개 미들웨어
+ *      (bearerAuth/sseTokenAuth/healSseKeyAuth/readOnlyGuard)가 if/else 블록에 섞여 있었다.
+ * 이후: 본 함수가 단일 진입점. dashboard-api.ts는 setupAuth(api, ctx) 한 줄로 위임.
+ *
+ * 동작:
+ *  - apiKey 설정 시: POST /api/auth(세션 토큰 발급) + bearerAuth(/api/*) +
+ *                    sseTokenAuth(/api/events, /api/jobs/:id/logs/stream) +
+ *                    healSseKeyAuth(/api/doctor/heal/:id/stream)
+ *  - apiKey 미설정 시:
+ *    - readOnly 모드: 쓰기 엔드포인트(config/projects/jobs/update/new-issue)에 readOnlyGuard
+ *    - readOnly 아님 + 로컬 바인드: 정보 로그
+ *    - readOnly 아님 + 비-로컬 바인드: 보안 위험 경고 로그
+ */
+export function setupAuth(api: Hono, ctx: AuthSetupContext): void {
+  const { apiKey, hostname, readOnly, sessionManager, loginRateLimiter } = ctx;
+
+  if (apiKey) {
+    // POST /api/auth — Bearer key를 짧은 수명 세션 토큰으로 교환
+    api.post("/api/auth", (c) => {
+      const ip =
+        c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+        ((c.env as Record<string, unknown> | undefined)?.["remoteAddress"] as string | undefined) ??
+        "unknown";
+
+      const rateLimitCheck = loginRateLimiter?.checkAndRecord(ip);
+      if (rateLimitCheck && !rateLimitCheck.allowed) {
+        const retryAfterSec = Math.ceil((rateLimitCheck.retryAfterMs ?? 900_000) / 1000);
+        getLogger().warn(`[Auth] Rate limit exceeded for IP ${ip}`);
+        return c.json(
+          { error: "Too Many Requests" },
+          429,
+          { "Retry-After": String(retryAfterSec) }
+        );
+      }
+
+      const auth = c.req.header("Authorization");
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      loginRateLimiter?.reset(ip);
+      const { token, expiresIn } = sessionManager.createToken();
+      return c.json({ token, expiresIn });
+    });
+
+    // Bearer 헤더 미들웨어 — 일반 (non-SSE) /api/* 라우트
+    // Deny-by-default: 공용 + SSE 경로 외 모든 요청에 인증 요구
+    const bearerAuth = async (c: Context, next: Next) => {
+      const path = c.req.path;
+      if (path === "/api/auth") {
+        await next();
+        return;
+      }
+      if (
+        path === "/api/events" ||
+        /^\/api\/jobs\/[^/]+\/logs\/stream$/.test(path) ||
+        /^\/api\/doctor\/heal\/[^/]+\/stream$/.test(path)
+      ) {
+        await next();
+        return;
+      }
+      const auth = c.req.header("Authorization");
+      const expected = Buffer.from(`Bearer ${apiKey}`);
+      const actual = Buffer.from(auth ?? "");
+      if (!auth || actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+
+    api.use("/api/*", bearerAuth);
+
+    // SSE 엔드포인트 — ?token= 쿼리 파람으로 짧은 수명 세션 토큰 검증
+    const sseTokenAuth = async (c: Context, next: Next) => {
+      const token = c.req.query("token");
+      if (!token || !sessionManager.validate(token)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+
+    api.use("/api/events", sseTokenAuth);
+    api.use("/api/jobs/:id/logs/stream", sseTokenAuth);
+
+    // Doctor heal SSE — EventSource는 헤더를 못 보내므로 ?key= 쿼리 파람으로 raw API key 검증
+    const healSseKeyAuth = async (c: Context, next: Next) => {
+      const key = c.req.query("key");
+      if (!key) return c.json({ error: "Unauthorized" }, 401);
+      const expected = Buffer.from(apiKey);
+      const actual = Buffer.from(key);
+      if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+      await next();
+    };
+    api.use("/api/doctor/heal/:id/stream", healSseKeyAuth);
+  } else {
+    // apiKey 미설정 — 바인드 호스트와 readOnly 여부에 따라 분기
+    const isLocalBind = !hostname || hostname === "127.0.0.1" || hostname === "localhost";
+
+    if (readOnly) {
+      // readOnly 모드: 쓰기 엔드포인트에 403 반환
+      const readOnlyGuard = async (c: Context, next: Next) => {
+        if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+          return c.json({ error: "Forbidden: dashboard is in read-only mode" }, 403);
+        }
+        await next();
+      };
+      api.use("/api/config", readOnlyGuard);
+      api.use("/api/projects", readOnlyGuard);
+      api.use("/api/projects/*", readOnlyGuard);
+      api.use("/api/jobs/*", readOnlyGuard);
+      api.use("/api/update", readOnlyGuard);
+      api.use("/api/new-issue", readOnlyGuard);
+      getLogger().info(
+        "Dashboard is running in read-only mode. Write endpoints are disabled." +
+        (!isLocalBind ? " Non-local bind is permitted in read-only mode." : "")
+      );
+    } else if (isLocalBind) {
+      getLogger().info(
+        "Dashboard API key is not configured. All endpoints are accessible without authentication."
+      );
+    } else {
+      getLogger().warn(
+        "Dashboard API key is not configured. All endpoints are accessible without authentication. " +
+        "Non-local bind without API key is a security risk."
+      );
+    }
+  }
+}

--- a/src/server/routes/config.ts
+++ b/src/server/routes/config.ts
@@ -1,0 +1,117 @@
+import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { SSEManager } from "../sse-manager.js";
+import type { AQConfig } from "../../types/config.js";
+import { safeError } from "../route-context.js";
+import { loadConfig, updateConfigSection } from "../../config/loader.js";
+import { maskSensitiveConfig } from "../../utils/config-masker.js";
+import { getBasicFieldMetas } from "../../config/schema-meta.js";
+import { getPresets } from "../../config/presets.js";
+import { UpdateConfigRequestSchema } from "../../types/api.js";
+import { zodValidationHook } from "../dashboard-api.js";
+import { setGlobalLogLevel, getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+export interface ConfigRouteContext {
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+}
+
+/**
+ * /api/config/* 라우트 등록 (Plan C #C9 — 6단계).
+ *
+ * 이전: dashboard-api.ts 524-601 (4 routes, 78줄).
+ * GET /api/config는 마스킹된 설정을 반환하고, PUT은 업데이트 후 런타임 적용 +
+ * SSE 브로드캐스트까지 수행한다.
+ */
+export function registerConfigRoutes(api: Hono, ctx: ConfigRouteContext): void {
+  const { queue, sseManager, configWatcher, rootDir } = ctx;
+
+  // Get configuration (masked for security)
+  api.get("/api/config", (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const maskedConfig = maskSensitiveConfig(config);
+      return c.json({ config: maskedConfig });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to load configuration");
+    }
+  });
+
+  // Get Basic tab field metadata (type, default, min/max, options)
+  api.get("/api/config/schema-meta", (c) => {
+    return c.json({ fields: getBasicFieldMetas() });
+  });
+
+  // Get config presets list
+  api.get("/api/config/presets", (c) => {
+    return c.json({ presets: getPresets() });
+  });
+
+  // Update configuration
+  api.put(
+    "/api/config",
+    zValidator("json", UpdateConfigRequestSchema.passthrough(), zodValidationHook),
+    async (c) => {
+      try {
+        const body = c.req.valid("json");
+
+        // Filter out undefined values and complex sections (projects).
+        // hooks는 passthrough 스키마로 통과되어 config에 저장된다.
+        const { projects: _projects, ...safeData } = body as Record<string, unknown>;
+        const cleanedData = Object.fromEntries(
+          Object.entries(safeData)
+            .map(([key, value]) => [
+              key,
+              typeof value === "object" && value !== null
+                ? Object.fromEntries(
+                    Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined)
+                  )
+                : value,
+            ])
+            .filter(([, v]) => v !== undefined)
+        ) as Partial<AQConfig>;
+
+        updateConfigSection(rootDir, cleanedData);
+        configWatcher?.refresh();
+
+        if (configWatcher) {
+          try {
+            const newConfig = configWatcher.current();
+
+            if (body.general?.concurrency !== undefined) {
+              queue.setConcurrency(newConfig.general.concurrency);
+            }
+            if (body.general?.logLevel !== undefined) {
+              setGlobalLogLevel(newConfig.general.logLevel);
+            }
+
+            sseManager.broadcast("configChanged", {
+              changes: body,
+              timestamp: new Date().toISOString(),
+            });
+          } catch (runtimeError: unknown) {
+            // 런타임 적용 실패는 요청 자체를 실패로 만들지 않는다 — 경고만 남기고 응답은 success.
+            getLogger().warn(`Failed to apply runtime config changes: ${getErrorMessage(runtimeError)}`);
+          }
+        }
+
+        return c.json({ success: true, message: "Configuration updated successfully" });
+      } catch (error: unknown) {
+        const rawMessage = getErrorMessage(error);
+        const isValidationError =
+          rawMessage.includes("validation") ||
+          rawMessage.includes("Invalid") ||
+          rawMessage.includes("not found");
+        const status = isValidationError ? 400 : 500;
+        const prefix = isValidationError ? "Configuration validation failed" : "Failed to update configuration";
+        return c.json({ error: `${prefix}: ${sanitizeErrorMessage(rawMessage)}` }, status);
+      }
+    }
+  );
+}

--- a/src/server/routes/doctor.ts
+++ b/src/server/routes/doctor.ts
@@ -1,0 +1,91 @@
+import type { Hono } from "hono";
+import { safeError } from "../route-context.js";
+import { runAllChecks } from "../../doctor/checks.js";
+import { healLevel1, healLevel2, writeToActiveHealProcess } from "../../doctor/heal.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+/**
+ * /api/doctor/* 라우트 등록 (Plan C #C9 — 8단계).
+ *
+ * 이전: dashboard-api.ts 977-1052 (4 routes, ~75줄).
+ * 의존성이 doctor 모듈에 한정되어 ctx 인자가 없다.
+ */
+export function registerDoctorRoutes(api: Hono): void {
+  api.get("/api/doctor/run", async (c) => {
+    try {
+      const checks = await runAllChecks();
+      return c.json({ checks });
+    } catch (error: unknown) {
+      return safeError(c, error, "Doctor run failed");
+    }
+  });
+
+  // POST /api/doctor/heal/stdin — stdin bridge for active Level2 process.
+  // Declared BEFORE :id route so "stdin" is not captured as checkId.
+  api.post("/api/doctor/heal/stdin", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as Record<string, unknown> | null;
+    const input = typeof body?.input === "string" ? body.input : null;
+    if (input === null) {
+      return c.json({ error: "Missing 'input' field" }, 400);
+    }
+    const ok = writeToActiveHealProcess(input);
+    if (!ok) {
+      return c.json({ error: "No active heal process" }, 404);
+    }
+    return c.json({ ok: true });
+  });
+
+  // POST /api/doctor/heal/:id — Level1 auto-fix (runs autoFixCommand, waits for completion)
+  api.post("/api/doctor/heal/:id", async (c) => {
+    const checkId = c.req.param("id");
+    try {
+      const result = await healLevel1(checkId);
+      return c.json({ ok: true, stdout: result.stdout, stderr: result.stderr });
+    } catch (error: unknown) {
+      return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
+    }
+  });
+
+  // GET /api/doctor/heal/:id/stream — Level2 SSE streaming (spawn + stdout/stderr bridge)
+  api.get("/api/doctor/heal/:id/stream", (c) => {
+    const checkId = c.req.param("id");
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream({
+      start(controller) {
+        healLevel2(checkId, {
+          onData(chunk) {
+            try {
+              for (const line of chunk.split("\n")) {
+                if (line.length > 0) {
+                  controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+                }
+              }
+            } catch { /* stream closed */ }
+          },
+          onDone() {
+            try {
+              controller.enqueue(encoder.encode(`event: done\ndata: \n\n`));
+              controller.close();
+            } catch { /* already closed */ }
+          },
+          onFail(msg) {
+            try {
+              controller.enqueue(encoder.encode(`event: fail\ndata: ${msg}\n\n`));
+              controller.close();
+            } catch { /* already closed */ }
+          },
+        });
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      },
+    });
+  });
+}

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -1,0 +1,251 @@
+import type { Hono } from "hono";
+import { resolve } from "path";
+import type { JobStore } from "../../queue/job-store.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { HealthCheckResponse } from "../../types/api.js";
+import { safeError } from "../route-context.js";
+import { loadConfig } from "../../config/loader.js";
+import { getProjectSummary } from "../../store/queries.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import {
+  checkGitRemoteAccess,
+  checkLocalPath,
+  checkDiskSpace,
+  checkDependencies,
+} from "../health-checks.js";
+
+export interface HealthRouteContext {
+  store: JobStore;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+}
+
+/**
+ * 프로젝트 헬스 체크 결과 — repositories/projects-health/health 세 라우트가 공통으로 사용.
+ */
+type CheckResults = {
+  gitRemoteCheck: Awaited<ReturnType<typeof checkGitRemoteAccess>>;
+  localPathCheck: Awaited<ReturnType<typeof checkLocalPath>>;
+  diskSpaceCheck: Awaited<ReturnType<typeof checkDiskSpace>>;
+  dependenciesCheck: Awaited<ReturnType<typeof checkDependencies>>;
+};
+
+function deriveOverallStatus(c: CheckResults): "healthy" | "warning" | "error" {
+  if (c.gitRemoteCheck.status === "error" || c.localPathCheck.status === "error") {
+    return "error";
+  }
+  if (
+    c.diskSpaceCheck.status === "warning" ||
+    c.diskSpaceCheck.status === "error" ||
+    c.dependenciesCheck.status === "warning" ||
+    c.dependenciesCheck.status === "error"
+  ) {
+    return "warning";
+  }
+  return "healthy";
+}
+
+async function runProjectChecks(projectPath: string, gitPath: string): Promise<CheckResults> {
+  const [gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck] = await Promise.all([
+    checkGitRemoteAccess(projectPath, gitPath),
+    checkLocalPath(projectPath),
+    checkDiskSpace(projectPath),
+    checkDependencies(projectPath),
+  ]);
+  return { gitRemoteCheck, localPathCheck, diskSpaceCheck, dependenciesCheck };
+}
+
+/**
+ * /api/repositories, /api/projects/health, /api/health 라우트 등록 (Plan C #C9 — 9단계).
+ *
+ * 이전: dashboard-api.ts 711-940 (3 routes, ~230줄). 4개 검사 헬퍼는 인라인.
+ * 이후: 헬퍼는 src/server/health-checks.ts로 추출, 라우트는 본 파일로 응집.
+ *      runProjectChecks/deriveOverallStatus 헬퍼로 3개 라우트의 중복도 정리.
+ */
+export function registerHealthRoutes(api: Hono, ctx: HealthRouteContext): void {
+  const { store, configWatcher, rootDir } = ctx;
+
+  // Repositories — project-level aggregated info with health + stats
+  api.get("/api/repositories", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projects = config.projects ?? [];
+
+      if (projects.length === 0) {
+        return c.json({
+          repositories: [],
+          summary: { total: 0, healthy: 0, warning: 0, error: 0, totalJobs: 0, checkedAt: new Date().toISOString() },
+        });
+      }
+
+      const gitPath = config.git?.gitPath ?? "git";
+
+      const healthResults = await Promise.all(
+        projects.map(async (projectConfig) => {
+          const projectPath = resolve(rootDir, projectConfig.path);
+          const checks = await runProjectChecks(projectPath, gitPath);
+          const worktreeCount = await runCli(gitPath, ["worktree", "list", "--porcelain"], { cwd: projectPath })
+            .then((result) =>
+              result.exitCode === 0
+                ? result.stdout.trim().split("\n").filter((line) => line.startsWith("worktree ")).length
+                : 0
+            )
+            .catch(() => 0);
+
+          return {
+            repository: projectConfig.repo,
+            name: projectConfig.repo,
+            path: projectConfig.path,
+            status: deriveOverallStatus(checks),
+            worktreeCount,
+            health: {
+              gitRemoteAccess: checks.gitRemoteCheck,
+              localPath: checks.localPathCheck,
+              diskSpace: checks.diskSpaceCheck,
+              dependencies: checks.dependenciesCheck,
+            },
+            lastChecked: new Date().toISOString(),
+          };
+        })
+      );
+
+      const projectStats = getProjectSummary(store.getAqDb());
+      const statsMap = new Map(projectStats.map((s) => [s.repo, s]));
+
+      const repositories = healthResults.map((result) => {
+        const stats = statsMap.get(result.repository) ?? {
+          repo: result.repository,
+          total: 0,
+          successCount: 0,
+          failureCount: 0,
+          totalCostUsd: 0,
+          successRate: 0,
+          lastActivity: null,
+        };
+
+        return {
+          ...result,
+          stats: {
+            totalJobs: stats.total,
+            successJobs: stats.successCount,
+            failedJobs: stats.failureCount,
+            successRate: stats.successRate,
+            totalCostUsd: stats.totalCostUsd,
+            lastActivity: stats.lastActivity,
+          },
+        };
+      });
+
+      const summary = {
+        total: repositories.length,
+        healthy: repositories.filter((r) => r.status === "healthy").length,
+        warning: repositories.filter((r) => r.status === "warning").length,
+        error: repositories.filter((r) => r.status === "error").length,
+        totalJobs: repositories.reduce((sum, r) => sum + r.stats.totalJobs, 0),
+        checkedAt: new Date().toISOString(),
+      };
+
+      return c.json({ repositories, summary });
+    } catch (error: unknown) {
+      getLogger().error(`Failed to fetch repositories: ${getErrorMessage(error)}`);
+      return c.json({ error: "Failed to fetch repositories" }, 500);
+    }
+  });
+
+  // Projects health — all configured projects
+  api.get("/api/projects/health", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projects = config.projects ?? [];
+
+      if (projects.length === 0) {
+        return c.json({
+          projects: [],
+          summary: { total: 0, healthy: 0, warning: 0, error: 0, checkedAt: new Date().toISOString() },
+        });
+      }
+
+      const gitPath = config.git?.gitPath ?? "git";
+
+      const healthResults = await Promise.all(
+        projects.map(async (projectConfig) => {
+          const projectPath = resolve(rootDir, projectConfig.path);
+          const checks = await runProjectChecks(projectPath, gitPath);
+
+          return {
+            project: projectConfig.repo,
+            status: deriveOverallStatus(checks),
+            checks: {
+              gitRemoteAccess: checks.gitRemoteCheck,
+              localPath: checks.localPathCheck,
+              diskSpace: checks.diskSpaceCheck,
+              dependencies: checks.dependenciesCheck,
+            },
+            lastChecked: new Date().toISOString(),
+          };
+        })
+      );
+
+      const projectStats = getProjectSummary(store.getAqDb());
+      const statsMap = new Map(projectStats.map((s) => [s.repo, s]));
+
+      const projectsWithStats = healthResults.map((result) => ({
+        ...result,
+        stats: statsMap.get(result.project) ?? null,
+      }));
+
+      const summary = {
+        total: projectsWithStats.length,
+        healthy: projectsWithStats.filter((p) => p.status === "healthy").length,
+        warning: projectsWithStats.filter((p) => p.status === "warning").length,
+        error: projectsWithStats.filter((p) => p.status === "error").length,
+        checkedAt: new Date().toISOString(),
+      };
+
+      return c.json({ projects: projectsWithStats, summary });
+    } catch (error: unknown) {
+      return safeError(c, error, "Projects health check failed");
+    }
+  });
+
+  // Single project health (with ?project= query param)
+  api.get("/api/health", async (c) => {
+    try {
+      const projectParam = c.req.query("project");
+      if (!projectParam) {
+        return c.json({ error: "project parameter is required" }, 400);
+      }
+
+      const project = decodeURIComponent(projectParam);
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const projectConfig = config.projects?.find((p) => p.repo === project);
+
+      if (!projectConfig) {
+        return c.json({ error: `Project "${project}" not found in configuration` }, 404);
+      }
+
+      const projectPath = resolve(rootDir, projectConfig.path);
+      const gitPath = config.git?.gitPath || "git";
+
+      const checks = await runProjectChecks(projectPath, gitPath);
+
+      const healthResponse: HealthCheckResponse = {
+        project,
+        status: deriveOverallStatus(checks),
+        checks: {
+          gitRemoteAccess: checks.gitRemoteCheck,
+          localPath: checks.localPathCheck,
+          diskSpace: checks.diskSpaceCheck,
+          dependencies: checks.dependenciesCheck,
+        },
+        lastChecked: new Date().toISOString(),
+      };
+
+      return c.json(healthResponse);
+    } catch (error: unknown) {
+      return safeError(c, error, "Health check failed");
+    }
+  });
+}

--- a/src/server/routes/jobs.ts
+++ b/src/server/routes/jobs.ts
@@ -1,0 +1,154 @@
+import type { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import type { JobStore, ListJobsOptions } from "../../queue/job-store.js";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { SSEManager } from "../sse-manager.js";
+import { safeError } from "../route-context.js";
+import {
+  GetJobsQuerySchema,
+  CancelJobRequestSchema,
+  UpdateJobPriorityRequestSchema,
+  RetryJobRequestSchema,
+  formatZodError,
+} from "../../types/api.js";
+import { zodValidationHook } from "../dashboard-api.js";
+
+export interface JobsRouteContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+}
+
+/**
+ * /api/jobs/* CRUD + cancel + priority + retry 라우트 등록 (Plan C #C9 — 4단계).
+ *
+ * 이전: dashboard-api.ts 605-705 (5 routes) + 1003-1015 (retry).
+ * 비포함: /api/jobs/:id/logs/stream (SSE, sse.ts에서 처리), /api/skip-events/* (별도 도메인).
+ */
+export function registerJobsRoutes(api: Hono, ctx: JobsRouteContext): void {
+  const { store, queue, sseManager } = ctx;
+
+  // List all jobs (exclude archived by default, ?include=archived to show)
+  api.get("/api/jobs", (c) => {
+    try {
+      const queryParamsForValidation = {
+        project: c.req.query("project"),
+        status: c.req.query("status"),
+        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
+        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
+      };
+      const includeArchived = c.req.query("include") === "archived";
+
+      const parseResult = GetJobsQuerySchema.safeParse(queryParamsForValidation);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error),
+        }, 400);
+      }
+
+      const { project, status, limit, offset } = parseResult.data;
+
+      const baseOptions: ListJobsOptions = {};
+      if (!includeArchived) baseOptions.excludeStatus = "archived";
+      if (project) baseOptions.repo = project;
+
+      // API status → 내부 JobStatus 매핑
+      if (status === "pending") {
+        baseOptions.status = "queued";
+      } else if (status === "running") {
+        baseOptions.status = "running";
+      } else if (status === "completed") {
+        baseOptions.status = "success";
+      } else if (status === "failed") {
+        baseOptions.statuses = ["failure", "cancelled"];
+      }
+
+      const totalJobs = store.list(baseOptions).length;
+      const jobs = store.list({ ...baseOptions, limit, offset });
+      const queueStatus = queue.getStatus();
+
+      return c.json({
+        jobs,
+        queue: queueStatus,
+        pagination: {
+          total: totalJobs,
+          offset: offset ?? 0,
+          limit: limit ?? totalJobs,
+          hasMore: (offset ?? 0) + (limit ?? totalJobs) < totalJobs,
+        },
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch jobs");
+    }
+  });
+
+  // Get single job
+  api.get("/api/jobs/:id", (c) => {
+    const job = store.get(c.req.param("id"));
+    if (!job) return c.json({ error: "Job not found" }, 404);
+    return c.json(job);
+  });
+
+  // Cancel a job
+  api.post(
+    "/api/jobs/:id/cancel",
+    zValidator("json", CancelJobRequestSchema, zodValidationHook),
+    (c) => {
+      const id = c.req.param("id") ?? "";
+      const cancelled = queue.cancel(id);
+      if (!cancelled) return c.json({ error: "Job not found or not cancellable" }, 404);
+      return c.json({ status: "cancelled", id });
+    }
+  );
+
+  // Update job priority
+  api.put(
+    "/api/jobs/:id/priority",
+    zValidator("json", UpdateJobPriorityRequestSchema, zodValidationHook),
+    async (c) => {
+      const id = c.req.param("id") ?? "";
+      const job = store.get(id);
+      if (!job) return c.json({ error: "Job not found" }, 404);
+
+      const { priority } = c.req.valid("json");
+      const updatedJob = store.update(id, { priority });
+      if (!updatedJob) return c.json({ error: "Failed to update priority" }, 500);
+
+      sseManager.broadcast("job-updated", updatedJob);
+      return c.json(updatedJob);
+    }
+  );
+
+  // Delete a completed/failed job
+  api.delete("/api/jobs/:id", (c) => {
+    const id = c.req.param("id");
+    const job = store.get(id);
+    if (!job) return c.json({ error: "Job not found" }, 404);
+    if (job.status === "queued" || job.status === "running") {
+      return c.json({ error: "Cannot delete active job. Cancel it first." }, 400);
+    }
+    const deleted = store.remove(id);
+    if (!deleted) return c.json({ error: "Failed to delete" }, 500);
+    return c.json({ status: "deleted", id });
+  });
+
+  // Retry a failed job
+  api.post(
+    "/api/jobs/:id/retry",
+    zValidator("json", RetryJobRequestSchema, zodValidationHook),
+    async (c) => {
+      const id = c.req.param("id") ?? "";
+      const job = store.get(id);
+      if (!job) return c.json({ error: "Job not found" }, 404);
+      if (job.status !== "failure" && job.status !== "cancelled") {
+        return c.json({ error: "Only failed or cancelled jobs can be retried" }, 400);
+      }
+      const newJob = await queue.retryJob(id);
+      if (!newJob) {
+        return c.json({ error: "Failed to retry job" }, 500);
+      }
+      return c.json({ status: "queued", id: newJob.id });
+    }
+  );
+}

--- a/src/server/routes/new-issue.ts
+++ b/src/server/routes/new-issue.ts
@@ -1,0 +1,67 @@
+import type { Hono } from "hono";
+import { resolve } from "path";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { safeError } from "../route-context.js";
+import { zodValidationHook } from "../dashboard-api.js";
+import { loadTemplate, renderTemplate } from "../../prompt/template-renderer.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+export interface NewIssueRouteContext {
+  rootDir: string;
+}
+
+const NewIssueRequestSchema = z.object({
+  category: z.enum(["bug", "feature", "refactor", "docs"]),
+  title: z.string().min(1),
+  repo: z.string().min(1),
+  what: z.string().min(1),
+  where: z.string().default(""),
+  how: z.string().default(""),
+  files: z.string().default(""),
+});
+
+/**
+ * POST /api/new-issue 라우트 등록 (Plan C #C9 — 10단계).
+ *
+ * 이전: dashboard-api.ts 621-652. 카테고리별 템플릿(prompts/issue-templates/*.md)을
+ *      렌더링한 뒤 `gh issue create`로 GitHub 이슈를 생성한다.
+ */
+export function registerNewIssueRoute(api: Hono, ctx: NewIssueRouteContext): void {
+  const { rootDir } = ctx;
+
+  api.post("/api/new-issue", zValidator("json", NewIssueRequestSchema, zodValidationHook), async (c) => {
+    const logger = getLogger();
+    try {
+      const { category, title, repo, what, where, how, files } = c.req.valid("json");
+
+      const templatesDir = resolve(rootDir, "prompts/issue-templates");
+      const templatePath = resolve(templatesDir, `${category}.md`);
+      const template = loadTemplate(templatePath, templatesDir);
+      const body = renderTemplate(template, { what, where, how, files });
+
+      const result = await runCli("gh", [
+        "issue", "create",
+        "--repo", repo,
+        "--title", title,
+        "--body", body,
+        "--label", "aqm-by",
+      ]);
+
+      if (result.exitCode !== 0) {
+        return c.json({ error: `Failed to create issue: ${sanitizeErrorMessage(result.stderr)}` }, 500);
+      }
+
+      const url = result.stdout.trim();
+      const numberMatch = url.match(/\/issues\/(\d+)$/);
+      const number = numberMatch ? parseInt(numberMatch[1], 10) : undefined;
+
+      logger.info(`New issue created: ${url}`);
+      return c.json({ url, number });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to create issue");
+    }
+  });
+}

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -1,0 +1,164 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import type { SSEManager } from "../sse-manager.js";
+import { safeError } from "../route-context.js";
+import { GetNotificationsQuerySchema, formatZodError } from "../../types/api.js";
+
+export interface NotificationsRouteContext {
+  store: JobStore;
+  sseManager: SSEManager;
+  readOnly: boolean;
+}
+
+/**
+ * /api/notifications/* 라우트 등록 (Plan C #C9 — 1단계).
+ *
+ * 이전: dashboard-api.ts 1973-2117 (145줄, 7 routes).
+ * 이후: 본 파일이 단일 책임으로 캡슐화. dashboard-api.ts의 createDashboardRoutes는
+ *      `registerNotificationsRoutes(api, { store, sseManager, readOnly })`만 호출.
+ */
+export function registerNotificationsRoutes(api: Hono, ctx: NotificationsRouteContext): void {
+  const { store, sseManager, readOnly } = ctx;
+
+  api.get("/api/notifications/unread-count", (c) => {
+    try {
+      const unreadCount = store.getAqDb().countUnreadNotifications();
+      return c.json({ unreadCount });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch unread count");
+    }
+  });
+
+  api.get("/api/notifications", (c) => {
+    try {
+      const queryParams = {
+        isRead: c.req.query("isRead"),
+        type: c.req.query("type"),
+        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
+        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
+      };
+
+      const parseResult = GetNotificationsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error)
+        }, 400);
+      }
+
+      const { isRead, type: typeFilter, limit, offset } = parseResult.data;
+      const aqDb = store.getAqDb();
+      const isReadFilter = isRead === "true" ? true : isRead === "false" ? false : undefined;
+      const notifFilter: { isRead?: boolean; type?: string } = {};
+      if (isReadFilter !== undefined) notifFilter.isRead = isReadFilter;
+      if (typeFilter !== undefined) notifFilter.type = typeFilter;
+      const notifications = aqDb.listNotifications({ ...notifFilter, limit, offset });
+      const total = aqDb.countNotifications(notifFilter);
+      const unreadCount = aqDb.countUnreadNotifications();
+      const start = offset ?? 0;
+
+      return c.json({
+        notifications,
+        total,
+        unreadCount,
+        pagination: {
+          total,
+          offset: start,
+          limit: limit ?? total,
+          hasMore: start + notifications.length < total,
+        },
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch notifications");
+    }
+  });
+
+  // mark all as read (static route before :id/read)
+  api.post("/api/notifications/read-all", (c) => {
+    try {
+      const count = store.getAqDb().markAllNotificationsRead();
+      sseManager.broadcast("notificationsReadAll", { count, timestamp: Date.now() });
+      return c.json({ status: "ok", count });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to mark all notifications as read");
+    }
+  });
+
+  api.post("/api/notifications/:id/read", (c) => {
+    try {
+      const idParam = c.req.param("id");
+      const id = parseInt(idParam, 10);
+      if (isNaN(id) || id <= 0) {
+        return c.json({ error: "Invalid notification id" }, 400);
+      }
+      const updated = store.getAqDb().markNotificationRead(id);
+      if (!updated) {
+        return c.json({ error: "Notification not found" }, 404);
+      }
+      return c.json({ status: "ok", id });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to mark notification as read");
+    }
+  });
+
+  // prune read notifications older than maxAgeDays (default 14)
+  api.post("/api/notifications/prune", async (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      let maxAgeDays = 14;
+      try {
+        const body = await c.req.json<{ maxAgeDays?: unknown }>();
+        if (typeof body?.maxAgeDays === "number" && body.maxAgeDays > 0) {
+          maxAgeDays = Math.floor(body.maxAgeDays);
+        }
+      } catch {
+        // body 없음 → 기본값 14일
+      }
+      const deleted = store.pruneReadNotifications(maxAgeDays);
+      sseManager.broadcast("notificationsPruned", { deleted, maxAgeDays, timestamp: Date.now() });
+      return c.json({ deleted, maxAgeDays });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to prune notifications");
+    }
+  });
+
+  // delete all (옵션으로 isRead 필터)
+  api.delete("/api/notifications", (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const isReadParam = c.req.query("isRead");
+      const filter: { isRead?: boolean } = {};
+      if (isReadParam === "true") filter.isRead = true;
+      else if (isReadParam === "false") filter.isRead = false;
+      const deleted = store.deleteAllNotifications(filter);
+      sseManager.broadcast("notificationsDeleted", { deleted, timestamp: Date.now() });
+      return c.json({ deleted });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete notifications");
+    }
+  });
+
+  api.delete("/api/notifications/:id", (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const idParam = c.req.param("id");
+      const id = parseInt(idParam, 10);
+      if (isNaN(id) || id <= 0) {
+        return c.json({ error: "Invalid notification id" }, 400);
+      }
+      const deleted = store.deleteNotification(id);
+      if (!deleted) {
+        return c.json({ error: "Notification not found" }, 404);
+      }
+      return c.json({ status: "ok", id });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete notification");
+    }
+  });
+}

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -1,0 +1,298 @@
+import type { Hono } from "hono";
+import { normalize } from "path";
+import { zValidator } from "@hono/zod-validator";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { ProjectConfig } from "../../types/config.js";
+import { safeError, type DashboardContext } from "../route-context.js";
+import {
+  loadConfig,
+  addProjectToConfig,
+  removeProjectFromConfig,
+  updateProjectInConfig,
+} from "../../config/loader.js";
+import { validateConfig } from "../../config/validator.js";
+import { CreateProjectRequestSchema, UpdateProjectRequestSchema } from "../../types/api.js";
+import { zodValidationHook } from "../dashboard-api.js";
+import { detectProjectCommands, detectBaseBranch } from "../../config/project-detector.js";
+import { isPathSafe } from "../../utils/slug.js";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+export interface ProjectsRouteContext {
+  queue: JobQueue;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+  configPath: string;
+}
+
+/**
+ * /api/projects/* 라우트 등록 (Plan C #C9 — 3단계).
+ *
+ * 이전: dashboard-api.ts 624-867 (7 routes, ~245줄).
+ * 이후: 본 파일이 캡슐화. validateAndNormalizePath 헬퍼는 projects 전용이므로 함께 이동.
+ *
+ * 비포함: /api/projects/health (1446-) — 인라인 health-check 헬퍼 의존성으로 별도 단계.
+ */
+function validateAndNormalizePath(path: string, paramName: string): string {
+  if (!path || typeof path !== "string") {
+    throw new Error(`${paramName} is required and must be a string`);
+  }
+
+  const trimmedPath = path.trim();
+  if (!isPathSafe(trimmedPath)) {
+    throw new Error(`${paramName} contains unsafe characters or path traversal patterns`);
+  }
+  return normalize(trimmedPath);
+}
+
+export function registerProjectsRoutes(api: Hono, ctx: ProjectsRouteContext): void {
+  const { queue, configWatcher, rootDir, configPath } = ctx;
+
+  // List projects
+  api.get("/api/projects", (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+
+      if (!config.projects || config.projects.length === 0) {
+        return c.json({ projects: [] });
+      }
+
+      const projects = config.projects.map((project) => ({
+        ...project,
+        errorState: queue.getProjectStatus(project.repo),
+      }));
+
+      return c.json({ projects });
+    } catch (error: unknown) {
+      getLogger().error(`Failed to load projects: ${getErrorMessage(error)}`);
+      return c.json({ error: "Failed to load projects" }, 500);
+    }
+  });
+
+  // Add project
+  api.post(
+    "/api/projects",
+    zValidator("json", CreateProjectRequestSchema, zodValidationHook),
+    async (c) => {
+      try {
+        const { repo, path, baseBranch, mode, commands } = c.req.valid("json");
+
+        let normalizedPath: string;
+        try {
+          normalizedPath = validateAndNormalizePath(path, "path");
+        } catch (error: unknown) {
+          return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
+        }
+
+        const detection = detectProjectCommands(normalizedPath);
+        const resolvedBaseBranch = baseBranch?.trim() || (await detectBaseBranch(normalizedPath));
+
+        const project: ProjectConfig = {
+          repo: repo.trim(),
+          path: normalizedPath,
+          baseBranch: resolvedBaseBranch,
+          mode,
+          commands: commands ?? detection.commands,
+        };
+
+        try {
+          const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
+          if (currentConfig.projects?.find((p) => p.repo === project.repo)) {
+            return c.json({ error: `Project "${project.repo}" already exists` }, 409);
+          }
+        } catch {
+          // Config doesn't exist yet, proceed
+        }
+
+        addProjectToConfig(configPath, project);
+        configWatcher?.refresh();
+
+        try {
+          validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
+        } catch (error: unknown) {
+          return safeError(c, error, "Configuration validation failed", 400);
+        }
+
+        return c.json(
+          {
+            message: "Project added successfully",
+            project,
+            detectedLanguage: detection.language,
+          },
+          201
+        );
+      } catch (error: unknown) {
+        return safeError(c, error, "Failed to add project");
+      }
+    }
+  );
+
+  // Remove project
+  api.delete("/api/projects/:repo", (c) => {
+    try {
+      const repo = decodeURIComponent(c.req.param("repo"));
+
+      if (!repo || repo.trim() === "") {
+        return c.json({ error: "repo parameter is required" }, 400);
+      }
+
+      try {
+        const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
+        if (!currentConfig.projects?.find((p) => p.repo === repo)) {
+          return c.json({ error: `Project "${repo}" not found` }, 404);
+        }
+      } catch (error: unknown) {
+        return safeError(c, error, "Failed to load configuration");
+      }
+
+      removeProjectFromConfig(configPath, repo);
+      configWatcher?.refresh();
+
+      try {
+        validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
+      } catch (error: unknown) {
+        return safeError(c, error, "Configuration validation failed", 400);
+      }
+
+      return c.json({ message: "Project removed successfully", repo });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to remove project");
+    }
+  });
+
+  // Update project
+  api.put(
+    "/api/projects/:repo",
+    zValidator("json", UpdateProjectRequestSchema, zodValidationHook),
+    async (c) => {
+      try {
+        const repo = decodeURIComponent(c.req.param("repo") ?? "");
+
+        if (!repo || repo.trim() === "") {
+          return c.json({ error: "repo parameter is required" }, 400);
+        }
+
+        try {
+          const currentConfig = configWatcher?.current() ?? loadConfig(rootDir);
+          if (!currentConfig.projects?.find((p) => p.repo === repo)) {
+            return c.json({ error: `Project "${repo}" not found` }, 404);
+          }
+        } catch (error: unknown) {
+          return safeError(c, error, "Failed to load configuration");
+        }
+
+        const { path, baseBranch, mode, commands } = c.req.valid("json");
+        const updates: Partial<Pick<ProjectConfig, "path" | "baseBranch" | "mode" | "commands">> = {};
+
+        if (path !== undefined) {
+          try {
+            updates.path = validateAndNormalizePath(path, "path");
+          } catch (error: unknown) {
+            return c.json({ error: sanitizeErrorMessage(getErrorMessage(error)) }, 400);
+          }
+        }
+
+        if (baseBranch !== undefined) {
+          updates.baseBranch = baseBranch?.trim() || undefined;
+        }
+
+        if (mode !== undefined) {
+          updates.mode = mode ?? undefined;
+        }
+
+        if (commands !== undefined) {
+          updates.commands = commands;
+        }
+
+        if (Object.keys(updates).length === 0) {
+          return c.json({ error: "No valid fields to update" }, 400);
+        }
+
+        updateProjectInConfig(configPath, repo, updates);
+        configWatcher?.refresh();
+
+        try {
+          validateConfig(configWatcher?.current() ?? loadConfig(rootDir));
+        } catch (error: unknown) {
+          return safeError(c, error, "Configuration validation failed", 400);
+        }
+
+        return c.json({ message: "Project updated successfully", repo, updates });
+      } catch (error: unknown) {
+        return safeError(c, error, "Failed to update project");
+      }
+    }
+  );
+
+  // Get project error state
+  api.get("/api/projects/:repo/error-state", (c) => {
+    try {
+      const repo = decodeURIComponent(c.req.param("repo"));
+
+      if (!repo || repo.trim() === "") {
+        return c.json({ error: "repo parameter is required" }, 400);
+      }
+
+      const errorState = queue.getProjectStatus(repo);
+      return c.json({ repo, errorState });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to get error state");
+    }
+  });
+
+  // Manually pause a project
+  api.post("/api/projects/:repo/pause", async (c) => {
+    try {
+      const repo = decodeURIComponent(c.req.param("repo"));
+
+      if (!repo || repo.trim() === "") {
+        return c.json({ error: "repo parameter is required" }, 400);
+      }
+
+      let durationMs: number | undefined;
+      try {
+        const body = (await c.req.json()) as Record<string, unknown>;
+        if (body.durationMs !== undefined) {
+          if (typeof body.durationMs !== "number" || body.durationMs <= 0) {
+            return c.json({ error: "durationMs must be a positive number" }, 400);
+          }
+          durationMs = body.durationMs;
+        }
+      } catch (err: unknown) {
+        getLogger().debug(`Optional body parse failed — using default: ${getErrorMessage(err)}`);
+      }
+
+      const effectiveDuration = durationMs ?? 30 * 60 * 1000; // 30 minutes
+      queue.pauseProject(repo, effectiveDuration);
+
+      return c.json({
+        message: `Project "${repo}" paused for ${Math.round(effectiveDuration / 1000)}s`,
+        repo,
+        pausedUntil: Date.now() + effectiveDuration,
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to pause project");
+    }
+  });
+
+  // Manually resume a paused project
+  api.post("/api/projects/:repo/resume", (c) => {
+    try {
+      const repo = decodeURIComponent(c.req.param("repo"));
+
+      if (!repo || repo.trim() === "") {
+        return c.json({ error: "repo parameter is required" }, 400);
+      }
+
+      queue.resumeProject(repo);
+      return c.json({ message: `Project "${repo}" resumed`, repo });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to resume project");
+    }
+  });
+}
+
+/** Re-export for convenience when callers already build a DashboardContext. */
+export type { DashboardContext };

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -1,0 +1,238 @@
+import type { Hono } from "hono";
+import { resolve, join } from "path";
+import { homedir } from "os";
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { safeError } from "../route-context.js";
+import { zodValidationHook } from "../dashboard-api.js";
+
+export interface SetupRouteContext {
+  rootDir: string;
+}
+
+const SetupPreviewBodySchema = z.object({
+  repo: z.string().min(1),
+  repoPath: z.string().min(1),
+  baseBranch: z.string().optional(),
+  mode: z.string().optional(),
+  token: z.string().optional(),
+});
+
+const SetupLabelsBodySchema = z.object({
+  repo: z.string().min(1),
+  token: z.string().min(1),
+  labels: z.array(z.string().min(1)).default(["aqm-by"]),
+});
+
+const GH_HEADERS_BASE = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "AI-Quartermaster",
+} as const;
+
+function generateSetupYaml(repo: string, repoPath: string, baseBranch?: string, mode?: string): string {
+  const projectLines = [
+    `  - repo: "${repo}"`,
+    `    path: "${repoPath}"`,
+  ];
+  if (baseBranch) projectLines.push(`    baseBranch: "${baseBranch}"`);
+  if (mode) projectLines.push(`    mode: "${mode}"`);
+  return `# AI Quartermaster 설정 파일\n# 전체 옵션은 docs/config-schema.md 참조\n\nprojects:\n${projectLines.join("\n")}\n`;
+}
+
+function computeYamlDiff(
+  existingYaml: string | null,
+  newYaml: string
+): { added: string[]; removed: string[]; unchanged: string[] } {
+  const newLines = newYaml.split("\n").filter((l) => l.trim());
+  if (!existingYaml) {
+    return { added: newLines, removed: [], unchanged: [] };
+  }
+  const existingLines = existingYaml.split("\n").filter((l) => l.trim());
+  const existingSet = new Set(existingLines);
+  const newSet = new Set(newLines);
+  return {
+    added: newLines.filter((l) => !existingSet.has(l)),
+    removed: existingLines.filter((l) => !newSet.has(l)),
+    unchanged: newLines.filter((l) => existingSet.has(l)),
+  };
+}
+
+/**
+ * /api/setup/* 라우트 등록 (Plan C #C9 — 7단계).
+ *
+ * 이전: dashboard-api.ts 927-1095 (5 routes, ~170줄) + 인라인 스키마/헬퍼.
+ * 셋업 위자드 흐름: validate-token → repos 목록 → labels 자동 생성 → preview → apply.
+ */
+export function registerSetupRoutes(api: Hono, ctx: SetupRouteContext): void {
+  const { rootDir } = ctx;
+
+  // Validate GitHub personal access token
+  api.get("/api/setup/validate-token", async (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
+    }
+
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) {
+      return c.json({ error: "Token must not be empty" }, 400);
+    }
+
+    try {
+      const response = await fetch("https://api.github.com/user", {
+        headers: { ...GH_HEADERS_BASE, Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return c.json({ error: "Invalid GitHub token" }, 401);
+        }
+        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
+      }
+
+      const data = (await response.json()) as Record<string, unknown>;
+      const username = typeof data.login === "string" ? data.login : null;
+      const avatarUrl = typeof data.avatar_url === "string" ? data.avatar_url : null;
+      const publicRepos = typeof data.public_repos === "number" ? data.public_repos : null;
+
+      return c.json({ username, avatar_url: avatarUrl, public_repos: publicRepos });
+    } catch (error: unknown) {
+      return safeError(c, error, "Token validation failed");
+    }
+  });
+
+  // Fetch authenticated user's GitHub repos
+  api.get("/api/setup/repos", async (c) => {
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json({ error: "Authorization header with Bearer token is required" }, 400);
+    }
+    const token = authHeader.slice("Bearer ".length).trim();
+    if (!token) {
+      return c.json({ error: "Token must not be empty" }, 400);
+    }
+
+    try {
+      const response = await fetch(
+        "https://api.github.com/user/repos?per_page=100&sort=updated&affiliation=owner,collaborator",
+        { headers: { ...GH_HEADERS_BASE, Authorization: `Bearer ${token}` } }
+      );
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return c.json({ error: "Invalid GitHub token" }, 401);
+        }
+        return c.json({ error: `GitHub API error: ${response.status}` }, 502);
+      }
+
+      const data = (await response.json()) as Array<Record<string, unknown>>;
+      const repos = data
+        .filter((r) => typeof r.full_name === "string")
+        .map((r) => ({
+          full_name: r.full_name as string,
+          private: Boolean(r.private),
+          description: typeof r.description === "string" ? r.description : null,
+        }));
+      return c.json({ repos });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch repos");
+    }
+  });
+
+  // Auto-create AQM labels in the target repository
+  api.post(
+    "/api/setup/labels",
+    zValidator("json", SetupLabelsBodySchema, zodValidationHook),
+    async (c) => {
+      const { repo, token, labels } = c.req.valid("json");
+
+      const ghHeaders: Record<string, string> = {
+        ...GH_HEADERS_BASE,
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      };
+
+      const results: Array<{ label: string; status: "created" | "skipped" | "failed" }> = [];
+
+      for (const label of labels) {
+        try {
+          const checkResp = await fetch(
+            `https://api.github.com/repos/${repo}/labels/${encodeURIComponent(label)}`,
+            { headers: ghHeaders }
+          );
+
+          if (checkResp.status === 200) {
+            results.push({ label, status: "skipped" });
+            continue;
+          }
+
+          if (checkResp.status !== 404) {
+            results.push({ label, status: "failed" });
+            continue;
+          }
+
+          // Label doesn't exist — create it
+          const createResp = await fetch(`https://api.github.com/repos/${repo}/labels`, {
+            method: "POST",
+            headers: ghHeaders,
+            body: JSON.stringify({ name: label, color: "0075ca", description: "AI Quartermaster task" }),
+          });
+          results.push({ label, status: createResp.ok ? "created" : "failed" });
+        } catch {
+          results.push({ label, status: "failed" });
+        }
+      }
+
+      return c.json({ results });
+    }
+  );
+
+  // Preview YAML diff before applying
+  api.post(
+    "/api/setup/preview",
+    zValidator("json", SetupPreviewBodySchema, zodValidationHook),
+    async (c) => {
+      try {
+        const { repo, repoPath, baseBranch, mode } = c.req.valid("json");
+        const configPath = resolve(rootDir, "config.yml");
+        const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
+        const existingYaml = existsSync(configPath) ? readFileSync(configPath, "utf-8") : null;
+        const diff = computeYamlDiff(existingYaml, newYaml);
+        return c.json({ yaml: newYaml, existingYaml, diff });
+      } catch (error: unknown) {
+        return safeError(c, error, "Preview failed");
+      }
+    }
+  );
+
+  // Apply config.yml with backup
+  api.post(
+    "/api/setup/apply",
+    zValidator("json", SetupPreviewBodySchema, zodValidationHook),
+    async (c) => {
+      try {
+        const { repo, repoPath, baseBranch, mode, token } = c.req.valid("json");
+        const configPath = resolve(rootDir, "config.yml");
+        let backupPath: string | null = null;
+        if (existsSync(configPath)) {
+          // 타임스탬프 접미사로 이전 백업 보존 (여러 번 apply 해도 직전 상태로 롤백 가능)
+          const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+          backupPath = `${configPath}.bak.${timestamp}`;
+          copyFileSync(configPath, backupPath);
+        }
+        const newYaml = generateSetupYaml(repo, repoPath, baseBranch, mode);
+        writeFileSync(configPath, newYaml, "utf-8");
+        if (token) {
+          const credentialsDir = join(homedir(), ".aqm");
+          mkdirSync(credentialsDir, { recursive: true });
+          writeFileSync(join(credentialsDir, "credentials"), `GITHUB_TOKEN=${token}\n`, { mode: 0o600 });
+        }
+        return c.json({ success: true, configPath, backupPath });
+      } catch (error: unknown) {
+        return safeError(c, error, "Apply failed");
+      }
+    }
+  );
+}

--- a/src/server/routes/skip-events.ts
+++ b/src/server/routes/skip-events.ts
@@ -1,0 +1,118 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import { safeError } from "../route-context.js";
+import { GetSkipEventsQuerySchema, formatZodError } from "../../types/api.js";
+
+export interface SkipEventsRouteContext {
+  store: JobStore;
+  readOnly: boolean;
+}
+
+/**
+ * /api/skip-events/* 라우트 등록 (Plan C #C9 — 10단계).
+ *
+ * 이전: dashboard-api.ts 395-491 (3 routes, ~95줄).
+ * 동일 이슈+reasonCode 중복 축약을 위한 그룹 뷰와 flat 뷰를 함께 제공한다.
+ */
+export function registerSkipEventsRoutes(api: Hono, ctx: SkipEventsRouteContext): void {
+  const { store, readOnly } = ctx;
+
+  // Skip events stats (reasonCode별 집계)
+  api.get("/api/skip-events/stats", (c) => {
+    try {
+      const repo = c.req.query("repo");
+      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
+
+      const reasonCodeCounts: Record<string, number> = {};
+      for (const event of allEvents) {
+        reasonCodeCounts[event.reasonCode] = (reasonCodeCounts[event.reasonCode] ?? 0) + 1;
+      }
+
+      const stats = Object.entries(reasonCodeCounts)
+        .map(([reasonCode, count]) => ({ reasonCode, count }))
+        .sort((a, b) => b.count - a.count);
+
+      return c.json({ total: allEvents.length, stats });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch skip event stats");
+    }
+  });
+
+  // List skip events (flat 또는 issueNumber+repo+reasonCode 그룹)
+  api.get("/api/skip-events", (c) => {
+    try {
+      const groupParam = c.req.query("group");
+      const queryParams = {
+        repo: c.req.query("repo"),
+        limit: c.req.query("limit") ? parseInt(c.req.query("limit")!, 10) : undefined,
+        offset: c.req.query("offset") ? parseInt(c.req.query("offset")!, 10) : undefined,
+        group: groupParam === "true" ? true : groupParam === "false" ? false : undefined,
+      };
+
+      const parseResult = GetSkipEventsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({
+          error: "Invalid query parameters",
+          details: formatZodError(parseResult.error),
+        }, 400);
+      }
+
+      const { repo, limit, offset, group } = parseResult.data;
+
+      // 그룹 뷰: 동일 이슈+reasonCode 중복 축약 (기본 대시보드 뷰)
+      if (group) {
+        const { groups, totalGroups } = store.listSkipEventsGrouped({ repo, limit, offset });
+        const start = offset ?? 0;
+        const end = limit !== undefined ? start + groups.length : totalGroups;
+        return c.json({
+          groups,
+          pagination: {
+            total: totalGroups,
+            offset: start,
+            limit: limit ?? totalGroups,
+            hasMore: end < totalGroups,
+          },
+        });
+      }
+
+      // Flat 뷰 (기존 API 호환)
+      const allEvents = store.listSkipEvents(repo ? { repo } : undefined);
+      const total = allEvents.length;
+      const start = offset ?? 0;
+      const end = limit !== undefined ? start + limit : total;
+      const events = allEvents.slice(start, end);
+
+      return c.json({
+        events,
+        pagination: {
+          total,
+          offset: start,
+          limit: limit ?? total,
+          hasMore: end < total,
+        },
+      });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch skip events");
+    }
+  });
+
+  // 특정 그룹(issueNumber+repo+reasonCode) 전체 삭제
+  api.delete("/api/skip-events/group", async (c) => {
+    if (readOnly) {
+      return c.json({ error: "Read-only mode" }, 403);
+    }
+    try {
+      const body = await c.req.json<{ issueNumber?: unknown; repo?: unknown; reasonCode?: unknown }>();
+      const issueNumber = typeof body.issueNumber === "number" ? body.issueNumber : Number(body.issueNumber);
+      const repoVal = typeof body.repo === "string" ? body.repo : "";
+      const reasonCode = typeof body.reasonCode === "string" ? body.reasonCode : "";
+      if (!Number.isInteger(issueNumber) || issueNumber <= 0 || !repoVal || !reasonCode) {
+        return c.json({ error: "issueNumber, repo, reasonCode 필수" }, 400);
+      }
+      const deleted = store.deleteSkipEventsByGroup(issueNumber, repoVal, reasonCode);
+      return c.json({ deleted });
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to delete skip event group");
+    }
+  });
+}

--- a/src/server/routes/sse.ts
+++ b/src/server/routes/sse.ts
@@ -1,0 +1,142 @@
+import type { Hono } from "hono";
+import { randomUUID } from "crypto";
+import type { JobStore, Job } from "../../queue/job-store.js";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { SSEManager } from "../sse-manager.js";
+
+export interface SSERouteContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+}
+
+const SSE_INITIAL_JOB_LIMIT = 20;
+const SSE_MAX_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const SSE_LOG_POLL_MS = 1000;
+const SSE_EVENT_POLL_MS = 10_000;
+
+/**
+ * SSE 초기 페이로드용 잡 목록.
+ * - archived 제외
+ * - running/queued는 항상 포함
+ * - 남은 슬롯은 최근 non-active job으로 채움 (총 SSE_INITIAL_JOB_LIMIT)
+ */
+function getInitialJobs(store: JobStore): Job[] {
+  const active = store.list({ statuses: ["running", "queued"] });
+  const remaining = Math.max(0, SSE_INITIAL_JOB_LIMIT - active.length);
+  const rest = remaining > 0
+    ? store.list({ statuses: ["success", "failure", "cancelled"], limit: remaining })
+    : [];
+  return [...active, ...rest];
+}
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  "Connection": "keep-alive",
+} as const;
+
+/**
+ * SSE 라우트 등록 (Plan C #C9 — 11단계).
+ *
+ * 이전: dashboard-api.ts 388-489 (2 routes, ~105줄).
+ *  - GET /api/jobs/:id/logs/stream — 단일 잡 로그 폴링 SSE
+ *  - GET /api/events — 글로벌 잡/큐 상태 SSE
+ *
+ * 클라이언트 풀(SSEManager)과 인증 미들웨어는 dashboard-api.ts에 그대로 남는다.
+ * 본 모듈은 라우트 핸들러만 응집한다.
+ */
+export function registerSSERoutes(api: Hono, ctx: SSERouteContext): void {
+  const { store, queue, sseManager } = ctx;
+
+  // 단일 잡 로그 SSE
+  api.get("/api/jobs/:id/logs/stream", (c) => {
+    const id = c.req.param("id");
+    let lastLogCount = 0;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        const send = () => {
+          try {
+            const job = store.get(id);
+            if (!job) {
+              controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ error: "Job not found" })}\n\n`));
+              clearInterval(intervalId);
+              try { controller.close(); } catch { /* already closed */ }
+              return;
+            }
+            const logs = job.logs || [];
+            if (logs.length > lastLogCount) {
+              const newLines = logs.slice(lastLogCount);
+              lastLogCount = logs.length;
+              for (const line of newLines) {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify({ line, status: job.status })}\n\n`));
+              }
+            }
+            // status가 종료 상태면 done 이벤트 + 스트림 종료
+            if (job.status !== "running" && job.status !== "queued") {
+              controller.enqueue(encoder.encode(`event: done\ndata: ${JSON.stringify({ status: job.status })}\n\n`));
+              clearInterval(intervalId);
+              try { controller.close(); } catch { /* already closed */ }
+            }
+          } catch {
+            // stream closed
+          }
+        };
+        send();
+        intervalId = setInterval(send, SSE_LOG_POLL_MS);
+        setTimeout(() => {
+          clearInterval(intervalId);
+          try { controller.close(); } catch { /* already closed */ }
+        }, SSE_MAX_DURATION_MS);
+      },
+      cancel() {
+        clearInterval(intervalId);
+      },
+    });
+
+    return new Response(stream, { headers: SSE_HEADERS });
+  });
+
+  // 글로벌 잡/큐 상태 SSE
+  api.get("/api/events", (_c) => {
+    const clientId = randomUUID();
+    const encoder = new TextEncoder();
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stream = new ReadableStream({
+      start(controller) {
+        sseManager.addClient(controller, clientId);
+
+        const sendInitialState = () => {
+          try {
+            const status = queue.getStatus();
+            const data = JSON.stringify({ jobs: getInitialJobs(store), queue: status });
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          } catch {
+            // stream closed
+          }
+        };
+
+        sendInitialState();
+
+        // 실시간 이벤트가 대부분의 업데이트를 처리하므로 폴링은 fallback 용도(10초).
+        intervalId = setInterval(sendInitialState, SSE_EVENT_POLL_MS);
+
+        // Auto-cleanup after 5 minutes
+        setTimeout(() => {
+          clearInterval(intervalId);
+          sseManager.removeClient(clientId);
+        }, SSE_MAX_DURATION_MS);
+      },
+      cancel() {
+        clearInterval(intervalId);
+        sseManager.removeClient(clientId);
+      },
+    });
+
+    return new Response(stream, { headers: SSE_HEADERS });
+  });
+}

--- a/src/server/routes/stats.ts
+++ b/src/server/routes/stats.ts
@@ -1,0 +1,156 @@
+import type { Hono } from "hono";
+import type { JobStore } from "../../queue/job-store.js";
+import type { PatternStore } from "../../learning/pattern-store.js";
+import { safeError } from "../route-context.js";
+import {
+  GetStatsQuerySchema,
+  GetCostsQuerySchema,
+  GetProjectStatsQuerySchema,
+  GetFailureReasonsQuerySchema,
+  GetMetricsQuerySchema,
+  formatZodError,
+} from "../../types/api.js";
+import {
+  getJobStats,
+  getCostStats,
+  getProjectStatsWithTimeRange,
+  getFailureReasons,
+  getThroughputTimeSeries,
+  getSuccessRate,
+} from "../../store/queries.js";
+
+export interface StatsRouteContext {
+  store: JobStore;
+  patternStore?: PatternStore;
+}
+
+/**
+ * /api/stats/* + /api/metrics/* 라우트 등록 (Plan C #C9 — 5단계).
+ *
+ * 이전: dashboard-api.ts 709-845 (6 read-only routes, ~140줄).
+ * 모두 동일한 패턴 — query parse → DB 조회 → JSON 반환.
+ */
+export function registerStatsRoutes(api: Hono, ctx: StatsRouteContext): void {
+  const { store, patternStore } = ctx;
+
+  // Aggregate stats
+  api.get("/api/stats", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetStatsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const stats = getJobStats(store.getAqDb(), parseResult.data);
+      return c.json(stats);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch stats");
+    }
+  });
+
+  // Cost stats
+  api.get("/api/stats/costs", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        timeRange: c.req.query("timeRange") || "30d",
+        groupBy: c.req.query("groupBy") || "project",
+      };
+
+      const parseResult = GetCostsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const costs = getCostStats(store.getAqDb(), parseResult.data);
+      return c.json(costs);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch cost stats");
+    }
+  });
+
+  // Project stats (success rate + cost per project)
+  api.get("/api/stats/projects", (c) => {
+    try {
+      const queryParams = {
+        timeRange: c.req.query("timeRange") || "7d",
+      };
+
+      const parseResult = GetProjectStatsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: parseResult.error }, 400);
+      }
+
+      const stats = getProjectStatsWithTimeRange(store.getAqDb(), parseResult.data);
+      return c.json(stats);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch project stats");
+    }
+  });
+
+  // Failure reason top-N analysis
+  api.get("/api/metrics/failure-reasons", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window"),
+        top: c.req.query("top"),
+      };
+
+      const parseResult = GetFailureReasonsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const result = getFailureReasons(store.getAqDb(), parseResult.data, patternStore);
+      return c.json(result);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch failure reasons");
+    }
+  });
+
+  // Throughput time series
+  api.get("/api/metrics/throughput", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const data = getThroughputTimeSeries(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch throughput metrics");
+    }
+  });
+
+  // Success rate metrics
+  api.get("/api/metrics/success-rate", (c) => {
+    try {
+      const queryParams = {
+        project: c.req.query("project"),
+        window: c.req.query("window") || "7d",
+      };
+
+      const parseResult = GetMetricsQuerySchema.safeParse(queryParams);
+      if (!parseResult.success) {
+        return c.json({ error: "Invalid query parameters", details: formatZodError(parseResult.error) }, 400);
+      }
+
+      const data = getSuccessRate(store.getAqDb(), parseResult.data);
+      return c.json(data);
+    } catch (error: unknown) {
+      return safeError(c, error, "Failed to fetch success rate metrics");
+    }
+  });
+}

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -1,0 +1,162 @@
+import type { Hono } from "hono";
+import { basename } from "path";
+import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
+import type { JobStore } from "../../queue/job-store.js";
+import type { JobQueue } from "../../queue/job-queue.js";
+import type { ConfigWatcher } from "../../config/config-watcher.js";
+import type { SSEManager } from "../sse-manager.js";
+import type { QuotaStatus } from "../../types/config.js";
+import { safeError } from "../route-context.js";
+import { loadConfig } from "../../config/loader.js";
+import { SelfUpdater } from "../../update/self-updater.js";
+import { checkClaudeQuota } from "../../claude/quota-checker.js";
+import { runCli } from "../../utils/cli-runner.js";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+import { sanitizeErrorMessage } from "../../utils/error-sanitizer.js";
+
+/**
+ * AQM 설치 루트의 package.json에서 버전을 읽는다.
+ * import.meta.url 기준으로 — process.cwd()는 서버 실행 디렉토리일 뿐 설치 루트와
+ * 다를 수 있어 "ENOENT: package.json" 에러를 일으킬 수 있다.
+ *
+ * src/server/routes/version.ts (dev) → ../../../package.json
+ * dist/server/routes/version.js (build) → ../../../package.json (동일)
+ */
+function getCurrentVersion(): string {
+  const packageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  return packageJson.version;
+}
+
+export interface VersionRouteContext {
+  store: JobStore;
+  queue: JobQueue;
+  sseManager: SSEManager;
+  configWatcher?: ConfigWatcher;
+  rootDir: string;
+  getQuotaStatus: () => QuotaStatus | null;
+  setQuotaStatus: (status: QuotaStatus) => void;
+}
+
+/**
+ * /api/version, /api/claude-profile*, /api/update 라우트 등록 (Plan C #C9 — 2단계).
+ *
+ * 이전: dashboard-api.ts 1346-1460 (4 routes, 115줄).
+ */
+export function registerVersionRoutes(api: Hono, ctx: VersionRouteContext): void {
+  const { store, queue, sseManager, configWatcher, rootDir, getQuotaStatus, setQuotaStatus } = ctx;
+
+  api.get("/api/version", async (c) => {
+    try {
+      const currentVersion = getCurrentVersion();
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
+
+      try {
+        const updateInfo = await selfUpdater.checkForUpdates();
+        return c.json({
+          currentVersion,
+          currentHash: updateInfo.currentHash.substring(0, 8),
+          remoteHash: updateInfo.remoteHash.substring(0, 8),
+          hasUpdates: updateInfo.hasUpdates,
+          packageLockChanged: updateInfo.packageLockChanged,
+        });
+      } catch (updateError: unknown) {
+        getLogger().warn(`업데이트 확인 실패: ${getErrorMessage(updateError)}`);
+        return c.json({
+          currentVersion,
+          currentHash: "unknown",
+          remoteHash: "unknown",
+          hasUpdates: false,
+          packageLockChanged: false,
+          error: "업데이트 확인에 실패했습니다",
+        });
+      }
+    } catch (error: unknown) {
+      return safeError(c, error, "버전 정보 조회 실패");
+    }
+  });
+
+  api.get("/api/claude-profile", async (c) => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR || "";
+    const profile = configDir ? basename(configDir).replace(/^\.claude-?/, "") || "default" : "default";
+    const config = configWatcher?.current() ?? loadConfig(rootDir);
+    const models = config.commands.claudeCli.models;
+
+    let cliVersion = "unknown";
+    try {
+      const result = await runCli(config.commands.claudeCli.path, ["--version"], { timeout: 5000 });
+      if (result.exitCode === 0) cliVersion = result.stdout.trim();
+    } catch { /* 비차단 버전 조회 — 실패 무시 */ }
+
+    return c.json({
+      profile,
+      configDir,
+      cliVersion,
+      model: config.commands.claudeCli.model,
+      models: {
+        plan: models?.plan,
+        phase: models?.phase,
+        review: models?.review,
+        fallback: models?.fallback,
+      },
+      maxTurns: config.commands.claudeCli.maxTurns,
+      timeout: config.commands.claudeCli.timeout,
+      quotaStatus: getQuotaStatus(),
+    });
+  });
+
+  api.post("/api/claude-profile/refresh", async (c) => {
+    try {
+      const config = configWatcher?.current() ?? loadConfig(rootDir);
+      const status = await checkClaudeQuota(config.commands.claudeCli);
+      setQuotaStatus(status);
+      return c.json({ quotaStatus: status });
+    } catch (error: unknown) {
+      return safeError(c, error, "quota 재검사 실패");
+    }
+  });
+
+  api.post("/api/update", async (c) => {
+    try {
+      const activeJobs = store.list().filter(job => job.status === "running" || job.status === "queued");
+      if (activeJobs.length > 0) {
+        getLogger().info(`업데이트 전 진행 중인 잡 ${activeJobs.length}개 취소 중`);
+        for (const job of activeJobs) {
+          queue.cancel(job.id);
+          getLogger().info(`잡 취소: ${job.id} (이슈 #${job.issueNumber}, 상태: ${job.status})`);
+        }
+      }
+
+      const config = loadConfig(rootDir);
+      const selfUpdater = new SelfUpdater(config.git, { cwd: rootDir });
+      getLogger().info("사용자 요청으로 업데이트 시작");
+
+      const result = await selfUpdater.performSelfUpdate();
+      if (result.updated) {
+        sseManager.broadcast("updateCompleted", {
+          updated: result.updated,
+          needsRestart: result.needsRestart,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      return c.json({
+        message: result.updated ? "업데이트가 완료되었습니다" : "이미 최신 버전입니다",
+        updated: result.updated,
+        needsRestart: result.needsRestart,
+      });
+    } catch (error: unknown) {
+      const rawMessage = getErrorMessage(error);
+      getLogger().error(`업데이트 실패: ${rawMessage}`);
+      const message = sanitizeErrorMessage(rawMessage);
+      sseManager.broadcast("updateFailed", {
+        error: message,
+        timestamp: new Date().toISOString(),
+      });
+      return c.json({ error: `업데이트 실패: ${message}` }, 500);
+    }
+  });
+}

--- a/src/server/sse-manager.ts
+++ b/src/server/sse-manager.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from "crypto";
+
+/**
+ * SSE 클라이언트 1건의 메타.
+ */
+interface SSEClient {
+  id: string;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  connectedAt: number;
+  lastHeartbeat: number;
+}
+
+export interface SSEManagerOptions {
+  /** 동시 연결 최대치. 기본 50. */
+  maxClients?: number;
+  /** Heartbeat 송출 주기 (ms). 기본 30s. */
+  heartbeatMs?: number;
+  /** 마지막 heartbeat 이후 이 시간이 지나면 stale로 간주 (ms). 기본 2m. */
+  clientTimeoutMs?: number;
+}
+
+/**
+ * SSE(Server-Sent Events) 클라이언트 풀 관리 + heartbeat 루프.
+ *
+ * 이전에는 `dashboard-api.ts` module-level 상태(Map<string, SSEClient> + interval)로 흩어져 있었다.
+ * Plan C #C5 — 단일 클래스로 캡슐화하고 dashboard-api는 인스턴스 1개를 보유한다.
+ *
+ * 라이프사이클:
+ *   addClient(controller) → broadcast/sendHeartbeat 발화 시 자동으로 stale 제거
+ *   startHeartbeat() ↔ stopHeartbeat() — interval 토글
+ *   cleanupAll() — 모든 컨트롤러 close + 맵 비움 (서버 종료 시)
+ */
+export class SSEManager {
+  private readonly clients = new Map<string, SSEClient>();
+  private readonly encoder = new TextEncoder();
+  private readonly maxClients: number;
+  private readonly heartbeatMs: number;
+  private readonly clientTimeoutMs: number;
+  private heartbeatInterval?: ReturnType<typeof setInterval>;
+
+  constructor(opts: SSEManagerOptions = {}) {
+    this.maxClients = opts.maxClients ?? 50;
+    this.heartbeatMs = opts.heartbeatMs ?? 30_000;
+    this.clientTimeoutMs = opts.clientTimeoutMs ?? 120_000;
+  }
+
+  /**
+   * 새 클라이언트 등록. 한도 초과 시 가장 오래된 클라이언트를 evict한 후 추가한다.
+   * @param controller ReadableStream 컨트롤러
+   * @param id 클라이언트 식별자(미주입 시 randomUUID). 호출부가 stream cancel 핸들러에서
+   *           동일 id로 removeClient를 호출할 수 있도록 외부에서 주입 가능.
+   * @returns 등록된 클라이언트 ID
+   */
+  addClient(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    id: string = randomUUID()
+  ): string {
+    if (this.clients.size >= this.maxClients) {
+      this.evictOldest(this.maxClients - 1);
+    }
+    const now = Date.now();
+    this.clients.set(id, { id, controller, connectedAt: now, lastHeartbeat: now });
+    return id;
+  }
+
+  /**
+   * 클라이언트 제거. 컨트롤러 close 실패는 무시한다.
+   */
+  removeClient(id: string): void {
+    const client = this.clients.get(id);
+    if (!client) return;
+    try {
+      client.controller.close();
+    } catch {
+      // already closed
+    }
+    this.clients.delete(id);
+  }
+
+  /**
+   * 모든 클라이언트에 SSE 이벤트 전송. 전송 실패 또는 stale 클라이언트는 즉시 제거.
+   */
+  broadcast(event: string, data: unknown): void {
+    const message = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    const now = Date.now();
+    const toRemove: string[] = [];
+
+    for (const [clientId, client] of this.clients) {
+      if (now - client.lastHeartbeat > this.clientTimeoutMs) {
+        toRemove.push(clientId);
+        continue;
+      }
+      try {
+        client.controller.enqueue(this.encoder.encode(message));
+        client.lastHeartbeat = now;
+      } catch {
+        toRemove.push(clientId);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * 모든 클라이언트에 heartbeat 이벤트 송출. 실패한 컨트롤러는 제거.
+   */
+  sendHeartbeat(): void {
+    const message = `event: heartbeat\ndata: ${JSON.stringify({ timestamp: Date.now() })}\n\n`;
+    const toRemove: string[] = [];
+
+    for (const [clientId, client] of this.clients) {
+      try {
+        client.controller.enqueue(this.encoder.encode(message));
+      } catch {
+        toRemove.push(clientId);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * 마지막 heartbeat 이후 timeout이 지난 클라이언트를 제거한다.
+   */
+  removeStale(): void {
+    const now = Date.now();
+    const toRemove: string[] = [];
+    for (const [clientId, client] of this.clients) {
+      if (now - client.lastHeartbeat > this.clientTimeoutMs) {
+        toRemove.push(clientId);
+      }
+    }
+    for (const id of toRemove) {
+      const client = this.clients.get(id);
+      try {
+        client?.controller.close();
+      } catch {
+        // ignore
+      }
+      this.clients.delete(id);
+    }
+  }
+
+  /**
+   * heartbeat interval 시작. 이미 켜져 있으면 먼저 정지 후 재시작.
+   * 매 주기마다 sendHeartbeat + removeStale 호출.
+   */
+  startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatInterval = setInterval(() => {
+      this.sendHeartbeat();
+      this.removeStale();
+    }, this.heartbeatMs);
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+  }
+
+  /**
+   * 모든 클라이언트 컨트롤러 close + 맵 비움. 서버 종료 시 호출.
+   */
+  cleanupAll(): void {
+    for (const [, client] of this.clients) {
+      try {
+        client.controller.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.clients.clear();
+  }
+
+  get clientCount(): number {
+    return this.clients.size;
+  }
+
+  /**
+   * 한도를 초과한 가장 오래된 클라이언트(connectedAt 기준)를 제거한다.
+   */
+  private evictOldest(targetCount: number): void {
+    if (this.clients.size <= targetCount) return;
+    const sorted = [...this.clients.entries()].sort(
+      ([, a], [, b]) => a.connectedAt - b.connectedAt
+    );
+    const evictCount = this.clients.size - targetCount;
+    for (let i = 0; i < evictCount; i++) {
+      const [clientId, client] = sorted[i];
+      try {
+        client.controller.close();
+      } catch {
+        // ignore
+      }
+      this.clients.delete(clientId);
+    }
+  }
+}

--- a/tests/dashboard-api.test.ts
+++ b/tests/dashboard-api.test.ts
@@ -121,7 +121,7 @@ describe("PUT /api/config — automations 저장 확인", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
   });
 
   it("valid config 업데이트 시 updateConfigSection이 호출됨", async () => {

--- a/tests/doctor-heal.test.ts
+++ b/tests/doctor-heal.test.ts
@@ -136,7 +136,7 @@ describe('GET /api/doctor/run', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
   });
 
   it('runAllChecks 성공 시 200과 checks 배열을 반환한다', async () => {
@@ -256,7 +256,7 @@ describe('DoctorCheck 확장 필드 (healLevel / autoFixCommand)', () => {
     const checks: DoctorCheck[] = [makeCheck({ status: 'fail', fixSteps: ['수동으로 설치'] })];
     mockRunAllChecks.mockResolvedValue(checks);
 
-    const app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    const app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     const res = await app.request('/api/doctor/run');
 
     expect(res.status).toBe(200);
@@ -272,7 +272,7 @@ describe('DoctorCheck 확장 필드 (healLevel / autoFixCommand)', () => {
     };
     mockRunAllChecks.mockResolvedValue([extendedCheck as unknown as DoctorCheck]);
 
-    const app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    const app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     const res = await app.request('/api/doctor/run');
 
     expect(res.status).toBe(200);

--- a/tests/notification.test.ts
+++ b/tests/notification.test.ts
@@ -330,7 +330,7 @@ function makeApp(mockAqDb: MockAqDb): Hono {
     setProjectConcurrency: vi.fn(),
   } as unknown as JobQueue;
 
-  return createDashboardRoutes(mockJobStore, mockJobQueue);
+  return createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 }
 
 describe("Notification API 엔드포인트", () => {

--- a/tests/pipeline/phases/phase-tracker.test.ts
+++ b/tests/pipeline/phases/phase-tracker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { runPhaseWithTracking } from "../../../src/pipeline/phases/phase-tracker.js";
+import { createFixedClock } from "../../../src/utils/clock.js";
+import type { PhaseResult } from "../../../src/types/pipeline.js";
+
+describe("runPhaseWithTracking", () => {
+  it("runner 성공 시 PhaseTrackingResult를 반환한다", async () => {
+    const clock = createFixedClock("2026-04-26T00:00:00.000Z");
+    const tracking = await runPhaseWithTracking(
+      "review:code",
+      async () => ({ success: true, costUsd: 0.5 }),
+      undefined,
+      clock
+    );
+
+    expect(tracking.result.success).toBe(true);
+    expect(tracking.startedAt).toBe("2026-04-26T00:00:00.000Z");
+    expect(tracking.completedAt).toBe("2026-04-26T00:00:00.000Z");
+    expect(tracking.durationMs).toBe(0);
+  });
+
+  it("성공한 runner의 PhaseResult를 누적 배열에 push한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "review:code",
+      async () => ({ success: true, costUsd: 1.23 }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated).toHaveLength(1);
+    expect(accumulated[0]).toMatchObject({
+      phaseName: "review:code",
+      success: true,
+      costUsd: 1.23,
+      startedAt: "2026-04-26T00:00:00.000Z",
+      completedAt: "2026-04-26T00:00:00.000Z",
+    });
+  });
+
+  it("실패한 runner의 PhaseResult를 failure로 push한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "validation:check",
+      async () => ({ success: false, error: "boom", costUsd: 0.1 }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated).toHaveLength(1);
+    expect(accumulated[0]).toMatchObject({
+      phaseName: "validation:check",
+      success: false,
+      error: "boom",
+      costUsd: 0.1,
+    });
+  });
+
+  it("error 미제공 시 기본 메시지를 사용한다", async () => {
+    const accumulated: PhaseResult[] = [];
+    await runPhaseWithTracking(
+      "publish:pr",
+      async () => ({ success: false }),
+      accumulated,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+
+    expect(accumulated[0].error).toBe("publish:pr failed");
+  });
+
+  it("accumulated 미주입 시 push하지 않는다", async () => {
+    const tracking = await runPhaseWithTracking(
+      "review:simplify",
+      async () => ({ success: true }),
+      undefined,
+      createFixedClock("2026-04-26T00:00:00.000Z")
+    );
+    expect(tracking.result.success).toBe(true);
+  });
+
+  it("runner 예외는 그대로 throw된다 (push 없음)", async () => {
+    const accumulated: PhaseResult[] = [];
+    await expect(
+      runPhaseWithTracking(
+        "review:code",
+        async () => {
+          throw new Error("runner crashed");
+        },
+        accumulated
+      )
+    ).rejects.toThrow("runner crashed");
+    expect(accumulated).toHaveLength(0);
+  });
+
+  it("durationMs는 nowMs 진행에 따라 측정된다", async () => {
+    let ms = 1000;
+    const advancingClock = {
+      nowIso: () => new Date(ms).toISOString(),
+      nowMs: () => {
+        const cur = ms;
+        ms += 250;
+        return cur;
+      },
+    };
+    const tracking = await runPhaseWithTracking(
+      "setup:worktree",
+      async () => ({ success: true }),
+      undefined,
+      advancingClock
+    );
+    // startMs=1000 → completedMs=1250 → duration 250
+    expect(tracking.durationMs).toBe(250);
+  });
+});

--- a/tests/queue/job-cleanup.test.ts
+++ b/tests/queue/job-cleanup.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadCheckpoint: vi.fn(),
+  removeCheckpoint: vi.fn(),
+  removeWorktree: vi.fn(),
+  deleteRemoteBranch: vi.fn(),
+}));
+
+vi.mock("../../src/pipeline/errors/checkpoint.js", () => ({
+  loadCheckpoint: mocks.loadCheckpoint,
+  removeCheckpoint: mocks.removeCheckpoint,
+}));
+
+vi.mock("../../src/git/worktree-manager.js", () => ({
+  removeWorktree: mocks.removeWorktree,
+}));
+
+vi.mock("../../src/git/branch-manager.js", () => ({
+  deleteRemoteBranch: mocks.deleteRemoteBranch,
+}));
+
+import { JobCleanupService } from "../../src/queue/job-cleanup.js";
+import type { ConfigProvider } from "../../src/config/config-provider.js";
+import type { AQConfig } from "../../src/types/config.js";
+
+function makeProvider(): ConfigProvider {
+  return {
+    current: () => ({ git: { gitPath: "git" } } as unknown as AQConfig),
+    refresh: () => {},
+  };
+}
+
+describe("JobCleanupService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("worktree와 branch 정리를 모두 await한 후 반환한다 (race 차단)", async () => {
+    let worktreeResolved = false;
+    let branchResolved = false;
+
+    mocks.loadCheckpoint.mockReturnValue({
+      worktreePath: "/tmp/worktree",
+      branchName: "feat/test",
+    });
+    mocks.removeWorktree.mockImplementation(
+      () =>
+        new Promise<void>(r => {
+          setTimeout(() => {
+            worktreeResolved = true;
+            r();
+          }, 10);
+        })
+    );
+    mocks.deleteRemoteBranch.mockImplementation(
+      () =>
+        new Promise<void>(r => {
+          setTimeout(() => {
+            branchResolved = true;
+            r();
+          }, 5);
+        })
+    );
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(42);
+
+    expect(worktreeResolved).toBe(true);
+    expect(branchResolved).toBe(true);
+    expect(mocks.removeCheckpoint).toHaveBeenCalledWith(expect.stringContaining("data"), 42);
+  });
+
+  it("worktree 제거 실패해도 branch/checkpoint 제거는 진행", async () => {
+    mocks.loadCheckpoint.mockReturnValue({
+      worktreePath: "/tmp/worktree",
+      branchName: "feat/test",
+    });
+    mocks.removeWorktree.mockRejectedValue(new Error("worktree gone"));
+    mocks.deleteRemoteBranch.mockResolvedValue(undefined);
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await expect(service.cleanupFailedJobArtifacts(42)).resolves.toBeUndefined();
+
+    expect(mocks.deleteRemoteBranch).toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalled();
+  });
+
+  it("checkpoint 로드 실패해도 removeCheckpoint는 시도", async () => {
+    mocks.loadCheckpoint.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(7);
+
+    expect(mocks.removeWorktree).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteBranch).not.toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalledWith(expect.stringContaining("data"), 7);
+  });
+
+  it("checkpoint가 없으면 worktree/branch 정리도 스킵", async () => {
+    mocks.loadCheckpoint.mockReturnValue(null);
+
+    const service = new JobCleanupService("/aq/root", makeProvider());
+    await service.cleanupFailedJobArtifacts(99);
+
+    expect(mocks.removeWorktree).not.toHaveBeenCalled();
+    expect(mocks.deleteRemoteBranch).not.toHaveBeenCalled();
+    expect(mocks.removeCheckpoint).toHaveBeenCalled();
+  });
+});

--- a/tests/queue/job-lifecycle.test.ts
+++ b/tests/queue/job-lifecycle.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JobLifecycle, type JobHandler } from "../../src/queue/job-lifecycle.js";
+import type { JobStore } from "../../src/queue/job-store.js";
+import type { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+import type { TaskFactory } from "../../src/tasks/task-factory.js";
+import type { AQMTask } from "../../src/tasks/aqm-task.js";
+import type { Job } from "../../src/types/pipeline.js";
+
+function makeStore(): JobStore {
+  return {
+    update: vi.fn(),
+  } as unknown as JobStore;
+}
+
+function makeTracker(): ProjectErrorTracker {
+  return {
+    trackFailure: vi.fn(),
+    trackSuccess: vi.fn(),
+  } as unknown as ProjectErrorTracker;
+}
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    issueNumber: 1,
+    repo: "a/b",
+    status: "running",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastUpdatedAt: "2025-01-01T00:00:00.000Z",
+    startedAt: "2025-01-01T00:00:00.000Z",
+    logs: [],
+    currentStep: null,
+    ...overrides,
+  } as unknown as Job;
+}
+
+describe("JobLifecycle", () => {
+  let store: JobStore;
+  let errorTracker: ProjectErrorTracker;
+  let activeTasks: Map<string, AQMTask>;
+  let stuckAborted: Set<string>;
+  let cancelled: Set<string>;
+  let onJobFinished: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = makeStore();
+    errorTracker = makeTracker();
+    activeTasks = new Map();
+    stuckAborted = new Set();
+    cancelled = new Set();
+    onJobFinished = vi.fn();
+  });
+
+  function makeLifecycle(handler: JobHandler, taskFactory?: TaskFactory) {
+    return new JobLifecycle({
+      store,
+      handler,
+      taskFactory,
+      errorTracker,
+      activeTasks,
+      stuckAborted,
+      cancelled,
+      onJobFinished,
+    });
+  }
+
+  it("성공 결과(prUrl)는 success로 update + trackSuccess", async () => {
+    const handler: JobHandler = vi.fn(async () => ({ prUrl: "https://github.com/x/y/pull/1" }));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(handler).toHaveBeenCalled();
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "success", prUrl: "https://github.com/x/y/pull/1" })
+    );
+    expect(errorTracker.trackSuccess).toHaveBeenCalledWith("a/b");
+    expect(errorTracker.trackFailure).not.toHaveBeenCalled();
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("error 결과는 failure로 update + trackFailure + diagnosis/userSummary 전파", async () => {
+    const handler: JobHandler = vi.fn(async () => ({
+      error: "boom",
+      diagnosis: { rootCause: "x" } as never,
+      userSummary: { headline: "y" } as never,
+    }));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        status: "failure",
+        error: "boom",
+        diagnosis: { rootCause: "x" },
+        userSummary: { headline: "y" },
+      })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("prUrl도 error도 없으면 'no PR was created' 실패", async () => {
+    const handler: JobHandler = vi.fn(async () => ({}));
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        status: "failure",
+        error: "Pipeline completed but no PR was created",
+      })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+  });
+
+  it("실행 시작 시 stuckAborted면 handler 호출하지 않고 종료(onJobFinished는 호출됨)", async () => {
+    stuckAborted.add("job-1");
+    const handler: JobHandler = vi.fn();
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(store.update).not.toHaveBeenCalled();
+    expect(stuckAborted.has("job-1")).toBe(false); // 플래그 클리어
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("handler 도중 stuckAborted 발화 시 status update는 하되 trackFailure 스킵", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      stuckAborted.add("job-1");
+      return { error: "boom" };
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "boom" })
+    );
+    expect(errorTracker.trackFailure).not.toHaveBeenCalled();
+    expect(stuckAborted.has("job-1")).toBe(false);
+  });
+
+  it("cancelled 플래그 set 상태에서 handler가 끝나면 store update 스킵 + 플래그 클리어", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      cancelled.add("job-1");
+      return { prUrl: "ignored" };
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).not.toHaveBeenCalled();
+    expect(cancelled.has("job-1")).toBe(false);
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("handler 예외 발생 시 failure로 update + trackFailure + onJobFinished 보장", async () => {
+    const handler: JobHandler = vi.fn(async () => {
+      throw new Error("kaboom");
+    });
+    const lifecycle = makeLifecycle(handler);
+
+    await lifecycle.execute(makeJob());
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "kaboom" })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+
+  it("taskFactory 경로: createTask로 만든 task.run()을 호출하고 activeTasks에 추가/제거", async () => {
+    const runMock = vi.fn(async () => ({ prUrl: "https://x" }));
+    const killMock = vi.fn();
+    const fakeTask = { run: runMock, kill: killMock } as unknown as AQMTask;
+    const taskFactory = {
+      createTask: vi.fn(() => fakeTask),
+    } as unknown as TaskFactory;
+
+    const handler: JobHandler = vi.fn();
+    const lifecycle = makeLifecycle(handler, taskFactory);
+
+    const finishedActiveTasks: Map<string, AQMTask>[] = [];
+    onJobFinished.mockImplementation(() => {
+      finishedActiveTasks.push(new Map(activeTasks));
+    });
+
+    await lifecycle.execute(makeJob());
+
+    expect(taskFactory.createTask).toHaveBeenCalled();
+    expect(runMock).toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+    expect(activeTasks.has("job-1")).toBe(false); // run 후 제거
+    // onJobFinished 시점에도 이미 빠져 있어야 함
+    expect(finishedActiveTasks[0]?.has("job-1")).toBe(false);
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "success", prUrl: "https://x" })
+    );
+  });
+
+  it("taskFactory.run()이 throw해도 activeTasks 정리 + onJobFinished 호출", async () => {
+    const runMock = vi.fn(async () => {
+      throw new Error("task-boom");
+    });
+    const fakeTask = { run: runMock, kill: vi.fn() } as unknown as AQMTask;
+    const taskFactory = {
+      createTask: vi.fn(() => fakeTask),
+    } as unknown as TaskFactory;
+
+    const lifecycle = makeLifecycle(vi.fn(), taskFactory);
+
+    await lifecycle.execute(makeJob());
+
+    expect(activeTasks.has("job-1")).toBe(false);
+    expect(store.update).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ status: "failure", error: "task-boom" })
+    );
+    expect(errorTracker.trackFailure).toHaveBeenCalledWith("a/b");
+    expect(onJobFinished).toHaveBeenCalledWith("job-1", "a/b");
+  });
+});

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -298,7 +298,7 @@ describe("JobQueue", () => {
       expect(failedJob?.error).toContain("initial failure");
 
       // Retry the failed job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
       expect(retryJob?.issueNumber).toBe(123);
@@ -352,7 +352,7 @@ describe("JobQueue", () => {
       store.update(job!.id, { logs: ["[2026. 4. 4. 21시 56분 30초] PR: https://pr/existing"] });
 
       // Try to retry - should fix status instead of retrying
-      const retryResult = queue.retryJob(job!.id);
+      const retryResult = await queue.retryJob(job!.id);
       expect(retryResult).toBeUndefined();
 
       // Verify job status was fixed to success
@@ -381,7 +381,7 @@ describe("JobQueue", () => {
       expect(failedJob?.status).toBe("failure");
 
       // Retry the job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
 
@@ -419,7 +419,7 @@ describe("JobQueue", () => {
       });
 
       // Try to retry - should fix status instead of retrying
-      const retryResult = queue.retryJob(job!.id);
+      const retryResult = await queue.retryJob(job!.id);
       expect(retryResult).toBeUndefined();
 
       // Verify job status was fixed to success
@@ -453,7 +453,7 @@ describe("JobQueue", () => {
       store.update(initialJob!.id, { phaseResults: mockPhaseResults });
 
       // Retry - new job should inherit phaseResults from failed job
-      const retryJob = queue.retryJob(initialJob!.id);
+      const retryJob = await queue.retryJob(initialJob!.id);
       expect(retryJob).toBeDefined();
       expect(retryJob?.isRetry).toBe(true);
 

--- a/tests/queue/job-queue.test.ts
+++ b/tests/queue/job-queue.test.ts
@@ -69,6 +69,7 @@ describe("JobQueue", () => {
   it("should enqueue and execute a job", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/1" });
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     expect(job).toBeDefined();
@@ -96,6 +97,7 @@ describe("JobQueue", () => {
     });
 
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
     queue.enqueue(1, "test/repo");
     queue.enqueue(2, "test/repo2");
     queue.enqueue(3, "test/repo3");
@@ -109,6 +111,7 @@ describe("JobQueue", () => {
   it("should prevent duplicate jobs for same issue", () => {
     const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
     const queue = new JobQueue(store, 2, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job1 = queue.enqueue(42, "test/repo");
     const job2 = queue.enqueue(42, "test/repo");
@@ -126,6 +129,7 @@ describe("JobQueue", () => {
       .mockResolvedValueOnce({ prUrl: "https://pr/new-success" });
 
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create initial failed job
     const initialJob = queue.enqueue(123, "test/repo");
@@ -161,6 +165,7 @@ describe("JobQueue", () => {
 
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/after-cancel" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create and immediately cancel a job
     const initialJob = queue.enqueue(456, "test/repo");
@@ -192,6 +197,7 @@ describe("JobQueue", () => {
   it("should auto-archive success job and allow re-enqueue", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     // Create successful job
     const successJob = queue.enqueue(789, "test/repo");
@@ -220,6 +226,7 @@ describe("JobQueue", () => {
     // Since concurrency is 0, the job is in pending... actually the enqueue adds to pending
     // Let's test via enqueue
     const queue2 = new JobQueue(store, 1, handler);
+    queue2.setDependencies({ projectRoot: dataDir });
     const j = queue2.enqueue(99, "test/repo2");
     // cancel immediately
     const result = queue2.cancel(j!.id);
@@ -231,6 +238,7 @@ describe("JobQueue", () => {
   it("should track queue status", () => {
     const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
     const queue = new JobQueue(store, 3, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const status = queue.getStatus();
     expect(status.concurrency).toBe(3);
@@ -241,6 +249,7 @@ describe("JobQueue", () => {
   it("should handle job handler failure", async () => {
     const handler: JobHandler = vi.fn().mockRejectedValue(new Error("boom"));
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -253,6 +262,7 @@ describe("JobQueue", () => {
   it("should mark job as failure when handler returns no prUrl", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({});
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(42, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -265,6 +275,7 @@ describe("JobQueue", () => {
   it("should mark job as failure when handler returns explicit error", async () => {
     const handler: JobHandler = vi.fn().mockResolvedValue({ error: "Phase execution failed" });
     const queue = new JobQueue(store, 1, handler);
+    queue.setDependencies({ projectRoot: dataDir });
 
     const job = queue.enqueue(43, "test/repo");
     await new Promise(r => setTimeout(r, 50));
@@ -286,6 +297,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue initial job that will fail
       const initialJob = queue.enqueue(123, "test/repo");
@@ -325,6 +337,7 @@ describe("JobQueue", () => {
       // Create a failed job with PR URL
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test error"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(456, "test/repo");
 
@@ -372,6 +385,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("retry failure"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(789, "test/repo");
@@ -405,6 +419,7 @@ describe("JobQueue", () => {
     it("should not retry jobs with logs indicating PR creation", async () => {
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test error"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(999, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -434,6 +449,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const initialJob = queue.enqueue(300, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -506,6 +522,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(123, "test/repo");
@@ -562,6 +579,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const initialJob = queue.enqueue(456, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -607,6 +625,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/retry-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create initial failed job
       const initialJob = queue.enqueue(789, "test/repo");
@@ -664,6 +683,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Initial job that fails
       const initialJob = queue.enqueue(555, "test/repo");
@@ -704,6 +724,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/second-success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create failed job
       const failedJob = queue.enqueue(666, "test/repo");
@@ -739,6 +760,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/dep-retry-success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue dependency (issue 100) and dependent (issue 101)
       const depJob = queue.enqueue(100, "test/repo");
@@ -815,6 +837,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Create and fail a job to trigger cleanup
       const job = queue.enqueue(123, "test/repo");
@@ -864,6 +887,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(456, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -893,6 +917,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(789, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -924,6 +949,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(111, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -956,6 +982,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(222, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -981,6 +1008,7 @@ describe("JobQueue", () => {
 
       const handler: JobHandler = vi.fn().mockRejectedValue(new Error("test failure"));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job = queue.enqueue(333, "test/repo");
       await new Promise(r => setTimeout(r, 50));
@@ -1009,6 +1037,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs with concurrency=1
       queue.enqueue(1, "test/repo");
@@ -1037,6 +1066,7 @@ describe("JobQueue", () => {
     it("should validate concurrency value", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       expect(() => queue.setConcurrency(0)).toThrow("Concurrency must be a positive integer");
       expect(() => queue.setConcurrency(-1)).toThrow("Concurrency must be a positive integer");
@@ -1059,6 +1089,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 3, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs
       queue.enqueue(1, "test/repo");
@@ -1102,6 +1133,7 @@ describe("JobQueue", () => {
       };
 
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue multiple jobs for each repo
       queue.enqueue(1, "test/repo1");
@@ -1137,6 +1169,7 @@ describe("JobQueue", () => {
 
       // No project concurrency specified - should use global limit
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo1");
       queue.enqueue(2, "test/repo1");
@@ -1168,6 +1201,7 @@ describe("JobQueue", () => {
       };
 
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Jobs should start simultaneously for different repos
       queue.enqueue(1, "test/repo1");
@@ -1191,6 +1225,7 @@ describe("JobQueue", () => {
 
       const projectConcurrency = { "test/repo": 1 };
       const queue = new JobQueue(store, 5, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Enqueue 3 jobs for same repo with limit 1
       const job1 = queue.enqueue(1, "test/repo");
@@ -1226,6 +1261,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // First failure
       const job1 = queue.enqueue(1, "test/repo");
@@ -1271,6 +1307,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("failure after success"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Two failures
       const job1 = queue.enqueue(1, "test/repo");
@@ -1302,6 +1339,7 @@ describe("JobQueue", () => {
     it("should auto-resume project after pause duration expires", async () => {
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Manually pause project for short duration
       const shortPauseDuration = 100; // 100ms
@@ -1329,6 +1367,7 @@ describe("JobQueue", () => {
     it("should manually resume paused project", async () => {
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Pause project
       queue.pauseProject("test/repo", 60000); // 1 minute
@@ -1359,6 +1398,7 @@ describe("JobQueue", () => {
         .mockResolvedValue({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 2, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Fail repo1 three times to pause it
       const job1 = queue.enqueue(1, "test/repo1");
@@ -1393,6 +1433,7 @@ describe("JobQueue", () => {
       // Test the logic by simulating job stuck abort without waiting for timeout
       const handler: JobHandler = vi.fn().mockResolvedValue({ prUrl: "https://pr/success" });
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const job1 = queue.enqueue(1, "test/repo");
 
@@ -1417,6 +1458,7 @@ describe("JobQueue", () => {
         .mockResolvedValueOnce({ prUrl: "https://pr/success" });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Manual pause
       queue.pauseProject("test/repo", 60000);
@@ -1440,6 +1482,7 @@ describe("JobQueue", () => {
     it("should handle getProjectStatus for non-existent project", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const status = queue.getProjectStatus("non/existent");
       expect(status).toBeNull();
@@ -1448,6 +1491,7 @@ describe("JobQueue", () => {
     it("should handle project pause with zero or negative duration", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Zero duration should effectively be no pause
       queue.pauseProject("test/repo", 0);
@@ -1467,6 +1511,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 5, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Set project limit to 1
       queue.setProjectConcurrency("test/repo", 1);
@@ -1500,6 +1545,7 @@ describe("JobQueue", () => {
 
       // Start with limit of 1
       const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Remove the limit at runtime
       queue.setProjectConcurrency("test/repo", null);
@@ -1519,6 +1565,7 @@ describe("JobQueue", () => {
     it("should validate limit value", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       expect(() => queue.setProjectConcurrency("test/repo", 0)).toThrow("Project concurrency limit must be a positive integer");
       expect(() => queue.setProjectConcurrency("test/repo", -1)).toThrow("Project concurrency limit must be a positive integer");
@@ -1540,6 +1587,7 @@ describe("JobQueue", () => {
 
       // Start with project limit of 1
       const queue = new JobQueue(store, 5, handler, 600000, { "test/repo": 1 });
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo");
       queue.enqueue(2, "test/repo");
@@ -1607,6 +1655,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 5, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Set different limits for two repos
       queue.setProjectConcurrency("org/repo-x", 1);
@@ -1633,6 +1682,7 @@ describe("JobQueue", () => {
     it("should clear projectErrorState on recover (paused project is resumed)", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Pause a project
       queue.pauseProject("test/repo", 60000); // 1분 pause
@@ -1652,6 +1702,7 @@ describe("JobQueue", () => {
         .mockRejectedValueOnce(new Error("failure 2"));
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // 두 번 실패하여 consecutiveFailures = 2
       const job1 = queue.enqueue(1, "test/repo");
@@ -1674,6 +1725,7 @@ describe("JobQueue", () => {
     it("should clear projectErrorState for multiple repos on recover", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // 두 repo 모두 pause
       queue.pauseProject("test/repo1", 60000);
@@ -1781,6 +1833,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // Mix jobs with and without priority
       queue.enqueue(1, "test/repo", undefined, false, "low");
@@ -1839,6 +1892,7 @@ describe("JobQueue", () => {
       // concurrency=0으로 시작하여 모든 잡을 먼저 pending 큐에 쌓음
       // (A 잡들이 슬롯을 독점하기 전에 B 잡도 큐에 있어야 라운드 로빈이 동작)
       const queue = new JobQueue(store, 0, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // A: 10개 대기
       for (let i = 1; i <= 10; i++) {
@@ -1886,6 +1940,7 @@ describe("JobQueue", () => {
 
       // concurrency=1: 순차 실행으로 라운드 로빈 순서 정확히 관찰
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       // A[1] 먼저 시작
       queue.enqueue(1, "project/A");
@@ -1924,6 +1979,7 @@ describe("JobQueue", () => {
       });
 
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "project/A");
       queue.enqueue(2, "project/A");
@@ -1954,6 +2010,7 @@ describe("JobQueue", () => {
       // concurrency=0으로 시작하여 모든 잡을 큐에 쌓은 뒤 라운드 로빈 적용
       const projectConcurrency = { "project/A": 1, "project/B": 2 };
       const queue = new JobQueue(store, 0, handler, 600000, projectConcurrency);
+      queue.setDependencies({ projectRoot: dataDir });
 
       for (let i = 1; i <= 5; i++) {
         queue.enqueue(i, "project/A");
@@ -1982,6 +2039,7 @@ describe("JobQueue", () => {
     it("should resolve immediately when no jobs are running", async () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       const start = Date.now();
       await queue.shutdown(5000);
@@ -1991,6 +2049,7 @@ describe("JobQueue", () => {
     it("should reject new jobs after shutdown", async () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       void queue.shutdown(100);
 
@@ -2007,6 +2066,7 @@ describe("JobQueue", () => {
           })
       );
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
       queue.enqueue(1, "test/repo");
 
       await new Promise((r) => setTimeout(r, 30));
@@ -2022,6 +2082,7 @@ describe("JobQueue", () => {
     it("should resolve after timeout even if jobs are still running", async () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
       queue.enqueue(1, "test/repo");
 
       await new Promise((r) => setTimeout(r, 30));
@@ -2040,6 +2101,7 @@ describe("JobQueue", () => {
     it("should return undefined when no taskFactory is set", () => {
       const handler: JobHandler = vi.fn().mockImplementation(() => new Promise(() => {}));
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       queue.enqueue(1, "test/repo");
       const jobs = store.list();
@@ -2052,6 +2114,7 @@ describe("JobQueue", () => {
     it("should return undefined and log warning when queue is shutting down", () => {
       const handler: JobHandler = vi.fn();
       const queue = new JobQueue(store, 1, handler);
+      queue.setDependencies({ projectRoot: dataDir });
 
       void queue.shutdown(5000);
 

--- a/tests/queue/job-scheduler.test.ts
+++ b/tests/queue/job-scheduler.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JobScheduler } from "../../src/queue/job-scheduler.js";
+import type { JobStore, Job as StoreJob } from "../../src/queue/job-store.js";
+import type { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+
+function makeStoreJob(overrides: Partial<StoreJob> = {}): StoreJob {
+  return {
+    id: "job-x",
+    issueNumber: 1,
+    repo: "a/b",
+    status: "queued",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastUpdatedAt: "2025-01-01T00:00:00.000Z",
+    logs: [],
+    currentStep: null,
+    ...overrides,
+  } as unknown as StoreJob;
+}
+
+function makeStore(jobs: Record<string, StoreJob> = {}): JobStore {
+  return {
+    isClosed: false,
+    get: vi.fn((id: string) => jobs[id]),
+    update: vi.fn(),
+    findAnyByIssue: vi.fn(),
+    findCompletedByIssue: vi.fn(() => undefined),
+  } as unknown as JobStore;
+}
+
+function makeTracker(paused = new Set<string>()): ProjectErrorTracker {
+  return {
+    isProjectPaused: vi.fn((repo: string) => paused.has(repo)),
+    getProjectStatus: vi.fn((repo: string) =>
+      paused.has(repo) ? { pausedUntil: Date.now() + 60_000 } : null
+    ),
+  } as unknown as ProjectErrorTracker;
+}
+
+describe("JobScheduler", () => {
+  let cancelled: Set<string>;
+  let onStartJob: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    cancelled = new Set();
+    onStartJob = vi.fn();
+  });
+
+  it("enqueue → onStartJob 호출 + running.size 증가 + store.update(running)", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledWith(j);
+    expect(scheduler.runningCount).toBe(1);
+    expect(scheduler.isRunning("j1")).toBe(true);
+    expect(store.update).toHaveBeenCalledWith(
+      "j1",
+      expect.objectContaining({ status: "running" })
+    );
+  });
+
+  it("concurrency 한도 초과 시 pending 유지", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "a/b" });
+    const j2 = makeStoreJob({ id: "j2", repo: "c/d" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+    expect(scheduler.getStatus()).toEqual({ pending: 1, running: 1, concurrency: 1 });
+  });
+
+  it("markJobFinished로 슬롯 해제 시 다음 잡 시작", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "a/b" });
+    const j2 = makeStoreJob({ id: "j2", repo: "c/d" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+
+    scheduler.markJobFinished("j1", "a/b");
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenCalledTimes(2);
+    expect(scheduler.runningCount).toBe(1);
+    expect(scheduler.isRunning("j2")).toBe(true);
+  });
+
+  it("removePending: pending에서 제거 후 onStartJob 호출 안 됨", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 0, // 즉시 처리 안 됨
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("j1");
+    expect(scheduler.removePending("j1")).toBe(true);
+    expect(scheduler.removePending("j1")).toBe(false);
+    expect(onStartJob).not.toHaveBeenCalled();
+  });
+
+  it("cancelledRef에 미리 set된 잡은 onStartJob 호출 안 됨 + 플래그 클리어", async () => {
+    const j = makeStoreJob({ id: "j1" });
+    const store = makeStore({ j1: j });
+    cancelled.add("j1");
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(cancelled.has("j1")).toBe(false);
+  });
+
+  it("project pause 상태면 잡을 deferred 처리 (다음 호출에 다시 시도)", async () => {
+    const j = makeStoreJob({ id: "j1", repo: "paused/repo" });
+    const store = makeStore({ j1: j });
+    const paused = new Set(["paused/repo"]);
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(paused),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(scheduler.getStatus().pending).toBe(1);
+  });
+
+  it("setProjectConcurrency 0이면 다음 잡은 시작 안 됨, null이면 제한 해제", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "r1" });
+    const j2 = makeStoreJob({ id: "j2", repo: "r1" });
+    const store = makeStore({ j1, j2 });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 5,
+      projectConcurrency: { r1: 1 },
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    scheduler.enqueue("j2");
+    await new Promise((r) => setImmediate(r));
+
+    // r1 제한 1 → j1만 시작
+    expect(onStartJob).toHaveBeenCalledTimes(1);
+    expect(scheduler.getStatus().pending).toBe(1);
+
+    scheduler.setProjectConcurrency("r1", null);
+    await new Promise((r) => setImmediate(r));
+
+    // 제한 해제 → j2 시작
+    expect(onStartJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("setConcurrency: 양수 정수가 아니면 throw", () => {
+    const scheduler = new JobScheduler({
+      store: makeStore(),
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+    expect(() => scheduler.setConcurrency(0)).toThrow();
+    expect(() => scheduler.setConcurrency(-1)).toThrow();
+    expect(() => scheduler.setConcurrency(1.5)).toThrow();
+  });
+
+  it("dependency 미충족이면 deferred", async () => {
+    const j1 = makeStoreJob({ id: "j1", repo: "r1", dependencies: [99] });
+    const store = makeStore({ j1 });
+    (store.findAnyByIssue as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.enqueue("j1");
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).not.toHaveBeenCalled();
+    expect(scheduler.getStatus().pending).toBe(1);
+  });
+
+  it("round-robin: 다른 repo 잡을 번갈아 서빙", async () => {
+    const j1a = makeStoreJob({ id: "j1a", repo: "A", createdAt: "2025-01-01T00:00:00Z" });
+    const j1b = makeStoreJob({ id: "j1b", repo: "A", createdAt: "2025-01-01T00:00:01Z" });
+    const j2a = makeStoreJob({ id: "j2a", repo: "B", createdAt: "2025-01-01T00:00:02Z" });
+    const store = makeStore({ j1a, j1b, j2a });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("j1a");
+    scheduler.pushPending("j1b");
+    scheduler.pushPending("j2a");
+    void scheduler.processNext();
+    await new Promise((r) => setImmediate(r));
+
+    // 첫 잡: A repo의 가장 빠른 j1a
+    expect(onStartJob).toHaveBeenNthCalledWith(1, j1a);
+
+    scheduler.markJobFinished("j1a", "A");
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    // 다음 잡: 다른 repo B의 j2a (round-robin)
+    expect(onStartJob).toHaveBeenNthCalledWith(2, j2a);
+  });
+
+  it("priority: high가 normal보다 먼저", async () => {
+    const jHigh = makeStoreJob({ id: "jH", repo: "X", priority: "high", createdAt: "2025-01-01T00:00:01Z" } as Partial<StoreJob>);
+    const jNorm = makeStoreJob({ id: "jN", repo: "X", priority: "normal", createdAt: "2025-01-01T00:00:00Z" } as Partial<StoreJob>);
+    const store = makeStore({ jH: jHigh, jN: jNorm });
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+
+    scheduler.pushPending("jN");
+    scheduler.pushPending("jH");
+    void scheduler.processNext();
+    await new Promise((r) => setImmediate(r));
+
+    expect(onStartJob).toHaveBeenNthCalledWith(1, jHigh);
+  });
+
+  it("store.isClosed면 processNext no-op", async () => {
+    const store = makeStore();
+    (store as unknown as { isClosed: boolean }).isClosed = true;
+    const scheduler = new JobScheduler({
+      store,
+      errorTracker: makeTracker(),
+      concurrency: 1,
+      cancelledRef: cancelled,
+      onStartJob,
+    });
+    scheduler.pushPending("any");
+    await scheduler.processNext();
+    expect(onStartJob).not.toHaveBeenCalled();
+  });
+});

--- a/tests/queue/project-error-tracker.test.ts
+++ b/tests/queue/project-error-tracker.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ProjectErrorTracker } from "../../src/queue/project-error-tracker.js";
+import type { ConfigProvider } from "../../src/config/config-provider.js";
+import type { AQConfig } from "../../src/types/config.js";
+
+function makeConfigProvider(config: Partial<AQConfig> = {}): ConfigProvider {
+  return {
+    current: () => config as AQConfig,
+    refresh: () => {},
+  };
+}
+
+describe("ProjectErrorTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("isProjectPaused / pauseProject / resumeProject", () => {
+    it("초기 상태는 paused가 아니다", () => {
+      const tracker = new ProjectErrorTracker();
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+
+    it("pauseProject 후 isProjectPaused는 true", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 60_000);
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("pause 만료 시 자동 재개", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 1000);
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+
+    it("resumeProject는 pause를 해제", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.pauseProject("a/b", 60_000);
+      tracker.resumeProject("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+    });
+  });
+
+  describe("trackFailure", () => {
+    it("기본 임계값 3회 도달 시 자동 pause", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(false);
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("config의 pauseThreshold가 우선", () => {
+      const provider = makeConfigProvider({
+        projects: [{ repo: "a/b", pauseThreshold: 1, pauseDurationMs: 60_000 } as never],
+      });
+      const tracker = new ProjectErrorTracker(provider);
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+
+    it("configProvider 없이도 기본값으로 동작", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      const status = tracker.getProjectStatus("a/b");
+      expect(status?.consecutiveFailures).toBe(1);
+    });
+
+    it("config.current() throw 시 기본값 fallback", () => {
+      const provider: ConfigProvider = {
+        current: () => {
+          throw new Error("config broken");
+        },
+        refresh: () => {},
+      };
+      const tracker = new ProjectErrorTracker(provider);
+      tracker.trackFailure("a/b");
+      const status = tracker.getProjectStatus("a/b");
+      expect(status?.consecutiveFailures).toBe(1);
+    });
+  });
+
+  describe("trackSuccess", () => {
+    it("연속 실패 카운터를 0으로 리셋", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.trackFailure("a/b");
+      tracker.trackSuccess("a/b");
+      expect(tracker.getProjectStatus("a/b")?.consecutiveFailures).toBe(0);
+    });
+
+    it("수동 pausedUntil은 trackSuccess가 유지", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.pauseProject("a/b", 60_000);
+      tracker.trackSuccess("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+  });
+
+  describe("setConfigProvider", () => {
+    it("지연 주입 후 trackFailure가 새 provider를 사용", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.setConfigProvider(
+        makeConfigProvider({
+          projects: [{ repo: "a/b", pauseThreshold: 1, pauseDurationMs: 60_000 } as never],
+        })
+      );
+      tracker.trackFailure("a/b");
+      expect(tracker.isProjectPaused("a/b")).toBe(true);
+    });
+  });
+
+  describe("clear", () => {
+    it("모든 상태를 비운다", () => {
+      const tracker = new ProjectErrorTracker();
+      tracker.trackFailure("a/b");
+      tracker.pauseProject("c/d", 60_000);
+      tracker.clear();
+      expect(tracker.getProjectStatus("a/b")).toBeNull();
+      expect(tracker.isProjectPaused("c/d")).toBe(false);
+    });
+  });
+});

--- a/tests/queue/stuck-monitor.test.ts
+++ b/tests/queue/stuck-monitor.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const claudeMocks = vi.hoisted(() => ({
+  isClaudeProcessAlive: vi.fn(() => false),
+  getLastActivityMs: vi.fn(() => Date.now()),
+}));
+
+const stuckDetectorMock = vi.hoisted(() => ({
+  checkJobStuck: vi.fn(),
+}));
+
+vi.mock("../../src/claude/claude-runner.js", () => claudeMocks);
+vi.mock("../../src/queue/stuck-detector.js", () => stuckDetectorMock);
+
+import { StuckJobMonitor } from "../../src/queue/stuck-monitor.js";
+import type { Job as StoreJob, JobStore } from "../../src/queue/job-store.js";
+import type { Job } from "../../src/types/pipeline.js";
+
+function makeStore(getResult: StoreJob | undefined = undefined): JobStore {
+  return {
+    get: vi.fn(() => getResult),
+    update: vi.fn(),
+  } as unknown as JobStore;
+}
+
+function makeStoreJob(id: string): StoreJob {
+  return {
+    id,
+    issueNumber: 1,
+    repo: "a/b",
+    status: "running",
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    logs: [],
+    currentStep: null,
+  } as unknown as StoreJob;
+}
+
+describe("StuckJobMonitor", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    claudeMocks.isClaudeProcessAlive.mockReturnValue(false);
+    claudeMocks.getLastActivityMs.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start/stop은 setInterval을 토글한다", () => {
+    const monitor = new StuckJobMonitor({
+      store: makeStore(),
+      stuckTimeoutMs: 1000,
+      checkIntervalMs: 100,
+      getRunningJobIds: () => [],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.start();
+    vi.advanceTimersByTime(250);
+    monitor.stop();
+    vi.advanceTimersByTime(500);
+    // 정상 동작 — 에러 없음
+    expect(true).toBe(true);
+  });
+
+  it("stuck 판정 시 onStuckDetected 콜백 호출", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: true,
+      reason: "타임아웃",
+      category: "default",
+      elapsedMs: 600_000,
+      thresholdMs: 300_000,
+    });
+    const storeJob = makeStoreJob("job-1");
+    const store = makeStore(storeJob);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-1"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(onStuckDetected).toHaveBeenCalledWith("job-1", "타임아웃");
+  });
+
+  it("stuck 아님 + threshold 초과 시 lastUpdatedAt 갱신", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "Claude 활동 중",
+      category: "default",
+      elapsedMs: 600_000,
+      thresholdMs: 300_000,
+    });
+    const storeJob = makeStoreJob("job-2");
+    const store = makeStore(storeJob);
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-2"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.runOnce();
+
+    expect(store.update).toHaveBeenCalledWith(
+      "job-2",
+      expect.objectContaining({ lastUpdatedAt: expect.any(String) })
+    );
+  });
+
+  it("threshold 이내 reason은 액션 없음", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "임계값 이내",
+      category: "default",
+      elapsedMs: 100,
+      thresholdMs: 1000,
+    });
+    const storeJob = makeStoreJob("job-3");
+    const store = makeStore(storeJob);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["job-3"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(store.update).not.toHaveBeenCalled();
+    expect(onStuckDetected).not.toHaveBeenCalled();
+  });
+
+  it("store.get이 undefined 반환하면 해당 잡은 스킵", () => {
+    const store = makeStore(undefined);
+    const onStuckDetected = vi.fn();
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      getRunningJobIds: () => ["ghost"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected,
+    });
+
+    monitor.runOnce();
+
+    expect(stuckDetectorMock.checkJobStuck).not.toHaveBeenCalled();
+    expect(onStuckDetected).not.toHaveBeenCalled();
+  });
+
+  it("interval 발화 시 checkJobStuck 호출", () => {
+    stuckDetectorMock.checkJobStuck.mockReturnValue({
+      isStuck: false,
+      reason: "임계값 이내",
+      category: "default",
+      elapsedMs: 0,
+      thresholdMs: 1000,
+    });
+    const store = makeStore(makeStoreJob("job-tick"));
+
+    const monitor = new StuckJobMonitor({
+      store,
+      stuckTimeoutMs: 1000,
+      checkIntervalMs: 50,
+      getRunningJobIds: () => ["job-tick"],
+      toJob: (j) => j as unknown as Job,
+      onStuckDetected: () => {},
+    });
+
+    monitor.start();
+    vi.advanceTimersByTime(170); // 50/100/150 = 3회
+    monitor.stop();
+
+    expect(stuckDetectorMock.checkJobStuck).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/security/dashboard-auth.test.ts
+++ b/tests/security/dashboard-auth.test.ts
@@ -113,33 +113,33 @@ describe("Dashboard Auth — apiKey 미설정 시 쓰기 API 차단", () => {
   });
 
   it("apiKey 미설정 시 job cancel(POST)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     // readOnlyGuard 제거 — apiKey 없이도 모든 API 허용
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 job retry(POST)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/retry");
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 job delete(DELETE)은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 project 관리(DELETE)는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     // projects 관리는 apiKey 없이도 허용 (403이 아님)
     expect(res.status).not.toBe(403);
   });
 
   it("apiKey 미설정 시 GET 읽기 요청은 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "GET", "/api/jobs");
     // 403이 아님 (읽기는 허용)
     expect(res.status).not.toBe(403);
@@ -162,7 +162,7 @@ describe("Dashboard Auth — readOnly 모드", () => {
 
   // (1) readOnly=true 시 write 엔드포인트 403 확인
   it("readOnly=true 시 POST /api/jobs/:id/cancel은 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     expect(res.status).toBe(403);
     const body = await res.json() as { error: string };
@@ -170,75 +170,75 @@ describe("Dashboard Auth — readOnly 모드", () => {
   });
 
   it("readOnly=true 시 POST /api/jobs/:id/retry는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/jobs/job-123/retry");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 DELETE /api/jobs/:id는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 DELETE /api/projects/:id는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 POST /api/projects는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/projects");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 PUT /api/config는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "PUT", "/api/config");
     expect(res.status).toBe(403);
   });
 
   it("readOnly=true 시 POST /api/update는 403을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "POST", "/api/update");
     expect(res.status).toBe(403);
   });
 
   // (2) readOnly=true 시 GET 엔드포인트는 허용 (200 확인)
   it("readOnly=true 시 GET /api/jobs는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/jobs");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=true 시 GET /api/stats는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/stats");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=true 시 GET /api/config는 허용된다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, undefined, undefined, undefined, true);
+    const app = createDashboardRoutes({ store, queue, readOnly: true });
     const res = await request(app, "GET", "/api/config");
     expect(res.status).not.toBe(403);
   });
 
   // (3) readOnly=false(기본) 시 기존 동작 유지 — write 엔드포인트가 403이 아님
   it("readOnly=false(기본) 시 POST /api/jobs/:id/cancel은 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "POST", "/api/jobs/job-123/cancel");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=false(기본) 시 DELETE /api/jobs/:id는 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/jobs/job-123");
     expect(res.status).not.toBe(403);
   });
 
   it("readOnly=false(기본) 시 DELETE /api/projects/:id는 차단되지 않는다", async () => {
-    const app = createDashboardRoutes(store, queue);
+    const app = createDashboardRoutes({ store, queue });
     const res = await request(app, "DELETE", "/api/projects/owner-repo");
     expect(res.status).not.toBe(403);
   });
@@ -260,7 +260,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 Authorization 헤더 없으면 /api/jobs는 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs");
     expect(res.status).toBe(401);
     const body = await res.json() as { error: string };
@@ -268,7 +268,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("잘못된 API 키로 요청 시 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: "Bearer wrong-key",
     });
@@ -276,7 +276,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("올바른 Bearer 토큰으로 요청 시 통과한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -285,7 +285,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("Bearer 접두어 없이 키만 보내면 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/jobs", {
       Authorization: API_KEY,
     });
@@ -293,7 +293,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("POST /api/auth에서 올바른 키로 세션 토큰을 발급받는다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "POST", "/api/auth", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -305,7 +305,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("POST /api/auth에서 잘못된 키는 401을 반환한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "POST", "/api/auth", {
       Authorization: "Bearer bad-key",
     });
@@ -313,19 +313,19 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 /api/stats도 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/stats");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/config도 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/config");
     expect(res.status).toBe(401);
   });
 
   it("타이밍 어택 방어: 잘못된 키도 일정 시간 내 응답한다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const start = Date.now();
     await request(app, "GET", "/api/jobs", {
       Authorization: "Bearer x",
@@ -337,43 +337,43 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("apiKey 설정 시 /api/metrics/throughput은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/throughput");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/metrics/success-rate은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/success-rate");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/skip-events/stats은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/skip-events/stats");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/claude-profile은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/claude-profile");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/repositories은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/repositories");
     expect(res.status).toBe(401);
   });
 
   it("apiKey 설정 시 /api/projects/health은 인증 필요하다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/projects/health");
     expect(res.status).toBe(401);
   });
 
   it("올바른 Bearer 토큰으로 /api/metrics/throughput 요청 시 401이 아니다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/metrics/throughput", {
       Authorization: `Bearer ${API_KEY}`,
     });
@@ -381,7 +381,7 @@ describe("Dashboard Auth — apiKey 설정 시 인증 강제", () => {
   });
 
   it("올바른 Bearer 토큰으로 /api/claude-profile 요청 시 401이 아니다", async () => {
-    const app = createDashboardRoutes(store, queue, undefined, API_KEY);
+    const app = createDashboardRoutes({ store, queue, apiKey: API_KEY });
     const res = await request(app, "GET", "/api/claude-profile", {
       Authorization: `Bearer ${API_KEY}`,
     });

--- a/tests/server/auth-rate-limit.test.ts
+++ b/tests/server/auth-rate-limit.test.ts
@@ -299,9 +299,14 @@ describe("POST /api/auth — rate-limit 통합 테스트", () => {
   let app: Hono;
 
   beforeEach(() => {
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey, undefined, {
+    app = createDashboardRoutes({
+      store: mockJobStore,
+      queue: mockJobQueue,
+      apiKey,
+      dashboardAuth: {
       rateLimit: { maxAttempts: 3, windowMs: 60_000, blockDurationMs: 60_000 },
       sessionTtlMs: 3_600_000,
+    },
     });
   });
 

--- a/tests/server/bind-security.test.ts
+++ b/tests/server/bind-security.test.ts
@@ -94,7 +94,7 @@ const mockQueue = {
 
 // Helper: createDashboardRoutes without apiKey, with given hostname
 function makeRoutes(hostname?: string) {
-  return createDashboardRoutes(mockStore, mockQueue, undefined, undefined, hostname);
+  return createDashboardRoutes({ store: mockStore, queue: mockQueue, hostname });
 }
 
 describe("isLocalBind detection (no API key)", () => {
@@ -198,7 +198,7 @@ describe("non-local bind + no API key: security warning", () => {
   });
 
   it("does not warn when API key is provided with non-local hostname", () => {
-    createDashboardRoutes(mockStore, mockQueue, undefined, "secure-api-key", "0.0.0.0");
+    createDashboardRoutes({ store: mockStore, queue: mockQueue, apiKey: "secure-api-key", hostname: "0.0.0.0" });
     expect(mockWarn).not.toHaveBeenCalledWith(
       expect.stringContaining("Non-local bind")
     );

--- a/tests/server/dashboard-api.test.ts
+++ b/tests/server/dashboard-api.test.ts
@@ -122,7 +122,7 @@ describe("Dashboard API - /api/config", () => {
 
   describe("without API key", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("should return config without authentication", async () => {
@@ -164,7 +164,7 @@ describe("Dashboard API - /api/config", () => {
     const apiKey = "test-api-key-123";
 
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
     });
 
     it("should require Bearer token authentication", async () => {
@@ -264,7 +264,7 @@ describe("Dashboard API - PUT /api/config", () => {
 
   describe("without API key", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("should update config section successfully", async () => {
@@ -489,7 +489,7 @@ describe("Dashboard API - PUT /api/config", () => {
     const apiKey = "test-api-key-123";
 
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
     });
 
     it("should require Bearer token authentication", async () => {
@@ -605,7 +605,7 @@ describe("Dashboard API - SSE broadcast", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(mockStore, mockQueue);
+    app = createDashboardRoutes({ store: mockStore, queue: mockQueue });
   });
 
   it("should register SSE client and handle job deletion event", async () => {
@@ -690,7 +690,7 @@ describe("Dashboard API - Resource Management", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(mockStore, mockQueue, undefined, apiKey);
+    app = createDashboardRoutes({ store: mockStore, queue: mockQueue, apiKey });
   });
 
   it("should create SSE client with proper timestamps", async () => {
@@ -736,7 +736,7 @@ describe("Dashboard API - Projects Management", () => {
     vi.clearAllMocks();
     mockDetectProjectCommands.mockReturnValue({ language: "unknown", commands: {} });
     mockDetectBaseBranch.mockResolvedValue("main");
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
   });
 
   describe("POST /api/projects", () => {
@@ -1287,7 +1287,7 @@ describe("Dashboard API - Version Management", () => {
   describe("GET /api/version", () => {
     describe("without API key", () => {
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       it("should return version info with update check", async () => {
@@ -1406,7 +1406,7 @@ describe("Dashboard API - Version Management", () => {
       const apiKey = "test-api-key-123";
 
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       it("should require Bearer token authentication", async () => {
@@ -1450,7 +1450,7 @@ describe("Dashboard API - Version Management", () => {
   describe("POST /api/update", () => {
     describe("without API key", () => {
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       it("should perform update successfully when no jobs running", async () => {
@@ -1562,7 +1562,7 @@ describe("Dashboard API - Version Management", () => {
       const apiKey = "test-api-key-123";
 
       beforeEach(() => {
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       it("should require Bearer token authentication", async () => {
@@ -1614,7 +1614,7 @@ describe("Dashboard API - Version Management", () => {
 
       beforeEach(() => {
         vi.clearAllMocks();
-        app = createDashboardRoutes(mockJobStore, mockJobQueue);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
       });
 
       describe("GET /api/jobs with project filter", () => {
@@ -1777,7 +1777,7 @@ describe("Dashboard API - Version Management", () => {
 
       beforeEach(() => {
         vi.clearAllMocks();
-        app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, apiKey);
+        app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, apiKey });
       });
 
       describe("GET /api/jobs with project filter", () => {
@@ -1858,7 +1858,7 @@ describe("Dashboard API - GET /api/health (detailed)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockLoadConfig.mockReturnValue(mockConfig as any);
 
@@ -2012,7 +2012,7 @@ describe("Dashboard API - GET /api/projects/health", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -2172,7 +2172,7 @@ describe("Dashboard API - SSE Connection Management", () => {
       cancel: vi.fn(),
       retryJob: vi.fn(),
     } as any;
-    return createDashboardRoutes(store, queue);
+    return createDashboardRoutes({ store, queue });
   }
 
   beforeEach(() => {
@@ -2343,7 +2343,7 @@ describe("Dashboard API - SSE Connection Management", () => {
         cancel: vi.fn(),
         retryJob: vi.fn(),
       } as any;
-      const appWithError = createDashboardRoutes(throwingStore, throwingQueue);
+      const appWithError = createDashboardRoutes({ store: throwingStore, queue: throwingQueue });
 
       // Should not throw even when store.list() throws inside the stream
       const response = await appWithError.request("/api/events");
@@ -2402,7 +2402,7 @@ describe("Dashboard API - PUT /api/jobs/:id/priority", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(localStore, localQueue);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue });
   });
 
   it("should update job priority to high", async () => {
@@ -2560,7 +2560,7 @@ describe("Dashboard API - PUT /api/jobs/:id/priority", () => {
         retryJob: vi.fn(),
       } as any;
 
-      app = createDashboardRoutes(localStore, localQueue, undefined, apiKey);
+      app = createDashboardRoutes({ store: localStore, queue: localQueue, apiKey });
     });
 
     it("should return 401 without authentication", async () => {
@@ -2601,7 +2601,7 @@ describe("Dashboard API - GET /api/repositories", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -2794,7 +2794,7 @@ describe("Dashboard API - GET /api/claude-profile", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     mockLoadConfig.mockReturnValue(mockClaudeConfig as any);
   });
 
@@ -2883,7 +2883,7 @@ describe("Dashboard API - GET /api/jobs/:id/logs/stream", () => {
       retryJob: vi.fn(),
     } as any;
 
-    app = createDashboardRoutes(localStore, localQueue);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue });
   });
 
   it("should return SSE stream with correct headers", async () => {
@@ -2943,7 +2943,7 @@ describe("Dashboard API - GET /api/projects/health warning branch", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     mockExistsSync.mockReturnValue(true);
     mockStatSync.mockReturnValue({ isDirectory: () => true } as any);
@@ -3014,7 +3014,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3037,7 +3037,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3061,7 +3061,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(200);
@@ -3078,7 +3078,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     await app.request("/api/projects/my-org%2Fmy-repo/error-state");
     expect(localQueue.getProjectStatus).toHaveBeenCalledWith("my-org/my-repo");
@@ -3093,7 +3093,7 @@ describe("Dashboard API - GET /api/projects/:repo/error-state", () => {
         throw new Error("Internal queue error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/error-state");
     expect(response.status).toBe(500);
@@ -3116,7 +3116,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const before = Date.now();
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
@@ -3141,7 +3141,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3162,7 +3162,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3183,7 +3183,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3204,7 +3204,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3225,7 +3225,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
       retryJob: vi.fn(),
       pauseProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3244,7 +3244,7 @@ describe("Dashboard API - POST /api/projects/:repo/pause", () => {
         throw new Error("Queue internal error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/pause", {
       method: "POST",
@@ -3270,7 +3270,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
       retryJob: vi.fn(),
       resumeProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/resume", {
       method: "POST",
@@ -3290,7 +3290,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
       retryJob: vi.fn(),
       resumeProject: vi.fn(),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     await app.request("/api/projects/my-org%2Fmy-repo/resume", { method: "POST" });
     expect(localQueue.resumeProject).toHaveBeenCalledWith("my-org/my-repo");
@@ -3305,7 +3305,7 @@ describe("Dashboard API - POST /api/projects/:repo/resume", () => {
         throw new Error("Queue internal error");
       }),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     const response = await app.request("/api/projects/owner%2Frepo/resume", {
       method: "POST",
@@ -3336,7 +3336,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(errorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [
@@ -3362,7 +3362,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [{ repo: "org/repo1", path: "./repo1" }],
@@ -3382,7 +3382,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(null),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({ projects: [] } as any);
 
@@ -3405,7 +3405,7 @@ describe("Dashboard API - GET /api/projects includes errorState", () => {
       retryJob: vi.fn(),
       getProjectStatus: vi.fn().mockReturnValue(pausedErrorState),
     } as any;
-    app = createDashboardRoutes(mockJobStore, localQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: localQueue });
 
     mockLoadConfig.mockReturnValue({
       projects: [{ repo: "org/paused-repo", path: "./paused-repo" }],
@@ -3438,7 +3438,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     const mockConfigWatcher = { current: mockCurrent } as any;
     mockMaskSensitiveConfig.mockReturnValue(mockConfig as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, mockConfigWatcher);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, configWatcher: mockConfigWatcher });
 
     await app.request("/api/config");
     await app.request("/api/config");
@@ -3462,7 +3462,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     const mockConfigWatcher = { current: mockCurrent } as any;
     mockMaskSensitiveConfig.mockImplementation((c) => c as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue, mockConfigWatcher);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, configWatcher: mockConfigWatcher });
 
     const res1 = await app.request("/api/config");
     const result1 = await res1.json() as { config: { general: { projectName: string } } };
@@ -3482,7 +3482,7 @@ describe("Dashboard API - stale config 회귀 테스트 (configWatcher.current()
     mockLoadConfig.mockReturnValue(mockConfig as any);
     mockMaskSensitiveConfig.mockReturnValue(mockConfig as any);
 
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 
     const response = await app.request("/api/config");
 
@@ -3516,7 +3516,7 @@ describe("Dashboard API - POST /api/jobs/:id/cancel", () => {
       retryJob: vi.fn(),
     };
 
-    app = createDashboardRoutes(localStore, localQueue as any);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue as any });
   });
 
   it("should return 400 for invalid JSON body", async () => {
@@ -3606,7 +3606,7 @@ describe("Dashboard API - POST /api/jobs/:id/retry", () => {
       retryJob: vi.fn(),
     };
 
-    app = createDashboardRoutes(localStore, localQueue as any);
+    app = createDashboardRoutes({ store: localStore, queue: localQueue as any });
   });
 
   it("should return 400 for invalid JSON body", async () => {

--- a/tests/server/failure-reasons-api.test.ts
+++ b/tests/server/failure-reasons-api.test.ts
@@ -80,7 +80,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("카테고리별 집계", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("실패 잡이 있을 때 카테고리별 집계 결과를 반환한다", async () => {
@@ -208,7 +208,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
         formatForPrompt: vi.fn(),
       } as any;
 
-      app = createDashboardRoutes(mockJobStore, mockJobQueue, undefined, undefined, undefined, undefined, undefined, mockPatternStore);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue, patternStore: mockPatternStore });
 
       mockGetFailureReasons.mockReturnValue({
         reasons: [{ category: "TIMEOUT", count: 5, percentage: 100.0, recentErrors: [] }],
@@ -233,7 +233,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("유효하지 않은 파라미터", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("잘못된 window 값에 400을 반환한다", async () => {
@@ -263,7 +263,7 @@ describe("Dashboard API - GET /api/metrics/failure-reasons", () => {
 
   describe("에러 핸들링", () => {
     beforeEach(() => {
-      app = createDashboardRoutes(mockJobStore, mockJobQueue);
+      app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     });
 
     it("getFailureReasons가 예외를 던지면 500을 반환한다", async () => {

--- a/tests/server/new-issue-api.test.ts
+++ b/tests/server/new-issue-api.test.ts
@@ -112,7 +112,7 @@ describe("POST /api/new-issue", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    app = createDashboardRoutes(mockJobStore, mockJobQueue);
+    app = createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
     mockLoadTemplate.mockReturnValue("template {{what}}");
     mockRenderTemplate.mockReturnValue("rendered body");
     mockRunCli.mockResolvedValue({ exitCode: 0, stdout: "https://github.com/owner/repo/issues/42\n", stderr: "" });
@@ -236,10 +236,11 @@ describe("POST /api/new-issue", () => {
   });
 
   it("readOnly 모드에서 POST 요청을 403으로 거부한다", async () => {
-    const readOnlyApp = createDashboardRoutes(
-      mockJobStore, mockJobQueue,
-      undefined, undefined, undefined, undefined, true
-    );
+    const readOnlyApp = createDashboardRoutes({
+      store: mockJobStore,
+      queue: mockJobQueue,
+      readOnly: true,
+    });
 
     const response = await readOnlyApp.request("/api/new-issue", {
       method: "POST",

--- a/tests/server/setup-api.test.ts
+++ b/tests/server/setup-api.test.ts
@@ -127,7 +127,7 @@ const mockJobQueue = {
 } as unknown as JobQueue;
 
 function makeApp() {
-  return createDashboardRoutes(mockJobStore, mockJobQueue);
+  return createDashboardRoutes({ store: mockJobStore, queue: mockJobQueue });
 }
 
 async function postJson(app: ReturnType<typeof makeApp>, path: string, body: unknown) {

--- a/tests/server/sse-manager.test.ts
+++ b/tests/server/sse-manager.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SSEManager } from "../../src/server/sse-manager.js";
+
+function makeController() {
+  return {
+    enqueue: vi.fn(),
+    close: vi.fn(),
+    error: vi.fn(),
+    desiredSize: 0,
+    terminate: vi.fn(),
+  } as unknown as ReadableStreamDefaultController<Uint8Array>;
+}
+
+describe("SSEManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("addClient / clientCount / removeClient", () => {
+    it("addClient는 ID를 반환하고 clientCount를 증가시킨다", () => {
+      const m = new SSEManager();
+      const id = m.addClient(makeController());
+      expect(id).toBeTruthy();
+      expect(m.clientCount).toBe(1);
+    });
+
+    it("외부 ID 주입 시 그대로 사용한다", () => {
+      const m = new SSEManager();
+      const id = m.addClient(makeController(), "external-id");
+      expect(id).toBe("external-id");
+    });
+
+    it("removeClient는 컨트롤러 close + 맵에서 제거", () => {
+      const m = new SSEManager();
+      const ctrl = makeController();
+      const id = m.addClient(ctrl, "abc");
+      m.removeClient(id);
+      expect(m.clientCount).toBe(0);
+      expect(ctrl.close).toHaveBeenCalled();
+    });
+
+    it("존재하지 않는 클라이언트 removeClient는 무시", () => {
+      const m = new SSEManager();
+      expect(() => m.removeClient("nope")).not.toThrow();
+    });
+
+    it("close 예외는 무시되고 맵에서 제거된다", () => {
+      const m = new SSEManager();
+      const ctrl = makeController();
+      (ctrl.close as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("already closed");
+      });
+      const id = m.addClient(ctrl);
+      expect(() => m.removeClient(id)).not.toThrow();
+      expect(m.clientCount).toBe(0);
+    });
+  });
+
+  describe("maxClients enforcement", () => {
+    it("한도 초과 시 가장 오래된 클라이언트를 evict한다", () => {
+      const m = new SSEManager({ maxClients: 2 });
+      const c1 = makeController();
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(c1, "first");
+      vi.setSystemTime(new Date("2026-04-26T00:00:01.000Z"));
+      m.addClient(makeController(), "second");
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      m.addClient(makeController(), "third");
+
+      expect(m.clientCount).toBe(2);
+      // oldest(first) should have been evicted
+      expect(c1.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("broadcast", () => {
+    it("모든 클라이언트에 SSE 메시지를 enqueue한다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      const c2 = makeController();
+      m.addClient(c1);
+      m.addClient(c2);
+      m.broadcast("jobUpdated", { id: 1 });
+
+      expect(c1.enqueue).toHaveBeenCalledTimes(1);
+      expect(c2.enqueue).toHaveBeenCalledTimes(1);
+
+      const sent = (c1.enqueue as ReturnType<typeof vi.fn>).mock.calls[0][0] as Uint8Array;
+      const decoded = new TextDecoder().decode(sent);
+      expect(decoded).toContain("event: jobUpdated");
+      expect(decoded).toContain('"id":1');
+    });
+
+    it("enqueue 실패한 클라이언트는 풀에서 제거", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      (c1.enqueue as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("write failed");
+      });
+      m.addClient(c1, "broken");
+      m.addClient(makeController(), "ok");
+
+      m.broadcast("event", {});
+      expect(m.clientCount).toBe(1);
+    });
+
+    it("clientTimeoutMs 초과한 클라이언트는 broadcast 시 제거", () => {
+      const m = new SSEManager({ clientTimeoutMs: 1000 });
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(makeController(), "stale");
+
+      vi.setSystemTime(new Date("2026-04-26T00:00:02.000Z"));
+      m.broadcast("event", {});
+      expect(m.clientCount).toBe(0);
+    });
+  });
+
+  describe("sendHeartbeat / removeStale", () => {
+    it("sendHeartbeat은 heartbeat 이벤트를 모든 클라이언트에 보낸다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      m.addClient(c1);
+      m.sendHeartbeat();
+
+      const sent = (c1.enqueue as ReturnType<typeof vi.fn>).mock.calls[0][0] as Uint8Array;
+      const decoded = new TextDecoder().decode(sent);
+      expect(decoded).toContain("event: heartbeat");
+    });
+
+    it("removeStale은 timeout 초과 클라이언트만 제거", () => {
+      const m = new SSEManager({ clientTimeoutMs: 1000 });
+      vi.setSystemTime(new Date("2026-04-26T00:00:00.000Z"));
+      m.addClient(makeController(), "old");
+      vi.setSystemTime(new Date("2026-04-26T00:00:01.500Z"));
+      m.addClient(makeController(), "fresh");
+
+      // old: lastHeartbeat=0s, now=1.5s, timeout=1s → stale
+      // fresh: lastHeartbeat=1.5s, now=1.5s → fresh
+      m.removeStale();
+      expect(m.clientCount).toBe(1);
+    });
+  });
+
+  describe("startHeartbeat / stopHeartbeat", () => {
+    it("startHeartbeat은 주기적으로 heartbeat을 송출한다", () => {
+      const m = new SSEManager({ heartbeatMs: 100 });
+      const c1 = makeController();
+      m.addClient(c1);
+      m.startHeartbeat();
+      vi.advanceTimersByTime(350);
+      // 100, 200, 300ms — 3회
+      expect(c1.enqueue).toHaveBeenCalledTimes(3);
+      m.stopHeartbeat();
+    });
+
+    it("startHeartbeat을 두 번 호출해도 interval이 누수되지 않는다", () => {
+      const m = new SSEManager({ heartbeatMs: 100 });
+      const c1 = makeController();
+      m.addClient(c1);
+      m.startHeartbeat();
+      m.startHeartbeat(); // restart
+      vi.advanceTimersByTime(150);
+      // 첫 interval은 종료됐으니 1회만 발화
+      expect(c1.enqueue).toHaveBeenCalledTimes(1);
+      m.stopHeartbeat();
+    });
+  });
+
+  describe("cleanupAll", () => {
+    it("모든 컨트롤러를 close하고 맵을 비운다", () => {
+      const m = new SSEManager();
+      const c1 = makeController();
+      const c2 = makeController();
+      m.addClient(c1);
+      m.addClient(c2);
+      m.cleanupAll();
+
+      expect(c1.close).toHaveBeenCalled();
+      expect(c2.close).toHaveBeenCalled();
+      expect(m.clientCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## v0.9.0 릴리스 (Plan C 완료)

표면 메트릭(tsc/vitest/any/TODO 모두 clean)은 v0.8.10에서 이미 통과했지만, 그 뒤에 숨은 **설계 품질 부채**를 걷어내 코드 품질 축을 끌어올린 릴리스.

## 핵심 변화

### 1. 단일 파일 거대화 해소
- **dashboard-api.ts: 2119 → 290줄 (86% 감축)** — 12 도메인 라우트 모듈 분할
- **job-queue.ts: 952 → 444줄 (53% 감축)** — StuckMonitor + Lifecycle + Scheduler 3-way Facade 분리
- **pipeline-phases.ts: 791 → 713줄** — runPhaseWithTracking으로 post-processing 4 phase 중복 제거

### 2. 동시성/안전성 강화
- `JobCleanupService` — fire-and-forget cleanup race 차단 (await Promise.allSettled)
- `ProjectErrorTracker` — config-driven 임계값 + 명시적 의존성 주입
- `StuckJobMonitor` — 외부 콜백 기반, store/processNext 의존성 격리
- `process.cwd()` 직접 참조 `src/queue/` 내 0건 달성 (Plan C 검증 게이트)

### 3. 신규 인프라 모듈
**Queue/Job 도메인:**
- `src/queue/job-cleanup.ts`, `project-error-tracker.ts`, `stuck-monitor.ts`, `job-lifecycle.ts`, `job-scheduler.ts`

**Server 도메인:**
- `src/server/sse-manager.ts`, `route-context.ts`, `health-checks.ts`
- `src/server/routes/*` (12개 파일): notifications, version, projects, jobs, stats, config, setup, doctor, health, skip-events, new-issue, sse, auth

**Pipeline 도메인:**
- `src/pipeline/phases/phase-tracker.ts` — runPhaseWithTracking 헬퍼 + CoreLoopPhaseContext

### 4. 내부 API breaking 변경 (외부 계약은 보존)
- `JobQueue` 생성자: 위치 파라미터 유지 (테스트 호환), 새 책임은 내부 위임
- `JobQueue.retryJob`: sync → async (cleanup race 차단)
- `createDashboardRoutes`: 9 positional → `DashboardRoutesOptions` 객체
- `PatternStore` 메서드: sync → async (#C3 mutex)

**외부 계약 (CLI 명령, HTTP API 경로, config.yml 스키마)는 모두 하위 호환 유지.**

### 5. Dead code 850줄+ 제거 (#C4)
- `coordinator.ts`(187), `worker-pool.ts`(252), `finding-formatter.ts`(60) 외 다수 삭제
- 미사용 config 필드(multiAI, sessionTtlMs, WorkerPoolConfig) 정리

## Plan C 이슈 완료 (12/12)
- ✅ #C1 Clock | ✅ #C2 ConfigProvider | ✅ #C3 PatternStore Mutex | ✅ #C4 Dead code
- ✅ #C5 SSEManager + DashboardContext | ✅ #C6 JobCleanup + ProjectErrorTracker
- ✅ #C7 plan-generator AST | ✅ #C8 phase-tracker
- ✅ #C9 dashboard-api 12 도메인 분할 (PR #820~#831)
- ✅ #C10 JobQueue Facade (Phase 1/2/3 PR #817~#819)
- ✅ #C11 runPhaseWithTracking 적용
- ✅ #C12 createDashboardRoutes 시그니처 (PR #832)

## 검증
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3406 passed / 7 skipped / 0 failed (160 files)
- [x] `npm run lint` — 0 errors

## Test plan
- [ ] 자가 파이프라인 1건 실제 실행 (#C1 또는 dead code 이슈로 dogfooding)
- [ ] dashboard UI smoke (Playwright e2e)
- [ ] CLI/HTTP API 하위 호환성 — 기존 클라이언트로 회귀 확인