### PR TITLE
fix(setup): setup-wizard에서 instanceOwners 강제 입력

### DIFF
--- a/src/setup/setup-wizard.ts
+++ b/src/setup/setup-wizard.ts
@@ -38,6 +38,11 @@ export async function runSetup(aqRoot: string, options?: SetupOptions): Promise<
       const minimalConfig = `# AI 병참부 최소 설정 파일
 # 전체 옵션은 config.reference.yml 참조
 
+general:
+  # 필수: 이 인스턴스가 처리할 이슈를 만든 GitHub 사용자(들).
+  # 비어 있으면 모든 이슈가 차단됩니다. 본인 GitHub 아이디로 교체하세요.
+  instanceOwners: []
+
 projects:
   - repo: "owner/repo-name"        # 필수: GitHub 저장소 (owner/repo)
     path: "/path/to/local/clone"   # 필수: 로컬 클론 경로
@@ -58,7 +63,14 @@ projects:
     }
 
     const answers = await runInteractiveWizard();
+    const ownersYaml = answers.instanceOwners.map(o => `    - "${o}"`).join("\n");
     const userConfig = `# AI 병참부 프로젝트 설정
+
+general:
+  # 이 인스턴스가 처리할 이슈를 만든 GitHub 사용자 목록.
+  # 비어 있으면 모든 이슈가 차단됩니다.
+  instanceOwners:
+${ownersYaml}
 
 projects:
   - repo: "${answers.repo}"
@@ -276,7 +288,31 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
     }
   }
 
-  // 3. 서버 모드 선택 (폴링/웹훅)
+  // 3. 인스턴스 소유자(GitHub 아이디) 입력 — 비어 있으면 모든 이슈가 차단되므로 강제.
+  let instanceOwners: string[] = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const raw = await askQuestion(
+      "이 인스턴스가 처리할 이슈를 만든 GitHub 사용자 (콤마 구분, 예: alice,bob): ",
+    );
+    instanceOwners = raw
+      .split(",")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    const invalid = instanceOwners.find(o => !/^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/.test(o));
+    if (instanceOwners.length === 0) {
+      console.log("   ❌ 최소 1명은 입력해야 합니다. 빈 값이면 모든 이슈가 차단됩니다.");
+      continue;
+    }
+    if (invalid) {
+      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}'`);
+      continue;
+    }
+    break;
+  }
+
+  // 4. 서버 모드 선택 (폴링/웹훅)
   const modeChoices = ["폴링 (간편 — webhook 설정 불필요)", "웹훅 (실시간 — smee.io 필요)"];
   const modeIndex = await askChoice("모드를 선택하세요:", modeChoices);
   const serverMode: ServerMode = modeIndex === 0 ? "polling" : "webhook";
@@ -284,7 +320,8 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
   console.log("\n✅ 설정 완료!");
   console.log(`   저장소: ${repo}`);
   console.log(`   경로: ${path}`);
+  console.log(`   소유자: ${instanceOwners.join(", ")}`);
   console.log(`   모드: ${serverMode}\n`);
 
-  return { repo, path, serverMode };
+  return { repo, path, serverMode, instanceOwners };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -220,6 +220,7 @@ export interface WizardAnswers {
   repo: string;
   path: string;
   serverMode: ServerMode;
+  instanceOwners: string[];
 }
 
 /** Options for the init command */

--- a/tests/setup/setup-wizard.test.ts
+++ b/tests/setup/setup-wizard.test.ts
@@ -257,7 +257,8 @@ PORT=3000
     it("should collect valid answers through complete wizard flow", async () => {
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("test-user/test-repo")  // valid repo
-        .mockResolvedValueOnce(mockPath);               // valid path
+        .mockResolvedValueOnce(mockPath)               // valid path
+        .mockResolvedValueOnce("alice,bob");           // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode (index 0)
@@ -267,10 +268,11 @@ PORT=3000
       expect(result).toEqual({
         repo: "test-user/test-repo",
         path: mockPath,
-        serverMode: "polling"
+        serverMode: "polling",
+        instanceOwners: ["alice", "bob"]
       });
 
-      expect(mockAskQuestion).toHaveBeenCalledTimes(2);
+      expect(mockAskQuestion).toHaveBeenCalledTimes(3);
       expect(mockAskChoice).toHaveBeenCalledTimes(1);
     });
 
