### PR TITLE
fix(pipeline-phases): content 모드에서 review/simplify 스킵

### DIFF
--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -7,6 +7,7 @@ import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { handleCoreLoopFailure } from "../errors/pipeline-error-handler.js";
 import { runReviewPhase, runSimplifyPhase, type ReviewContext, type SimplifyContext } from "./pipeline-review.js";
+import type { ReviewVariables } from "../../types/review.js";
 import { runValidationPhase } from "../setup/pipeline-validation.js";
 import { pushAndCreatePR, cleanupOnSuccess } from "./pipeline-publish.js";
 import { setupGitEnvironment, prepareWorkEnvironment } from "../setup/pipeline-git-setup.js";
@@ -449,46 +450,59 @@ export async function executePostProcessingPhases(
     });
   }
 
-  // Review Phase
-  const reviewContext: ReviewContext = {
-    issue,
-    coreResult,
-    gitConfig,
-    project,
-    worktreePath,
-    promptsDir,
-    skillsContext,
-    jl,
-    timer,
-    checkpoint
-  };
+  // Review Phase — mode preset이 skipReview면 스킵하고 상태 전이만 수행.
+  let reviewCostUsd = 0;
+  let reviewVariables: ReviewVariables | undefined;
 
-  const reviewTracking = await runPhaseWithTracking(
-    "review:code",
-    () => runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState),
-    context.accumulatedPhaseResults
-  );
-  const reviewResult = reviewTracking.result;
+  if (preset.skipReview) {
+    logger.info("Review phase skipped (preset.skipReview=true)");
+    jl?.log("Review 단계 스킵 (모드 preset)");
+    transitionState(runtime, "REVIEWING");
+  } else {
+    const reviewContext: ReviewContext = {
+      issue,
+      coreResult,
+      gitConfig,
+      project,
+      worktreePath,
+      promptsDir,
+      skillsContext,
+      jl,
+      timer,
+      checkpoint
+    };
 
-  if (!reviewResult.success) {
-    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
-    saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
-    throw new Error(reviewResult.error || "Review phase failed");
+    const reviewTracking = await runPhaseWithTracking(
+      "review:code",
+      () => runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState),
+      context.accumulatedPhaseResults
+    );
+    const reviewResult = reviewTracking.result;
+
+    if (!reviewResult.success) {
+      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
+      saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
+      throw new Error(reviewResult.error || "Review phase failed");
+    }
+
+    reviewCostUsd = reviewResult.costUsd ?? 0;
+    reviewVariables = reviewResult.reviewVariables;
+    transitionState(runtime, "REVIEWING");
+
+    if (hookRegistry && hookExecutor) {
+      await safeExecuteHooks(hookRegistry, hookExecutor, "post-review", {
+        repo,
+        issue_number: String(issueNumber),
+      });
+    }
   }
 
-  let reviewCostUsd = reviewResult.costUsd ?? 0;
-  const reviewVariables = reviewResult.reviewVariables;
-  transitionState(runtime, "REVIEWING");
-
-  if (hookRegistry && hookExecutor) {
-    await safeExecuteHooks(hookRegistry, hookExecutor, "post-review", {
-      repo,
-      issue_number: String(issueNumber),
-    });
-  }
-
-  // Simplify Phase
-  if (reviewVariables) {
+  // Simplify Phase — skipSimplify 또는 reviewVariables 없으면 스킵.
+  if (preset.skipSimplify) {
+    logger.info("Simplify phase skipped (preset.skipSimplify=true)");
+    jl?.log("Simplify 단계 스킵 (모드 preset)");
+    transitionState(runtime, "SIMPLIFYING");
+  } else if (reviewVariables) {
     const simplifyContext: SimplifyContext = {
       project,
       worktreePath,


### PR DESCRIPTION
## Summary
- \`executePostProcessingPhases\`가 \`preset.skipReview\` / \`preset.skipSimplify\` 플래그를 평가하여 해당 블록을 건너뛰도록 수정
- skip 시 상태 전이(REVIEWING/SIMPLIFYING)만 수행하여 후속 단계 호환 유지
- \`reviewCostUsd\` / \`reviewVariables\`를 외부 스코프로 끌어올려 양 분기에서 일관 처리

## 배경
content 모드는 \`CONTENT_PRESET\`에서 \`skipReview=true, skipSimplify=true\`로 지정돼 있으나 \`pipeline-phases.ts\`가 그 플래그를 무시하고 항상 review/simplify를 호출했다. 콘텐츠 작업에서는 diff 기반 review가 부적절하고 simplify-runner도 reviewVariables 없으면 실패한다.

## 검증
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/pipeline/\` 682/682 통과