### PR TITLE
fix(install): 기본 모드를 git로, mktemp 템플릿 BSD 호환

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-AQM_INSTALL_MODE="${AQM_INSTALL_MODE:-npm}"
+AQM_INSTALL_MODE="${AQM_INSTALL_MODE:-git}"
 AQM_HOME="${AQM_HOME:-$HOME/.ai-quartermaster}"
 BIN_DIR="${HOME}/.local/bin"
 REPO_URL="https://github.com/happytalkrz/AI-Quartermaster.git"
@@ -128,7 +128,9 @@ check_optional "claude" "https://docs.anthropic.com/en/docs/claude-code"
 echo ""
 
 # ── 2. 설치 ────────────────────────────────────────────────────────────
-NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX.log)
+# macOS(BSD) mktemp는 'XXXXXX' 뒤에 suffix가 있으면 치환을 하지 않아 매 호출 같은 경로를 반환한다.
+# .log 확장자는 외부에 노출되지 않으므로 XXXXXX를 끝에 두고 suffix를 제거한다.
+NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX)
 
 if [ "$AQM_INSTALL_MODE" = "git" ]; then
   # ── git-clone 모드 (AQM_INSTALL_MODE=git) ─────────────────────────


### PR DESCRIPTION
## Summary
- 첫 설치 시 `AQM_INSTALL_MODE` 기본값을 `npm` → `git`로 변경. happytalkrz/AI-Quartermaster는 npm 레지스트리 미공개라 기존 기본값으로는 첫 설치가 즉시 실패.
- `mktemp /tmp/aqm-install-XXXXXX.log` 템플릿의 `.log` suffix 제거. macOS(BSD) mktemp는 `XXXXXX` 뒤에 suffix가 있으면 X 치환을 하지 않아 매 호출 동일 경로 반환 → 재실행 시 `File exists` 충돌.

## 검증
- `bash -n install.sh` 통과
- npm 모드 명시 시(`AQM_INSTALL_MODE=npm`) 기존 동작 유지

## 후속
- README/안내 문서 내 `ai-quartermaster` 라벨 잔재는 별도 PR