### PR TITLE
fix(plan): Plan 생성 실패 진단 인프라 (#800-1)

### DIFF
--- a/src/pipeline/phases/plan-failure-dump.ts
+++ b/src/pipeline/phases/plan-failure-dump.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, writeFileSync, appendFileSync } from "fs";
+import { join } from "path";
+import { getLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/error-utils.js";
+
+const logger = getLogger();
+
+/**
+ * Plan 생성 실패(JSON 파싱 미스매치) 진단 인프라 (#800-1).
+ *
+ * 배경: #791/#792/#795/#796 등 4건 연속 동일한 "JSON 파싱 실패" 패턴이 관찰됐다.
+ *      재현/패턴 분석을 위해 본 모듈은 매 실패마다 raw 응답 + 메타데이터를 디스크에 적재한다.
+ *
+ * 산출물:
+ *  - `$AQM_HOME/logs/plan-fail-{issueNumber}-{timestamp}.txt` — Claude raw 응답 (replay용)
+ *  - `$AQM_HOME/logs/plan-fail-{issueNumber}-{timestamp}.json` — 메타데이터(JSON)
+ *  - `$AQM_HOME/logs/plan-failures-index.jsonl` — 모든 실패의 한 줄 요약 (시계열 분석)
+ *
+ * 비목표: 복구 자체는 #800-2(파서 강건화)/#800-3(프롬프트)/#800-4(차등 retry)에서 처리.
+ */
+
+export interface PlanFailureCharStats {
+  backticks: number;
+  arrowRight: number;
+  curlyQuotes: number;
+  controlChars: number;
+  nonAscii: number;
+}
+
+export interface PlanFailureRecord {
+  issueNumber: number;
+  attempt: number;
+  errorCategory: string;
+  errorMessage: string;
+  responseLength: number;
+  rawDumpFile: string;
+  charStats: PlanFailureCharStats;
+  timestamp: string;
+}
+
+/** 실패 응답에 자주 등장하는 문제 문자 카운트. 패턴 분류용. */
+export function computeCharStats(text: string): PlanFailureCharStats {
+  let backticks = 0;
+  let arrowRight = 0;
+  let curlyQuotes = 0;
+  let controlChars = 0;
+  let nonAscii = 0;
+
+  for (const ch of text) {
+    const code = ch.codePointAt(0)!;
+
+    if (ch === "`") backticks++;
+    else if (ch === "→") arrowRight++;
+    else if (ch === "“" || ch === "”" || ch === "‘" || ch === "’") curlyQuotes++;
+
+    if (code < 32 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+      controlChars++;
+    }
+    if (code > 127) {
+      nonAscii++;
+    }
+  }
+
+  return { backticks, arrowRight, curlyQuotes, controlChars, nonAscii };
+}
+
+export interface DumpPlanFailureOpts {
+  aqmHome: string;
+  issueNumber: number;
+  attempt: number;
+  errorCategory: string;
+  errorMessage: string;
+  rawResponse: string;
+  /** 시계 주입 (테스트용). 미지정 시 현재 시각. */
+  now?: Date;
+}
+
+/**
+ * Plan 실패 응답을 디스크에 저장하고 인덱스 라인을 추가한다.
+ * 실패가 발생해도 호출부의 흐름을 깨지 않도록 모든 IO 에러는 swallow + warn.
+ *
+ * @returns 작성된 PlanFailureRecord, 또는 저장 실패 시 undefined.
+ */
+export function dumpPlanFailure(opts: DumpPlanFailureOpts): PlanFailureRecord | undefined {
+  const { aqmHome, issueNumber, attempt, errorCategory, errorMessage, rawResponse } = opts;
+  const now = opts.now ?? new Date();
+  const timestamp = now.toISOString().replace(/[:.]/g, "-");
+  const logsDir = join(aqmHome, "logs");
+
+  try {
+    mkdirSync(logsDir, { recursive: true });
+
+    const rawDumpFile = join(logsDir, `plan-fail-${issueNumber}-${timestamp}.txt`);
+    const metaDumpFile = join(logsDir, `plan-fail-${issueNumber}-${timestamp}.json`);
+    const indexFile = join(logsDir, "plan-failures-index.jsonl");
+
+    const charStats = computeCharStats(rawResponse);
+    const record: PlanFailureRecord = {
+      issueNumber,
+      attempt,
+      errorCategory,
+      errorMessage,
+      responseLength: rawResponse.length,
+      rawDumpFile,
+      charStats,
+      timestamp: now.toISOString(),
+    };
+
+    writeFileSync(rawDumpFile, rawResponse, "utf-8");
+    writeFileSync(metaDumpFile, JSON.stringify(record, null, 2), "utf-8");
+    appendFileSync(indexFile, JSON.stringify(record) + "\n", "utf-8");
+
+    logger.warn(
+      `[plan-fail-dump] issue=#${issueNumber} attempt=${attempt} ` +
+      `bytes=${rawResponse.length} backticks=${charStats.backticks} arrows=${charStats.arrowRight} ` +
+      `→ ${rawDumpFile}`
+    );
+
+    return record;
+  } catch (err: unknown) {
+    logger.warn(`Failed to dump plan failure: ${getErrorMessage(err)}`);
+    return undefined;
+  }
+}

--- a/src/pipeline/phases/plan-generator.ts
+++ b/src/pipeline/phases/plan-generator.ts
@@ -52,6 +52,7 @@ import { notifyPlanRetryContext } from "../../notification/notifier.js";
 import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { AQM_HOME } from "../../config/project-resolver.js";
+import { dumpPlanFailure } from "./plan-failure-dump.js";
 import { DEFAULT_PLAN_MAX_RETRIES } from "../execution/retry-config.js";
 import { analyzeTokenUsage, truncateRepoStructure, truncateToTokenBudget } from "../../review/token-estimator.js";
 
@@ -316,16 +317,15 @@ export async function generatePlan(ctx: PlanGeneratorContext): Promise<PlanWithC
       errorMessage = getErrorMessage(parseError);
       logger.error(`Plan JSON parsing failed (attempt ${attempt}): ${errorMessage}. Claude output: ${result.output.slice(0, 500)}`);
 
-      try {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const logsDir = join(AQM_HOME, 'logs');
-        mkdirSync(logsDir, { recursive: true });
-        const dumpPath = join(logsDir, `plan-fail-${ctx.issue.number}-${timestamp}.txt`);
-        writeFileSync(dumpPath, result.output, 'utf-8');
-        logger.warn(`Plan 원본 응답 저장됨: ${dumpPath}`);
-      } catch (dumpError: unknown) {
-        logger.warn(`Failed to dump plan response: ${getErrorMessage(dumpError)}`);
-      }
+      // #800-1: 실패 응답 + 메타데이터 + 인덱스 라인 일괄 적재 (replay/패턴 분석용)
+      dumpPlanFailure({
+        aqmHome: AQM_HOME,
+        issueNumber: ctx.issue.number,
+        attempt,
+        errorCategory,
+        errorMessage,
+        rawResponse: result.output,
+      });
 
       // 히스토리 기록
       retryContext.generationHistory.push({

--- a/tests/pipeline/phases/plan-failure-dump.test.ts
+++ b/tests/pipeline/phases/plan-failure-dump.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { dumpPlanFailure, computeCharStats } from "../../../src/pipeline/phases/plan-failure-dump.js";
+
+describe("computeCharStats", () => {
+  it("백틱/화살표/curly quote/control char 카운트", () => {
+    const text = "Hello `world` → 한글 “quote” \x07 ascii";
+    const stats = computeCharStats(text);
+
+    expect(stats.backticks).toBe(2);
+    expect(stats.arrowRight).toBe(1);
+    expect(stats.curlyQuotes).toBe(2);
+    expect(stats.controlChars).toBe(1);
+    expect(stats.nonAscii).toBeGreaterThan(0);
+  });
+
+  it("줄바꿈/탭은 controlChars에 포함하지 않는다", () => {
+    expect(computeCharStats("a\nb\tc\rd").controlChars).toBe(0);
+  });
+
+  it("ASCII 전용 문자열은 nonAscii=0", () => {
+    expect(computeCharStats("plain text").nonAscii).toBe(0);
+  });
+});
+
+describe("dumpPlanFailure", () => {
+  let aqmHome: string;
+
+  beforeEach(() => {
+    aqmHome = mkdtempSync(join(tmpdir(), "plan-fail-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(aqmHome, { recursive: true, force: true });
+  });
+
+  it("raw .txt + meta .json + index.jsonl 3개를 생성한다", () => {
+    const fixedNow = new Date("2026-04-29T12:00:00.000Z");
+    const record = dumpPlanFailure({
+      aqmHome,
+      issueNumber: 791,
+      attempt: 2,
+      errorCategory: "UNKNOWN",
+      errorMessage: "Unexpected token in JSON at position 1234",
+      rawResponse: "raw `claude` output → 한글 with \x07 ctrl",
+      now: fixedNow,
+    });
+
+    expect(record).toBeDefined();
+    const logsDir = join(aqmHome, "logs");
+    const files = readdirSync(logsDir).sort();
+
+    expect(files).toContain("plan-failures-index.jsonl");
+    expect(files.some(f => f.startsWith("plan-fail-791-") && f.endsWith(".txt"))).toBe(true);
+    expect(files.some(f => f.startsWith("plan-fail-791-") && f.endsWith(".json"))).toBe(true);
+
+    // raw 응답 보존
+    const txt = readFileSync(record!.rawDumpFile, "utf-8");
+    expect(txt).toBe("raw `claude` output → 한글 with \x07 ctrl");
+
+    // 메타 JSON 구조
+    const metaPath = record!.rawDumpFile.replace(/\.txt$/, ".json");
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    expect(meta.issueNumber).toBe(791);
+    expect(meta.attempt).toBe(2);
+    expect(meta.errorCategory).toBe("UNKNOWN");
+    expect(meta.charStats.backticks).toBe(2);
+    expect(meta.charStats.arrowRight).toBe(1);
+    expect(meta.charStats.controlChars).toBe(1);
+  });
+
+  it("같은 이슈 재실패 시 인덱스에 라인이 누적된다", () => {
+    dumpPlanFailure({
+      aqmHome, issueNumber: 791, attempt: 1, errorCategory: "UNKNOWN",
+      errorMessage: "fail-1", rawResponse: "first",
+      now: new Date("2026-04-29T12:00:00.000Z"),
+    });
+    dumpPlanFailure({
+      aqmHome, issueNumber: 791, attempt: 2, errorCategory: "UNKNOWN",
+      errorMessage: "fail-2", rawResponse: "second",
+      now: new Date("2026-04-29T12:00:01.000Z"),
+    });
+
+    const indexPath = join(aqmHome, "logs", "plan-failures-index.jsonl");
+    const lines = readFileSync(indexPath, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+    expect(first.attempt).toBe(1);
+    expect(second.attempt).toBe(2);
+    expect(first.errorMessage).toBe("fail-1");
+    expect(second.errorMessage).toBe("fail-2");
+  });
+
+  it("aqmHome가 존재하지 않으면 자동 생성한다", () => {
+    const nestedHome = join(aqmHome, "deep", "nested");
+    expect(existsSync(nestedHome)).toBe(false);
+
+    const record = dumpPlanFailure({
+      aqmHome: nestedHome,
+      issueNumber: 1,
+      attempt: 1,
+      errorCategory: "UNKNOWN",
+      errorMessage: "x",
+      rawResponse: "y",
+    });
+
+    expect(record).toBeDefined();
+    expect(existsSync(join(nestedHome, "logs"))).toBe(true);
+  });
+
+  it("IO 실패 시에도 throw하지 않고 undefined 반환", () => {
+    // aqmHome 경로에 일반 파일을 두면 그 하위 mkdir이 ENOTDIR로 실패한다
+    const fakeHome = join(aqmHome, "fake");
+    writeFileSync(fakeHome, "this-is-a-file-not-a-dir", "utf-8");
+
+    const result = dumpPlanFailure({
+      aqmHome: fakeHome,
+      issueNumber: 1,
+      attempt: 1,
+      errorCategory: "UNKNOWN",
+      errorMessage: "x",
+      rawResponse: "y",
+    });
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 배경
#791/#792/#795/#796 등 4건 연속 "JSON 파싱 실패" 패턴 관찰. 재현/패턴 분석을 위한 데이터 인프라가 부족했음 (raw 응답만 .txt로 저장).

## 변경
- `src/pipeline/phases/plan-failure-dump.ts` 신규 (118줄)
  - `dumpPlanFailure()` — 실패마다 raw `.txt` + 메타 `.json` + `index.jsonl` 일괄 적재
  - `computeCharStats()` — 백틱/화살표/curly quote/control char/non-ASCII 카운트
- `plan-generator.ts`에서 인라인 dump 로직을 헬퍼로 위임
- 단위 테스트 7건

## 산출물 위치 (런타임)
- `$AQM_HOME/logs/plan-fail-{issueNumber}-{timestamp}.txt` — replay용 raw 응답
- `$AQM_HOME/logs/plan-fail-{issueNumber}-{timestamp}.json` — 메타데이터 (charStats 포함)
- `$AQM_HOME/logs/plan-failures-index.jsonl` — 시계열 한 줄 요약

## #800 분할 위치
- **#800-1 본 PR** — 진단 인프라 (수동)
- 후속 #800-2: 파서 강건화 (수동, 본 PR 데이터 활용)
- 후속 #800-3: 프롬프트 단순화 (AQM 가능)
- 후속 #800-4: 차등 retry (AQM 가능)
- 후속 #800-5: Structured output API (수동, 별도 트랙)

## Test plan
- [x] `npx tsc --noEmit` — 0 error
- [x] `npx vitest run` — 3413 passed / 7 skipped / 0 failed (161 files, +1)
- [x] `npm run lint` — clean