### PR TITLE
fix(plan): phase 인덱스 0-base 강제 시 dependsOn 동기화 누락 (#844)

### DIFF
--- a/src/pipeline/phases/plan-generator.ts
+++ b/src/pipeline/phases/plan-generator.ts
@@ -417,6 +417,29 @@ async function handleRetryContext(ctx: PlanGeneratorContext, retryContext: PlanR
   }
 }
 
+export function normalizePhaseIndices(plan: Plan): void {
+  // Build remap from Claude's original index space (may be 0-based or 1-based) to array positions.
+  // Without this, overwriting phase.index = i leaves dependsOn pointing at wrong/self phases
+  // when Claude emits 1-based indices (e.g., Phase 2 dependsOn=[1] → after overwrite becomes self-reference).
+  const originalIndexToPosition = new Map<number, number>();
+  plan.phases.forEach((phase, i) => {
+    if (typeof phase.index === "number") {
+      originalIndexToPosition.set(phase.index, i);
+    }
+  });
+
+  plan.phases.forEach((phase, i) => {
+    phase.targetFiles = phase.targetFiles ?? [];
+    phase.verificationCriteria = phase.verificationCriteria ?? [];
+    const rawDeps = phase.dependsOn ?? [];
+    phase.dependsOn = rawDeps.map(d => {
+      const remapped = originalIndexToPosition.get(d);
+      return remapped !== undefined ? remapped : d;
+    });
+    phase.index = i;
+  });
+}
+
 function validatePlan(plan: Plan): void {
   if (!plan.phases || plan.phases.length === 0) {
     throw new Error("Plan must have at least one phase");
@@ -427,13 +450,7 @@ function validatePlan(plan: Plan): void {
   if (!plan.requirements || plan.requirements.length === 0) {
     throw new Error("Plan must have requirements");
   }
-  // Ensure phases have indices and required array fields
-  plan.phases.forEach((phase, i) => {
-    phase.index = i;
-    phase.targetFiles = phase.targetFiles ?? [];
-    phase.verificationCriteria = phase.verificationCriteria ?? [];
-    phase.dependsOn = phase.dependsOn ?? [];
-  });
+  normalizePhaseIndices(plan);
 
   // Validate phase dependencies (self-dependency, non-existent refs)
   const depValidation = validatePhaseDependencies(plan.phases);

--- a/tests/pipeline/phases/plan-generator.test.ts
+++ b/tests/pipeline/phases/plan-generator.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../../src/claude/model-router.js", () => ({
   configForTaskWithMode: vi.fn(),
 }));
 
-import { generatePlan } from "../../../src/pipeline/phases/plan-generator.js";
+import { generatePlan, normalizePhaseIndices } from "../../../src/pipeline/phases/plan-generator.js";
 import { loadTemplate } from "../../../src/prompt/template-renderer.js";
 import { runClaude, extractJson } from "../../../src/claude/claude-runner.js";
 import { configForTaskWithMode } from "../../../src/claude/model-router.js";
@@ -137,5 +137,55 @@ describe("plan-generator 템플릿 분기 로직", () => {
     expect(calledPaths.some((p) => p.endsWith("plan-generation.md"))).toBe(true);
     expect(calledPaths.some((p) => p.endsWith("plan-generation-retry.md"))).toBe(true);
     expect(mockRunClaude).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("normalizePhaseIndices — Claude 1-based 응답 호환", () => {
+  const baseMeta = {
+    mode: "code" as const,
+    issueNumber: 1,
+    title: "T",
+    problemDefinition: "P",
+    requirements: ["R"],
+    affectedFiles: [] as string[],
+    risks: [] as string[],
+  };
+
+  it("1-based phase index + 1-based dependsOn을 0-based 위치로 remap", () => {
+    const plan = {
+      ...baseMeta,
+      phases: [
+        { index: 1, name: "P1", description: "", targetFiles: [], dependsOn: [], verificationCriteria: [], commitStrategy: "" },
+        { index: 2, name: "P2", description: "", targetFiles: [], dependsOn: [1], verificationCriteria: [], commitStrategy: "" },
+      ],
+    };
+    normalizePhaseIndices(plan as any);
+    expect(plan.phases[0].index).toBe(0);
+    expect(plan.phases[0].dependsOn).toEqual([]);
+    expect(plan.phases[1].index).toBe(1);
+    expect(plan.phases[1].dependsOn).toEqual([0]);
+  });
+
+  it("0-based phase index + 0-based dependsOn은 그대로 유지", () => {
+    const plan = {
+      ...baseMeta,
+      phases: [
+        { index: 0, name: "P1", description: "", targetFiles: [], dependsOn: [], verificationCriteria: [], commitStrategy: "" },
+        { index: 1, name: "P2", description: "", targetFiles: [], dependsOn: [0], verificationCriteria: [], commitStrategy: "" },
+      ],
+    };
+    normalizePhaseIndices(plan as any);
+    expect(plan.phases[1].dependsOn).toEqual([0]);
+  });
+
+  it("dependsOn 미지정 시 빈 배열로 채움", () => {
+    const plan = {
+      ...baseMeta,
+      phases: [
+        { index: 1, name: "P1", description: "", targetFiles: [], verificationCriteria: [], commitStrategy: "" } as any,
+      ],
+    };
+    normalizePhaseIndices(plan as any);
+    expect(plan.phases[0].dependsOn).toEqual([]);
   });
 });


### PR DESCRIPTION
## 요약

- `validatePlan()`이 `phase.index = i` (0-based)로 덮어쓰지만 `dependsOn` 값은 변환하지 않아, Claude가 1-based phase index로 응답할 때 Phase 2 `dependsOn=[1]`이 배열 위치 기준 자기 참조로 오인됨.
- `validatePhaseDependencies`가 `Phase 1 cannot depend on itself`로 reject → 사용자에게는 `JSON 파싱 실패`로 표시되어 #800 트랙과 혼동을 유발.
- `normalizePhaseIndices` 헬퍼 분리 export, 원본 index → 배열 위치 Map 기반 remap. 0-based/1-based 응답 모두 호환.

## 재현 (#844)

```
Claude 응답:
  phases[0] = { index: 1, dependsOn: [] }
  phases[1] = { index: 2, dependsOn: [1] }   ← Phase 1 의도

validatePlan 후 (수정 전):
  phases[0] = { index: 0, dependsOn: [] }
  phases[1] = { index: 1, dependsOn: [1] }   ← 자기 참조!
```

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run tests/pipeline/phases/plan-generator.test.ts` 6/6 pass (기존 3 + 신규 3)
- [x] `npx vitest run` 전체 회귀 163 files / 3434 tests / 0 fail
- [ ] 머지 후 #844 재시도하여 Plan 생성 성공 확인

Closes #844 측면 보조 (Plan 생성 자체 차단 해결, #844의 본 작업과는 별개)