### PR TITLE
fix(core-loop): content 모드에서 test/lint 명령 스킵

### DIFF
--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -13,6 +13,7 @@ import type { JobLogger } from "../../queue/job-logger.js";
 import { PatternStore, getPatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PLAN_GENERATED, phaseStart } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
+import { getModePreset } from "../../config/mode-presets.js";
 import { createWorktree, removeWorktree } from "../../git/worktree-manager.js";
 import { createCheckpoint } from "../../safety/rollback-manager.js";
 import { createSlug } from "../../utils/slug.js";
@@ -313,6 +314,13 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     }
   }
 
+  // mode preset에 따라 phase 실행 단계에서 사용할 test/lint 명령을 결정한다.
+  // content 모드 등 코드 검증이 부적절한 모드에서는 빈 문자열로 비워 phase-executor /
+  // phase-retry가 명령 실행을 건너뛰도록 한다 (ENOENT 방지).
+  const modePreset = getModePreset(plan.mode ?? "code");
+  const effectiveTestCommand = modePreset.skipTests ? "" : ctx.config.commands.test;
+  const effectiveLintCommand = modePreset.skipLint ? "" : ctx.config.commands.lint;
+
   // Schedule phases for parallel execution based on dependencies
   const enableParallelPhases = ctx.config.features?.parallelPhases ?? false;
   logger.info(`Parallel phases feature: ${enableParallelPhases ? 'enabled' : 'disabled'}`);
@@ -377,8 +385,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         claudeConfig: ctx.config.commands.claudeCli,
         promptsDir: ctx.promptsDir,
         cwd: ctx.cwd,
-        testCommand: ctx.config.commands.test,
-        lintCommand: ctx.config.commands.lint,
+        testCommand: effectiveTestCommand,
+        lintCommand: effectiveLintCommand,
         gitPath: ctx.config.git.gitPath,
         projectConventions: ctx.projectConventions,
         skillsContext: ctx.skillsContext,
@@ -420,8 +428,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
             claudeConfig: ctx.config.commands.claudeCli,
             promptsDir: ctx.promptsDir,
             cwd: ctx.cwd,
-            testCommand: ctx.config.commands.test,
-            lintCommand: ctx.config.commands.lint,
+            testCommand: effectiveTestCommand,
+            lintCommand: effectiveLintCommand,
             gitPath: ctx.config.git.gitPath,
             jobLogger: jl,
             checkpoint,


### PR DESCRIPTION
## Summary
- \`core-loop\`이 plan.mode를 결정한 직후 \`getModePreset\`을 1회 평가해 \`effectiveTestCommand\` / \`effectiveLintCommand\`를 산출
- phase 실행(executor)과 retry(phase-retry) 양쪽에 effective 값을 전달
- content 모드에서는 빈 문자열이 전달되어 phase-retry의 \`if (ctx.testCommand)\` 가드로 실행 스킵

## 배경
사용자 보고:
\`\`\`
content 이슈인데 phase 후 npm test 호출 → ENOENT (package.json 없음)
→ [VERIFICATION_FAILED] CLI_CRASH 분류 → retry 모두 실패
\`\`\`
\`mode-presets.ts\`에 \`skipTests/skipLint=true\`가 정의돼 있었으나 \`core-loop\`가 그 플래그를 읽지 않고 항상 ctx의 raw 명령을 사용하던 버그.

## 검증
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/pipeline/\` 682/682 통과