### PR TITLE
fix(config): review/simplify promptTemplate를 raw text → 파일명으로

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -100,8 +100,9 @@ export const DEFAULT_CONFIG: AQConfig = {
     rounds: [
       {
         name: "code-review",
-        promptTemplate:
-          "Review the following code changes for correctness, style, and potential issues:\n\n{diff}",
+        // review-runner는 promptTemplate를 prompts/ 디렉토리 내 파일명으로 취급한다.
+        // raw text를 넣으면 path로 resolve돼 ENOENT가 발생한다.
+        promptTemplate: "review-round1.md",
         failAction: "warn",
         maxRetries: 2,
         model: null,
@@ -111,8 +112,7 @@ export const DEFAULT_CONFIG: AQConfig = {
     ],
     simplify: {
       enabled: true,
-      promptTemplate:
-        "Simplify the following implementation while preserving all functionality:\n\n{diff}",
+      promptTemplate: "review-round3-simplify.md",
     },
     unifiedMode: false,  // 기본값은 false로 기존 동작 유지
   },


### PR DESCRIPTION
## Summary
- defaults.ts의 \`review.rounds[0].promptTemplate\`와 \`review.simplify.promptTemplate\` 기본값을 raw text → 파일명으로 변경
- review-runner / simplify-runner가 \`resolve(promptsDir, ctx.promptTemplate)\`로 파일 경로 취급하기 때문

## 배경
사용자 보고:
\`\`\`
Diagnosis runner failed: Template file not found:
  /Users/.../prompts/Review the following code changes for correctness... {diff}
\`\`\`
사용자 config에 review 섹션이 없으면 defaults의 raw text가 그대로 promptTemplate에 들어가 path resolve 시 ENOENT 발생.

\`prompts/review-round1.md\`, \`prompts/review-round3-simplify.md\`는 이미 존재 — 그 파일명을 가리키도록 정정.

## 검증
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/config/ tests/review/\` 535/535 통과