@@ -279,7 +281,8 @@ PORT=3000
         .mockResolvedValueOnce("invalid-repo")         // invalid (no slash)
         .mockResolvedValueOnce("user/")               // invalid (empty repo)
         .mockResolvedValueOnce("valid-user/valid-repo") // valid
-        .mockResolvedValueOnce(mockPath);             // valid path
+        .mockResolvedValueOnce(mockPath)              // valid path
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode
@@ -309,7 +312,8 @@ PORT=3000
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")           // valid repo
         .mockResolvedValueOnce(invalidPath)           // invalid path (doesn't exist)
-        .mockResolvedValueOnce(mockPath);              // valid path
+        .mockResolvedValueOnce(mockPath)              // valid path
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(1); // webhook mode (index 1)
@@ -328,7 +332,8 @@ PORT=3000
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")           // valid repo
         .mockResolvedValueOnce(nonExistentPath)       // invalid path
-        .mockResolvedValueOnce(mockPath);             // valid path (after clone suggestion)
+        .mockResolvedValueOnce(mockPath)              // valid path (after clone suggestion)
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode
@@ -367,7 +372,8 @@ PORT=3000
       // Test polling mode (choice 0)
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(mockPath);
+        .mockResolvedValueOnce(mockPath)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0);  // polling mode (index 0)
@@ -381,7 +387,8 @@ PORT=3000
       // Test webhook mode (choice 1)
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(mockPath);
+        .mockResolvedValueOnce(mockPath)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(1);  // webhook mode (index 1)
@@ -394,7 +401,8 @@ PORT=3000
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")    // valid repo
         .mockResolvedValueOnce("")             // empty path - triggers non-existence error
-        .mockResolvedValueOnce(mockPath);      // valid path
+        .mockResolvedValueOnce(mockPath)       // valid path
+        .mockResolvedValueOnce("alice");       // instance owners
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(0);
 
@@ -498,7 +506,8 @@ PORT=3000
     it("should write config and return early for polling mode", async () => {
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(testDir);  // testDir already exists
+        .mockResolvedValueOnce(testDir)        // testDir already exists
+        .mockResolvedValueOnce("alice");       // instance owners
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(0); // polling
 
@@ -508,12 +517,14 @@ PORT=3000
       expect(existsSync(configPath)).toBe(true);
       const content = readFileSync(configPath, "utf-8");
       expect(content).toContain("user/repo");
+      expect(content).toContain("alice");
     });
 
     it("should continue to smee/webhook steps for webhook mode", async () => {
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(testDir);
+        .mockResolvedValueOnce(testDir)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(1); // webhook
 


### PR DESCRIPTION
## Summary
- 인터랙티브 위자드에 GitHub 사용자(콤마 구분) 입력 단계 추가
- 위자드/비인터랙티브 양쪽 모두 config.yml에 \`general.instanceOwners\` 포함
- 빈 배열이면 \`event-dispatcher\`의 \`hasInstanceOwnersConfigured\` 가드에 막혀 모든 이슈가 차단되는 사고를 첫 단계에서 차단

## 배경
첫 설치자가 위자드를 끝까지 돌려도 \`instanceOwners\`가 \`[]\`이라 첫 이슈가 \`instance_owners_not_configured\` 사유로 디스패치 거부됨. 사용자가 "왜 아무것도 잡히지 않지" 막다른 길에 빠지는 보고가 있었음.

## 테스트
- \`npx vitest run tests/setup/setup-wizard.test.ts\` 27/27 통과
- \`npx tsc --noEmit\` 통과