### PR TITLE
fix(cli): aqm run --target 미지정 시 config.projects[].path로 폴백

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,8 +69,24 @@ export async function runCommand(args: CliArgs): Promise<void> {
     ? { ...config, general: { ...config.general, dryRun: true } }
     : config;
   setGlobalLogLevel(effectiveConfig.general.logLevel);
-  const targetRoot = args.target ? resolve(args.target) : process.cwd();
+
+  // --target 미지정 시: config.projects에서 repo가 일치하는 항목의 path를 사용한다.
+  // 매칭 실패한 경우에만 cwd로 폴백. 기존에는 항상 cwd로 폴백해 aqm run을 다른
+  // 디렉토리에서 실행하면 엉뚱한 경로를 프로젝트 루트로 잡았다.
   const logger = getLogger();
+  let targetRoot: string;
+  if (args.target) {
+    targetRoot = resolve(args.target);
+  } else {
+    const matched = (effectiveConfig.projects ?? []).find(p => p.repo === args.repo);
+    if (matched) {
+      targetRoot = resolve(matched.path);
+      logger.info(`--target 미지정: config.projects의 매칭 path 사용 (${args.repo} → ${targetRoot})`);
+    } else {
+      targetRoot = process.cwd();
+      logger.warn(`--target 미지정 + config.projects에 ${args.repo} 매칭 없음 → 현재 디렉토리(cwd) 사용`);
+    }
+  }
 
   logger.info(`AI Quartermaster 시작 - Issue #${args.issue} (${args.repo})`);
   logger.info(`대상 프로젝트: ${targetRoot}`);


### PR DESCRIPTION
## Summary
- \`aqm run\` 실행 시 \`--target\`이 없으면 \`config.projects\`에서 \`args.repo\`와 일치하는 항목의 \`path\`를 사용
- 매칭 실패한 경우에만 \`process.cwd()\`로 폴백, 결과 경로를 info/warn 로그로 명시

## 배경
사용자 보고: \`aqm run --issue N --repo owner/repo\`를 다른 디렉토리에서 실행하면 그 디렉토리를 프로젝트 루트로 잡아 \`.worktrees/\`가 엉뚱한 위치에 생성됨.

## 검증
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/\` 3438 passed (7 skipped)