### PR TITLE
[AQ-#843] refactor: core-loop에 executor 팩토리 분기 추가 (mode 기반)

### DIFF
--- a/src/config/mode-presets.ts
+++ b/src/config/mode-presets.ts
@@ -36,9 +36,22 @@ const CONTENT_PRESET: ModePreset = {
   planHint: "이 이슈는 코드가 아닌 콘텐츠(문서, 블로그 등) 작업입니다. Phase를 1개로 구성하고 파일 생성/수정에 집중하세요.",
 };
 
+const QA_PRESET: ModePreset = {
+  skipTests: false,
+  skipLint: false,
+  skipBuild: false,
+  skipTypecheck: false,
+  skipReview: false,
+  skipSimplify: false,
+  skipFinalValidation: false,
+  maxPhases: 10,
+  planHint: "",
+};
+
 const PRESETS: Record<PipelineMode, ModePreset> = {
   code: CODE_PRESET,
   content: CONTENT_PRESET,
+  qa: QA_PRESET,
 };
 
 export function getModePreset(mode: PipelineMode): ModePreset {
@@ -51,7 +64,7 @@ export function getModePreset(mode: PipelineMode): ModePreset {
 export function detectModeFromLabels(labels: string[], defaultMode: PipelineMode = "code"): PipelineMode {
   for (const label of labels) {
     const match = label.match(/^aq-mode:(\w+)$/);
-    if (match && (match[1] === "code" || match[1] === "content")) {
+    if (match && (match[1] === "code" || match[1] === "content" || match[1] === "qa")) {
       return match[1] as PipelineMode;
     }
   }

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -1,5 +1,5 @@
 import { generatePlan } from "../phases/plan-generator.js";
-import { executePhase } from "../execution/phase-executor.js";
+import { selectExecutor } from "../execution/executor-factory.js";
 import { retryPhase } from "../execution/phase-retry.js";
 import { checkPhaseLimit } from "../../safety/phase-limit-guard.js";
 import { schedulePhases } from "../execution/phase-scheduler.js";

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -369,7 +369,7 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
       jl?.setStep(`Phase ${phase.index + 1}/${plan.phases.length}: ${phase.name}`);
       jl?.setProgress(phaseStart(phase.index, plan.phases.length));
 
-      let result = await executePhase({
+      let result = await selectExecutor(plan.mode ?? "code").execute({
         issue: ctx.issue,
         plan,
         phase,

--- a/src/pipeline/execution/executor-factory.ts
+++ b/src/pipeline/execution/executor-factory.ts
@@ -1,0 +1,19 @@
+import { executePhase, type PhaseExecutorContext } from "./phase-executor.js";
+import type { PhaseResult } from "../../types/pipeline.js";
+
+export interface PhaseExecutor {
+  execute(ctx: PhaseExecutorContext): Promise<PhaseResult>;
+}
+
+const claudePhaseExecutor: PhaseExecutor = {
+  execute(ctx: PhaseExecutorContext): Promise<PhaseResult> {
+    return executePhase(ctx);
+  },
+};
+
+export function selectExecutor(mode: "code" | "content" | "qa" | undefined): PhaseExecutor {
+  if (mode === "qa") {
+    throw new Error("qa executor not implemented");
+  }
+  return claudePhaseExecutor;
+}

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -354,7 +354,7 @@ export async function executeCoreLoopPhase(
 
   if (coreResult.plan.mode && !issue.labels.some((l: string) => l.startsWith("aq-mode:"))) {
     const planMode = coreResult.plan.mode;
-    if (planMode !== mode) {
+    if (planMode !== "qa" && planMode !== mode) {
       finalMode = planMode;
       finalPreset = getModePreset(finalMode);
       logger.info(`Pipeline mode updated by Plan: ${finalMode}`);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -206,7 +206,7 @@ export interface ExecutionModePreset {
   description: string;
 }
 
-export type PipelineMode = "code" | "content";
+export type PipelineMode = "code" | "content" | "qa";
 export type ExecutionMode = "economy" | "standard" | "thorough";
 export type ServerMode = "polling" | "webhook" | "hybrid";
 

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -52,7 +52,7 @@ export interface CostBreakdown {
 }
 
 export interface Plan {
-  mode?: "code" | "content";
+  mode?: "code" | "content" | "qa";
   issueNumber: number;
   title: string;
   problemDefinition: string;

--- a/tests/pipeline/execution/executor-factory.test.ts
+++ b/tests/pipeline/execution/executor-factory.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../../src/pipeline/execution/phase-executor.js", () => ({
+  executePhase: vi.fn(),
+}));
+
+import { selectExecutor } from "../../../src/pipeline/execution/executor-factory.js";
+
+describe("selectExecutor — 팩토리 분기 검증", () => {
+  it('selectExecutor("code")가 execute 메서드를 가진 PhaseExecutor를 반환한다', () => {
+    const executor = selectExecutor("code");
+
+    expect(executor).toBeDefined();
+    expect(typeof executor.execute).toBe("function");
+  });
+
+  it('selectExecutor("content")가 execute 메서드를 가진 PhaseExecutor를 반환한다', () => {
+    const executor = selectExecutor("content");
+
+    expect(executor).toBeDefined();
+    expect(typeof executor.execute).toBe("function");
+  });
+
+  it('selectExecutor(undefined)가 execute 메서드를 가진 PhaseExecutor를 반환한다', () => {
+    const executor = selectExecutor(undefined);
+
+    expect(executor).toBeDefined();
+    expect(typeof executor.execute).toBe("function");
+  });
+
+  it('selectExecutor("qa") 호출 시 "not implemented"를 포함한 에러를 throw한다', () => {
+    expect(() => selectExecutor("qa")).toThrow(/not implemented/i);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #843 — refactor: core-loop에 executor 팩토리 분기 추가 (mode 기반)

core-loop가 executePhase를 직접 호출해 mode별 executor 분기 확장이 어렵다. Plan.mode에 qa placeholder를 추가하고 selectExecutor 팩토리로 분기점을 도입해 향후 PlaywrightPhaseExecutor 연결 지점을 확보한다. 기존 code/content 동작은 100% 유지.

## Requirements

- Plan.mode 타입에 "qa" 리터럴 추가 (placeholder)
- src/pipeline/execution/executor-factory.ts 신규 생성: PhaseExecutor 인터페이스와 selectExecutor(mode) 팩토리 정의
- code/content 모드는 기존 executePhase를 래핑한 ClaudePhaseExecutor 반환
- qa 모드는 throw new Error("qa executor not implemented") 처리
- core-loop.ts의 executePhase 직접 호출을 selectExecutor(plan.mode).execute(ctx)로 전환
- pipeline-phases.ts 등 Plan.mode를 PipelineMode로 좁히는 지점에 "qa" 가드 추가 (타입 에러 방지)
- 기존 code/content 파이프라인 동작은 100% 유지 (회귀 없음)
- npx tsc --noEmit 통과
- npx vitest run 통과

## Implementation Phases

- Phase -5: plan:generate — SUCCESS (-)
- Phase 0: 타입 확장 및 executor-factory 신규 작성 — SUCCESS (399907d8)
- Phase 1: core-loop 및 pipeline-phases 통합 — SUCCESS (88178e4b)
- Phase 2: executor-factory 단위 테스트 추가 — SUCCESS (b017354c)

## Risks

- Plan.mode 확장으로 PipelineMode(code|content)에 좁히는 기존 코드(pipeline-phases.ts:358)에서 타입 에러 발생 가능 — 가드 추가로 해결
- executor-factory의 PhaseExecutor 인터페이스가 PhaseExecutorContext와 PhaseResult 시그니처를 정확히 일치시켜야 함
- core-loop 변경 시 retry 경로(retryPhase)는 분기 대상이 아니므로 그대로 둬야 함 (qa 미구현 단계에서는 retry 무관)
- qa 모드가 실제 Plan에서 반환되는 일은 아직 없음에도 throw 경로가 트리거되면 파이프라인이 즉사하므로 placeholder임을 주석으로 명시

## Pipeline Stats

- **Instance**: `aqm-by`
- **Total Cost**: $2.5583 (review: $0.1426)
- **Phases**: 4/4 completed
- **Branch**: `aq/843-refactor-core-loop-executor-mode` → `develop`
- **Tokens**: 159 input, 22515 output
- **Cache Hit**: 100.0% (절감 토큰: 2726622)


### Phase Cost Breakdown

| Phase | Cost | Retries | Retry Cost |
|-------|------|---------|------------|
| 타입 확장 및 executor-factory 신규 작성 | $0.5504 | 0 | $0.0000 |
| core-loop 및 pipeline-phases 통합 | $0.6184 | 0 | $0.0000 |
| executor-factory 단위 테스트 추가 | $0.2768 | 0 | $0.0000 |


### Model Usage

| Model | Cost |
|-------|------|
| claude-sonnet-4-6 | $1.4456 |


---

> Generated by AI 병참부 (AI Quartermaster)


Closes #843