### PR TITLE
chore(review-round1): code-reviewer/simplifier 피드백 반영

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -364,12 +364,16 @@ case "${1:-}" in
     # Foreground mode — PID 파일을 작성하고 자식 프로세스로 띄워 부모가 wait한다.
     # 기존에는 exec_cli로 바로 교체해 PID 파일이 없었고, aqm stop/restart가
     # lsof 폴백에만 의존했다. PID 파일이 있으면 즉시 신호 전달 가능.
+    # 출력은 터미널과 server.log에 동시에 남긴다 — daemon 모드와 동일한 위치라
+    # aqm logs가 일관되게 동작한다. (process substitution 사용 → CHILD_PID는 node)
     mkdir -p "$AQM_DATA_DIR/logs"
     inject_default_config start "${ARGS[@]}"
     if [ "$AQM_MODE" = "npm" ]; then
-      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" &
+      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" \
+        > >(tee -a "$AQM_LOG_FILE") 2> >(tee -a "$AQM_LOG_FILE" >&2) &
     else
-      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" &
+      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" \
+        > >(tee -a "$AQM_LOG_FILE") 2> >(tee -a "$AQM_LOG_FILE" >&2) &
     fi
     CHILD_PID=$!
     echo "$CHILD_PID" > "$AQM_PID_FILE"
@@ -377,8 +381,7 @@ case "${1:-}" in
     trap 'rm -f "$AQM_PID_FILE"' EXIT
     trap 'kill -TERM "$CHILD_PID" 2>/dev/null' INT TERM
     wait "$CHILD_PID"
-    EXIT_CODE=$?
-    exit $EXIT_CODE
+    exit $?
     ;;
   stop)
     # Extract port from config or use default

--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -48,9 +48,7 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     const elapsedSec = Math.floor((Date.now() - startTime) / 1000);
     logger.info(`[HEARTBEAT] pipeline alive — issue=#${input.issueNumber} repo=${input.repo} state=${runtime.state} elapsed=${elapsedSec}s`);
   }, HEARTBEAT_INTERVAL_MS);
-  if (typeof heartbeatTimer.unref === "function") {
-    heartbeatTimer.unref();
-  }
+  heartbeatTimer.unref?.();
 
   // 전체 파이프라인 수명 동안 유지되는 누적 phase 결과 배열
   const accumulatedPhaseResults: PhaseResult[] = [];

--- a/src/pipeline/setup/pipeline-setup.ts
+++ b/src/pipeline/setup/pipeline-setup.ts
@@ -169,10 +169,9 @@ export async function fetchAndValidateIssue(
   // 우선순위: 명시 라벨(aq-mode:*) > resumeMode(체크포인트 mode) > project.mode > "code".
   // 명시 라벨을 resumeMode보다 우선하지 않으면, 한 번 잘못 저장된 체크포인트가 라벨 변경을
   // 이기는 상황이 생긴다 (사용자 보고: "라벨을 바꿔도 mode가 안 바뀐다").
-  const explicitLabelModeMatch = issue.labels
-    .map(l => /^aq-mode:(code|content|qa)$/.exec(l))
-    .find((m): m is RegExpExecArray => m !== null);
-  const explicitLabelMode = explicitLabelModeMatch?.[1] as PipelineMode | undefined;
+  const explicitLabelMode = issue.labels
+    .map(l => /^aq-mode:(code|content|qa)$/.exec(l)?.[1])
+    .find((m): m is string => m !== undefined) as PipelineMode | undefined;
   const mode: PipelineMode = explicitLabelMode
     ?? resumeMode
     ?? detectModeFromLabels(issue.labels, project.mode ?? "code");

--- a/src/setup/setup-wizard.ts
+++ b/src/setup/setup-wizard.ts
@@ -306,7 +306,7 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
       continue;
     }
     if (invalid) {
-      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}'`);
+      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}' — 영숫자/하이픈만, 하이픈으로 시작·종료 불가, 최대 39자`);
       continue;
     }
     break;


### PR DESCRIPTION
## Summary
1라운드 자동 리뷰(code-reviewer + code-simplifier)에서 실질적 항목만 픽스:
- bin/aqm foreground stdout/stderr → server.log tee (HIGH 항목)
- bin/aqm \`EXIT_CODE\` 변수 제거 → \`exit \$?\`
- orchestrator \`unref?.()\` 옵셔널 체이닝
- setup-wizard 잘못된 GitHub ID 입력 시 규칙 안내 (UX)
- pipeline-setup aq-mode 라벨 추출 simplify (DRY)

## 검증
- \`bash -n bin/aqm\` 통과
- \`npx tsc --noEmit\` 통과
- \`npx vitest run tests/\` 3438 passed (7 skipped)