### PR TITLE
fix(bin): foreground 시작도 PID 파일 작성

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -361,8 +361,24 @@ case "${1:-}" in
       exit 0
     fi
 
-    # Foreground mode — pass through
-    exec_cli start "${ARGS[@]}"
+    # Foreground mode — PID 파일을 작성하고 자식 프로세스로 띄워 부모가 wait한다.
+    # 기존에는 exec_cli로 바로 교체해 PID 파일이 없었고, aqm stop/restart가
+    # lsof 폴백에만 의존했다. PID 파일이 있으면 즉시 신호 전달 가능.
+    mkdir -p "$AQM_DATA_DIR/logs"
+    inject_default_config start "${ARGS[@]}"
+    if [ "$AQM_MODE" = "npm" ]; then
+      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" &
+    else
+      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" &
+    fi
+    CHILD_PID=$!
+    echo "$CHILD_PID" > "$AQM_PID_FILE"
+    # Ctrl+C / SIGTERM 시 자식에게 신호 전달, EXIT에서 PID 파일 정리
+    trap 'rm -f "$AQM_PID_FILE"' EXIT
+    trap 'kill -TERM "$CHILD_PID" 2>/dev/null' INT TERM
+    wait "$CHILD_PID"
+    EXIT_CODE=$?
+    exit $EXIT_CODE
     ;;
   stop)
     # Extract port from config or use default


### PR DESCRIPTION
## Summary
- \`aqm start\` foreground 모드를 \`exec_cli\` 대체에서 자식 프로세스 + \`wait\` 패턴으로 변경
- 부모가 \`.aqm-server.pid\` 작성, INT/TERM 신호를 자식에게 전달, EXIT에서 PID 파일 정리
- 자식 종료 코드를 그대로 종료 코드로 사용

## 배경
foreground는 PID 파일이 없어 \`aqm stop\` / \`aqm restart\`가 lsof 폴백에만 의존. lsof 없는 환경 또는 PID 파일을 기대하는 외부 도구에서 무력화. daemon 모드와 동일하게 PID 파일이 있으면 즉시 신호 전달 가능.

## 검증
- \`bash -n bin/aqm\` 통과