### PR TITLE
fix(pipeline-setup): 첫 체크포인트의 mode 하드코딩 제거

### DIFF
--- a/src/pipeline/setup/pipeline-setup.ts
+++ b/src/pipeline/setup/pipeline-setup.ts
@@ -163,20 +163,24 @@ export async function fetchAndValidateIssue(
 
     // === Safety: validate issue labels ===
     validateIssue(issue, project.safety, instanceLabel);
-
-    if (setupContext) {
-      saveCheckpoint(setupContext.dataDir, issueNumber, {
-        issueNumber, repo, state, projectRoot: setupContext.projectRoot,
-        worktreePath: setupContext.worktreePath, branchName: setupContext.branchName,
-        phaseResults: [], mode: "code", savedAt: new Date().toISOString(),
-      });
-    }
   }
 
   // Determine initial pipeline mode: issue label > project config > default
   const mode = resumeMode || detectModeFromLabels(issue.labels, project.mode ?? "code");
   logger.info(`Pipeline mode (초기): ${mode}`);
   jl?.log(`모드: ${mode}`);
+
+  // VALIDATED 단계 첫 진입이면 mode를 포함해 1회 저장.
+  // 이전에는 mode 결정 전에 saveCheckpoint를 호출하며 mode:"code"를 하드코딩했고,
+  // 그 결과 첫 체크포인트가 항상 code로 저장돼 resume 시 라벨/project.mode가
+  // 무시되는 버그가 있었다.
+  if (state === "VALIDATED" && setupContext) {
+    saveCheckpoint(setupContext.dataDir, issueNumber, {
+      issueNumber, repo, state, projectRoot: setupContext.projectRoot,
+      worktreePath: setupContext.worktreePath, branchName: setupContext.branchName,
+      phaseResults: [], mode, savedAt: new Date().toISOString(),
+    });
+  }
 
   // === Feasibility Check ===
   const feasibilityResult = checkFeasibility(issue, project.safety.feasibilityCheck);


### PR DESCRIPTION
## Summary
- VALIDATED 첫 진입에서 \`saveCheckpoint\`를 mode 결정 직후로 이동, 실제 결정된 \`mode\` 변수를 저장
- 기존 인라인 저장(\`mode: "code"\` 하드코딩)은 제거

## 배경
\`pipeline-setup.ts\`는 RECEIVED→VALIDATED 전이 시 \`saveCheckpoint\`를 호출했는데, 그 시점은 \`mode\` 변수 선언 이전이라 \`mode: "code"\`를 박아 넣었다. 첫 체크포인트가 code로 저장되고, resume 흐름이 \`resumeMode > label > project.mode\` 우선순위로 동작하므로 한 번 잘못 저장되면 영구적으로 code 모드로 재개되는 버그.

## 검증
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/pipeline/\` 682/682 통과