### PR TITLE
release: v0.9.4 — 첫 설치자/콘텐츠 모드 블로커 픽스

### DIFF
--- a/bin/aqm
+++ b/bin/aqm
@@ -364,12 +364,16 @@ case "${1:-}" in
     # Foreground mode — PID 파일을 작성하고 자식 프로세스로 띄워 부모가 wait한다.
     # 기존에는 exec_cli로 바로 교체해 PID 파일이 없었고, aqm stop/restart가
     # lsof 폴백에만 의존했다. PID 파일이 있으면 즉시 신호 전달 가능.
+    # 출력은 터미널과 server.log에 동시에 남긴다 — daemon 모드와 동일한 위치라
+    # aqm logs가 일관되게 동작한다. (process substitution 사용 → CHILD_PID는 node)
     mkdir -p "$AQM_DATA_DIR/logs"
     inject_default_config start "${ARGS[@]}"
     if [ "$AQM_MODE" = "npm" ]; then
-      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" &
+      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" \
+        > >(tee -a "$AQM_LOG_FILE") 2> >(tee -a "$AQM_LOG_FILE" >&2) &
     else
-      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" &
+      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" \
+        > >(tee -a "$AQM_LOG_FILE") 2> >(tee -a "$AQM_LOG_FILE" >&2) &
     fi
     CHILD_PID=$!
     echo "$CHILD_PID" > "$AQM_PID_FILE"
@@ -377,8 +381,7 @@ case "${1:-}" in
     trap 'rm -f "$AQM_PID_FILE"' EXIT
     trap 'kill -TERM "$CHILD_PID" 2>/dev/null' INT TERM
     wait "$CHILD_PID"
-    EXIT_CODE=$?
-    exit $EXIT_CODE
+    exit $?
     ;;
   stop)
     # Extract port from config or use default

--- a/bin/aqm
+++ b/bin/aqm
@@ -361,8 +361,24 @@ case "${1:-}" in
       exit 0
     fi
 
-    # Foreground mode — pass through
-    exec_cli start "${ARGS[@]}"
+    # Foreground mode — PID 파일을 작성하고 자식 프로세스로 띄워 부모가 wait한다.
+    # 기존에는 exec_cli로 바로 교체해 PID 파일이 없었고, aqm stop/restart가
+    # lsof 폴백에만 의존했다. PID 파일이 있으면 즉시 신호 전달 가능.
+    mkdir -p "$AQM_DATA_DIR/logs"
+    inject_default_config start "${ARGS[@]}"
+    if [ "$AQM_MODE" = "npm" ]; then
+      node "$AQM_ROOT/dist/cli.js" "${INJECTED_ARGS[@]}" &
+    else
+      npx --prefix "$AQM_ROOT" tsx "$AQM_ROOT/src/cli.ts" "${INJECTED_ARGS[@]}" &
+    fi
+    CHILD_PID=$!
+    echo "$CHILD_PID" > "$AQM_PID_FILE"
+    # Ctrl+C / SIGTERM 시 자식에게 신호 전달, EXIT에서 PID 파일 정리
+    trap 'rm -f "$AQM_PID_FILE"' EXIT
+    trap 'kill -TERM "$CHILD_PID" 2>/dev/null' INT TERM
+    wait "$CHILD_PID"
+    EXIT_CODE=$?
+    exit $EXIT_CODE
     ;;
   stop)
     # Extract port from config or use default

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-AQM_INSTALL_MODE="${AQM_INSTALL_MODE:-npm}"
+AQM_INSTALL_MODE="${AQM_INSTALL_MODE:-git}"
 AQM_HOME="${AQM_HOME:-$HOME/.ai-quartermaster}"
 BIN_DIR="${HOME}/.local/bin"
 REPO_URL="https://github.com/happytalkrz/AI-Quartermaster.git"
@@ -128,7 +128,9 @@ check_optional "claude" "https://docs.anthropic.com/en/docs/claude-code"
 echo ""
 
 # ── 2. 설치 ────────────────────────────────────────────────────────────
-NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX.log)
+# macOS(BSD) mktemp는 'XXXXXX' 뒤에 suffix가 있으면 치환을 하지 않아 매 호출 같은 경로를 반환한다.
+# .log 확장자는 외부에 노출되지 않으므로 XXXXXX를 끝에 두고 suffix를 제거한다.
+NPM_LOG=$(mktemp /tmp/aqm-install-XXXXXX)
 
 if [ "$AQM_INSTALL_MODE" = "git" ]; then
   # ── git-clone 모드 (AQM_INSTALL_MODE=git) ─────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-quartermaster",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
         "@hono/zod-validator": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-quartermaster",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "AI 병참부 - GitHub Issue to Draft PR automation pipeline",
   "type": "module",
   "engines": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,8 +69,24 @@ export async function runCommand(args: CliArgs): Promise<void> {
     ? { ...config, general: { ...config.general, dryRun: true } }
     : config;
   setGlobalLogLevel(effectiveConfig.general.logLevel);
-  const targetRoot = args.target ? resolve(args.target) : process.cwd();
+
+  // --target 미지정 시: config.projects에서 repo가 일치하는 항목의 path를 사용한다.
+  // 매칭 실패한 경우에만 cwd로 폴백. 기존에는 항상 cwd로 폴백해 aqm run을 다른
+  // 디렉토리에서 실행하면 엉뚱한 경로를 프로젝트 루트로 잡았다.
   const logger = getLogger();
+  let targetRoot: string;
+  if (args.target) {
+    targetRoot = resolve(args.target);
+  } else {
+    const matched = (effectiveConfig.projects ?? []).find(p => p.repo === args.repo);
+    if (matched) {
+      targetRoot = resolve(matched.path);
+      logger.info(`--target 미지정: config.projects의 매칭 path 사용 (${args.repo} → ${targetRoot})`);
+    } else {
+      targetRoot = process.cwd();
+      logger.warn(`--target 미지정 + config.projects에 ${args.repo} 매칭 없음 → 현재 디렉토리(cwd) 사용`);
+    }
+  }
 
   logger.info(`AI Quartermaster 시작 - Issue #${args.issue} (${args.repo})`);
   logger.info(`대상 프로젝트: ${targetRoot}`);

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -100,8 +100,9 @@ export const DEFAULT_CONFIG: AQConfig = {
     rounds: [
       {
         name: "code-review",
-        promptTemplate:
-          "Review the following code changes for correctness, style, and potential issues:\n\n{diff}",
+        // review-runner는 promptTemplate를 prompts/ 디렉토리 내 파일명으로 취급한다.
+        // raw text를 넣으면 path로 resolve돼 ENOENT가 발생한다.
+        promptTemplate: "review-round1.md",
         failAction: "warn",
         maxRetries: 2,
         model: null,
@@ -111,8 +112,7 @@ export const DEFAULT_CONFIG: AQConfig = {
     ],
     simplify: {
       enabled: true,
-      promptTemplate:
-        "Simplify the following implementation while preserving all functionality:\n\n{diff}",
+      promptTemplate: "review-round3-simplify.md",
     },
     unifiedMode: false,  // 기본값은 false로 기존 동작 유지
   },

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -13,6 +13,7 @@ import type { JobLogger } from "../../queue/job-logger.js";
 import { PatternStore, getPatternStore } from "../../learning/pattern-store.js";
 import { PROGRESS_PLAN_GENERATED, phaseStart } from "../reporting/progress-tracker.js";
 import { makePseudoPhaseSuccess, makePseudoPhaseFailure, nowIso } from "../reporting/phase-result-helper.js";
+import { getModePreset } from "../../config/mode-presets.js";
 import { createWorktree, removeWorktree } from "../../git/worktree-manager.js";
 import { createCheckpoint } from "../../safety/rollback-manager.js";
 import { createSlug } from "../../utils/slug.js";
@@ -313,6 +314,13 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
     }
   }
 
+  // mode preset에 따라 phase 실행 단계에서 사용할 test/lint 명령을 결정한다.
+  // content 모드 등 코드 검증이 부적절한 모드에서는 빈 문자열로 비워 phase-executor /
+  // phase-retry가 명령 실행을 건너뛰도록 한다 (ENOENT 방지).
+  const modePreset = getModePreset(plan.mode ?? "code");
+  const effectiveTestCommand = modePreset.skipTests ? "" : ctx.config.commands.test;
+  const effectiveLintCommand = modePreset.skipLint ? "" : ctx.config.commands.lint;
+
   // Schedule phases for parallel execution based on dependencies
   const enableParallelPhases = ctx.config.features?.parallelPhases ?? false;
   logger.info(`Parallel phases feature: ${enableParallelPhases ? 'enabled' : 'disabled'}`);
@@ -377,8 +385,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
         claudeConfig: ctx.config.commands.claudeCli,
         promptsDir: ctx.promptsDir,
         cwd: ctx.cwd,
-        testCommand: ctx.config.commands.test,
-        lintCommand: ctx.config.commands.lint,
+        testCommand: effectiveTestCommand,
+        lintCommand: effectiveLintCommand,
         gitPath: ctx.config.git.gitPath,
         projectConventions: ctx.projectConventions,
         skillsContext: ctx.skillsContext,
@@ -420,8 +428,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
             claudeConfig: ctx.config.commands.claudeCli,
             promptsDir: ctx.promptsDir,
             cwd: ctx.cwd,
-            testCommand: ctx.config.commands.test,
-            lintCommand: ctx.config.commands.lint,
+            testCommand: effectiveTestCommand,
+            lintCommand: effectiveLintCommand,
             gitPath: ctx.config.git.gitPath,
             jobLogger: jl,
             checkpoint,

--- a/src/pipeline/core/core-loop.ts
+++ b/src/pipeline/core/core-loop.ts
@@ -3,7 +3,7 @@ import { selectExecutor } from "../execution/executor-factory.js";
 import { retryPhase } from "../execution/phase-retry.js";
 import { checkPhaseLimit } from "../../safety/phase-limit-guard.js";
 import { schedulePhases } from "../execution/phase-scheduler.js";
-import type { AQConfig } from "../../types/config.js";
+import type { AQConfig, PipelineMode } from "../../types/config.js";
 import type { Plan, PhaseResult, ErrorHistoryEntry, ErrorCategory, PlanWithCost, CostBreakdown, ModelCostEntry } from "../../types/pipeline.js";
 import type { GitHubIssue } from "../../github/issue-fetcher.js";
 import { getLogger } from "../../utils/logger.js";
@@ -138,6 +138,12 @@ export interface CoreLoopContext {
   promptsDir: string;
   cwd: string;
   modeHint?: string;
+  /**
+   * 호출자가 결정한 초기 PipelineMode. baseline 캡처 등 plan 생성 이전 단계에서
+   * preset 플래그(skipTypecheck/skipLint 등)를 적용하는 데 사용된다.
+   * 생략 시 "code"로 간주한다.
+   */
+  mode?: PipelineMode;
   projectConventions?: string;
   skillsContext?: string;
   dataDir?: string;
@@ -212,7 +218,11 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
   }
 
   // Step 0b: Capture error baseline (한 번만 캡처하여 모든 phase에서 재사용)
-  if (!ctx.baseline) {
+  // content 모드 등 코드 검증을 건너뛰는 preset에서는 baseline 캡처 자체를 스킵한다.
+  // 그렇지 않으면 package.json이 없는 디렉토리에서 ENOENT/오류 로그가 양산된다.
+  const initialPreset = getModePreset(ctx.mode ?? "code");
+  const shouldSkipBaseline = initialPreset.skipTypecheck && initialPreset.skipLint;
+  if (!ctx.baseline && !shouldSkipBaseline) {
     logger.info("Capturing pre-existing error baseline (tsc + eslint)...");
     ctx.baseline = await captureErrorBaseline(ctx.cwd, {
       typecheck: ctx.config.commands.typecheck,
@@ -220,6 +230,8 @@ export async function runCoreLoop(ctx: CoreLoopContext): Promise<CoreLoopResult>
       test: ctx.config.commands.test,
     });
     logger.info(`Baseline captured: tsc=${ctx.baseline.tsc.totalErrors} errors, eslint=${ctx.baseline.eslint.totalErrors} errors, test failures=${ctx.baseline.test?.failedFiles.length ?? "not captured"}, capture warnings=${ctx.baseline.captureWarnings?.length ?? 0}`);
+  } else if (shouldSkipBaseline) {
+    logger.info(`Baseline capture skipped (mode=${ctx.mode ?? "code"}, skipTypecheck+skipLint preset)`);
   }
 
   // Step 1: Generate plan

--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -48,9 +48,7 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
     const elapsedSec = Math.floor((Date.now() - startTime) / 1000);
     logger.info(`[HEARTBEAT] pipeline alive — issue=#${input.issueNumber} repo=${input.repo} state=${runtime.state} elapsed=${elapsedSec}s`);
   }, HEARTBEAT_INTERVAL_MS);
-  if (typeof heartbeatTimer.unref === "function") {
-    heartbeatTimer.unref();
-  }
+  heartbeatTimer.unref?.();
 
   // 전체 파이프라인 수명 동안 유지되는 누적 phase 결과 배열
   const accumulatedPhaseResults: PhaseResult[] = [];

--- a/src/pipeline/core/orchestrator.ts
+++ b/src/pipeline/core/orchestrator.ts
@@ -22,11 +22,15 @@ import { HookRegistry } from "../../hooks/hook-registry.js";
 import { HookExecutor } from "../../hooks/hook-executor.js";
 import { dispatchPipelineEvent } from "../automation/automation-dispatcher.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
+import { getLogger } from "../../utils/logger.js";
+
+const HEARTBEAT_INTERVAL_MS = 60_000;
 
 
 export async function runPipeline(input: OrchestratorInput): Promise<OrchestratorResult> {
   const { config, aqRoot } = input;
   const startTime = Date.now();
+  const logger = getLogger();
 
   // Initialize hook registry and executor from config
   const hookRegistry = new HookRegistry(config.hooks ?? {});
@@ -37,6 +41,16 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
 
   // Initialize pipeline state
   const runtime = await initializePipelineState(input, config);
+
+  // 파이프라인 진행 단계 heartbeat — 사용자에게 hang이 아님을 알린다.
+  // Plan 생성/Phase 작성 같은 장기 단계가 60s 이상 걸려도 server.log에 진행 신호가 보이도록.
+  const heartbeatTimer = setInterval(() => {
+    const elapsedSec = Math.floor((Date.now() - startTime) / 1000);
+    logger.info(`[HEARTBEAT] pipeline alive — issue=#${input.issueNumber} repo=${input.repo} state=${runtime.state} elapsed=${elapsedSec}s`);
+  }, HEARTBEAT_INTERVAL_MS);
+  if (typeof heartbeatTimer.unref === "function") {
+    heartbeatTimer.unref();
+  }
 
   // 전체 파이프라인 수명 동안 유지되는 누적 phase 결과 배열
   const accumulatedPhaseResults: PhaseResult[] = [];
@@ -153,7 +167,8 @@ export async function runPipeline(input: OrchestratorInput): Promise<Orchestrato
       startTime
     });
   } finally {
-    // 파이프라인 종료 시 캐시 정리 - 성공/실패 모두 메모리 누수 방지
+    // 파이프라인 종료 시 heartbeat 중지 + 캐시 정리 — 성공/실패 모두 메모리 누수 방지
+    clearInterval(heartbeatTimer);
     clearCache();
   }
 }

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -7,6 +7,7 @@ import { getLogger } from "../../utils/logger.js";
 import { getErrorMessage } from "../../utils/error-utils.js";
 import { handleCoreLoopFailure } from "../errors/pipeline-error-handler.js";
 import { runReviewPhase, runSimplifyPhase, type ReviewContext, type SimplifyContext } from "./pipeline-review.js";
+import type { ReviewVariables } from "../../types/review.js";
 import { runValidationPhase } from "../setup/pipeline-validation.js";
 import { pushAndCreatePR, cleanupOnSuccess } from "./pipeline-publish.js";
 import { setupGitEnvironment, prepareWorkEnvironment } from "../setup/pipeline-git-setup.js";
@@ -449,46 +450,59 @@ export async function executePostProcessingPhases(
     });
   }
 
-  // Review Phase
-  const reviewContext: ReviewContext = {
-    issue,
-    coreResult,
-    gitConfig,
-    project,
-    worktreePath,
-    promptsDir,
-    skillsContext,
-    jl,
-    timer,
-    checkpoint
-  };
+  // Review Phase — mode preset이 skipReview면 스킵하고 상태 전이만 수행.
+  let reviewCostUsd = 0;
+  let reviewVariables: ReviewVariables | undefined;
 
-  const reviewTracking = await runPhaseWithTracking(
-    "review:code",
-    () => runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState),
-    context.accumulatedPhaseResults
-  );
-  const reviewResult = reviewTracking.result;
+  if (preset.skipReview) {
+    logger.info("Review phase skipped (preset.skipReview=true)");
+    jl?.log("Review 단계 스킵 (모드 preset)");
+    transitionState(runtime, "REVIEWING");
+  } else {
+    const reviewContext: ReviewContext = {
+      issue,
+      coreResult,
+      gitConfig,
+      project,
+      worktreePath,
+      promptsDir,
+      skillsContext,
+      jl,
+      timer,
+      checkpoint
+    };
 
-  if (!reviewResult.success) {
-    const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
-    saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
-    throw new Error(reviewResult.error || "Review phase failed");
+    const reviewTracking = await runPhaseWithTracking(
+      "review:code",
+      () => runReviewPhase(reviewContext, executionModePreset, runtime.state, isPastState),
+      context.accumulatedPhaseResults
+    );
+    const reviewResult = reviewTracking.result;
+
+    if (!reviewResult.success) {
+      const report = formatResult(issueNumber, repo, coreResult.plan, coreResult.phaseResults, startTime, undefined, coreResult.totalUsage);
+      saveResult(config, aqRoot ?? runtime.projectRoot, issueNumber, report);
+      throw new Error(reviewResult.error || "Review phase failed");
+    }
+
+    reviewCostUsd = reviewResult.costUsd ?? 0;
+    reviewVariables = reviewResult.reviewVariables;
+    transitionState(runtime, "REVIEWING");
+
+    if (hookRegistry && hookExecutor) {
+      await safeExecuteHooks(hookRegistry, hookExecutor, "post-review", {
+        repo,
+        issue_number: String(issueNumber),
+      });
+    }
   }
 
-  let reviewCostUsd = reviewResult.costUsd ?? 0;
-  const reviewVariables = reviewResult.reviewVariables;
-  transitionState(runtime, "REVIEWING");
-
-  if (hookRegistry && hookExecutor) {
-    await safeExecuteHooks(hookRegistry, hookExecutor, "post-review", {
-      repo,
-      issue_number: String(issueNumber),
-    });
-  }
-
-  // Simplify Phase
-  if (reviewVariables) {
+  // Simplify Phase — skipSimplify 또는 reviewVariables 없으면 스킵.
+  if (preset.skipSimplify) {
+    logger.info("Simplify phase skipped (preset.skipSimplify=true)");
+    jl?.log("Simplify 단계 스킵 (모드 preset)");
+    transitionState(runtime, "SIMPLIFYING");
+  } else if (reviewVariables) {
     const simplifyContext: SimplifyContext = {
       project,
       worktreePath,

--- a/src/pipeline/phases/pipeline-phases.ts
+++ b/src/pipeline/phases/pipeline-phases.ts
@@ -326,6 +326,7 @@ export async function executeCoreLoopPhase(
     promptsDir,
     cwd: runtime.worktreePath!,
     modeHint: preset.planHint,
+    mode,
     projectConventions: envResult.projectConventions,
     skillsContext: envResult.skillsContext,
     dataDir,

--- a/src/pipeline/setup/pipeline-setup.ts
+++ b/src/pipeline/setup/pipeline-setup.ts
@@ -165,8 +165,17 @@ export async function fetchAndValidateIssue(
     validateIssue(issue, project.safety, instanceLabel);
   }
 
-  // Determine initial pipeline mode: issue label > project config > default
-  const mode = resumeMode || detectModeFromLabels(issue.labels, project.mode ?? "code");
+  // Determine initial pipeline mode.
+  // 우선순위: 명시 라벨(aq-mode:*) > resumeMode(체크포인트 mode) > project.mode > "code".
+  // 명시 라벨을 resumeMode보다 우선하지 않으면, 한 번 잘못 저장된 체크포인트가 라벨 변경을
+  // 이기는 상황이 생긴다 (사용자 보고: "라벨을 바꿔도 mode가 안 바뀐다").
+  const explicitLabelModeMatch = issue.labels
+    .map(l => /^aq-mode:(code|content|qa)$/.exec(l))
+    .find((m): m is RegExpExecArray => m !== null);
+  const explicitLabelMode = explicitLabelModeMatch?.[1] as PipelineMode | undefined;
+  const mode: PipelineMode = explicitLabelMode
+    ?? resumeMode
+    ?? detectModeFromLabels(issue.labels, project.mode ?? "code");
   logger.info(`Pipeline mode (초기): ${mode}`);
   jl?.log(`모드: ${mode}`);
 

--- a/src/pipeline/setup/pipeline-setup.ts
+++ b/src/pipeline/setup/pipeline-setup.ts
@@ -169,10 +169,9 @@ export async function fetchAndValidateIssue(
   // 우선순위: 명시 라벨(aq-mode:*) > resumeMode(체크포인트 mode) > project.mode > "code".
   // 명시 라벨을 resumeMode보다 우선하지 않으면, 한 번 잘못 저장된 체크포인트가 라벨 변경을
   // 이기는 상황이 생긴다 (사용자 보고: "라벨을 바꿔도 mode가 안 바뀐다").
-  const explicitLabelModeMatch = issue.labels
-    .map(l => /^aq-mode:(code|content|qa)$/.exec(l))
-    .find((m): m is RegExpExecArray => m !== null);
-  const explicitLabelMode = explicitLabelModeMatch?.[1] as PipelineMode | undefined;
+  const explicitLabelMode = issue.labels
+    .map(l => /^aq-mode:(code|content|qa)$/.exec(l)?.[1])
+    .find((m): m is string => m !== undefined) as PipelineMode | undefined;
   const mode: PipelineMode = explicitLabelMode
     ?? resumeMode
     ?? detectModeFromLabels(issue.labels, project.mode ?? "code");

--- a/src/pipeline/setup/pipeline-setup.ts
+++ b/src/pipeline/setup/pipeline-setup.ts
@@ -163,20 +163,24 @@ export async function fetchAndValidateIssue(
 
     // === Safety: validate issue labels ===
     validateIssue(issue, project.safety, instanceLabel);
-
-    if (setupContext) {
-      saveCheckpoint(setupContext.dataDir, issueNumber, {
-        issueNumber, repo, state, projectRoot: setupContext.projectRoot,
-        worktreePath: setupContext.worktreePath, branchName: setupContext.branchName,
-        phaseResults: [], mode: "code", savedAt: new Date().toISOString(),
-      });
-    }
   }
 
   // Determine initial pipeline mode: issue label > project config > default
   const mode = resumeMode || detectModeFromLabels(issue.labels, project.mode ?? "code");
   logger.info(`Pipeline mode (초기): ${mode}`);
   jl?.log(`모드: ${mode}`);
+
+  // VALIDATED 단계 첫 진입이면 mode를 포함해 1회 저장.
+  // 이전에는 mode 결정 전에 saveCheckpoint를 호출하며 mode:"code"를 하드코딩했고,
+  // 그 결과 첫 체크포인트가 항상 code로 저장돼 resume 시 라벨/project.mode가
+  // 무시되는 버그가 있었다.
+  if (state === "VALIDATED" && setupContext) {
+    saveCheckpoint(setupContext.dataDir, issueNumber, {
+      issueNumber, repo, state, projectRoot: setupContext.projectRoot,
+      worktreePath: setupContext.worktreePath, branchName: setupContext.branchName,
+      phaseResults: [], mode, savedAt: new Date().toISOString(),
+    });
+  }
 
   // === Feasibility Check ===
   const feasibilityResult = checkFeasibility(issue, project.safety.feasibilityCheck);

--- a/src/setup/setup-wizard.ts
+++ b/src/setup/setup-wizard.ts
@@ -306,7 +306,7 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
       continue;
     }
     if (invalid) {
-      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}'`);
+      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}' — 영숫자/하이픈만, 하이픈으로 시작·종료 불가, 최대 39자`);
       continue;
     }
     break;

--- a/src/setup/setup-wizard.ts
+++ b/src/setup/setup-wizard.ts
@@ -38,6 +38,11 @@ export async function runSetup(aqRoot: string, options?: SetupOptions): Promise<
       const minimalConfig = `# AI 병참부 최소 설정 파일
 # 전체 옵션은 config.reference.yml 참조
 
+general:
+  # 필수: 이 인스턴스가 처리할 이슈를 만든 GitHub 사용자(들).
+  # 비어 있으면 모든 이슈가 차단됩니다. 본인 GitHub 아이디로 교체하세요.
+  instanceOwners: []
+
 projects:
   - repo: "owner/repo-name"        # 필수: GitHub 저장소 (owner/repo)
     path: "/path/to/local/clone"   # 필수: 로컬 클론 경로
@@ -58,7 +63,14 @@ projects:
     }
 
     const answers = await runInteractiveWizard();
+    const ownersYaml = answers.instanceOwners.map(o => `    - "${o}"`).join("\n");
     const userConfig = `# AI 병참부 프로젝트 설정
+
+general:
+  # 이 인스턴스가 처리할 이슈를 만든 GitHub 사용자 목록.
+  # 비어 있으면 모든 이슈가 차단됩니다.
+  instanceOwners:
+${ownersYaml}
 
 projects:
   - repo: "${answers.repo}"
@@ -276,7 +288,31 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
     }
   }
 
-  // 3. 서버 모드 선택 (폴링/웹훅)
+  // 3. 인스턴스 소유자(GitHub 아이디) 입력 — 비어 있으면 모든 이슈가 차단되므로 강제.
+  let instanceOwners: string[] = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const raw = await askQuestion(
+      "이 인스턴스가 처리할 이슈를 만든 GitHub 사용자 (콤마 구분, 예: alice,bob): ",
+    );
+    instanceOwners = raw
+      .split(",")
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    const invalid = instanceOwners.find(o => !/^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/.test(o));
+    if (instanceOwners.length === 0) {
+      console.log("   ❌ 최소 1명은 입력해야 합니다. 빈 값이면 모든 이슈가 차단됩니다.");
+      continue;
+    }
+    if (invalid) {
+      console.log(`   ❌ 잘못된 GitHub 아이디 형식: '${invalid}'`);
+      continue;
+    }
+    break;
+  }
+
+  // 4. 서버 모드 선택 (폴링/웹훅)
   const modeChoices = ["폴링 (간편 — webhook 설정 불필요)", "웹훅 (실시간 — smee.io 필요)"];
   const modeIndex = await askChoice("모드를 선택하세요:", modeChoices);
   const serverMode: ServerMode = modeIndex === 0 ? "polling" : "webhook";
@@ -284,7 +320,8 @@ export async function runInteractiveWizard(): Promise<WizardAnswers> {
   console.log("\n✅ 설정 완료!");
   console.log(`   저장소: ${repo}`);
   console.log(`   경로: ${path}`);
+  console.log(`   소유자: ${instanceOwners.join(", ")}`);
   console.log(`   모드: ${serverMode}\n`);
 
-  return { repo, path, serverMode };
+  return { repo, path, serverMode, instanceOwners };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -220,6 +220,7 @@ export interface WizardAnswers {
   repo: string;
   path: string;
   serverMode: ServerMode;
+  instanceOwners: string[];
 }
 
 /** Options for the init command */

--- a/tests/setup/setup-wizard.test.ts
+++ b/tests/setup/setup-wizard.test.ts
@@ -257,7 +257,8 @@ PORT=3000
     it("should collect valid answers through complete wizard flow", async () => {
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("test-user/test-repo")  // valid repo
-        .mockResolvedValueOnce(mockPath);               // valid path
+        .mockResolvedValueOnce(mockPath)               // valid path
+        .mockResolvedValueOnce("alice,bob");           // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode (index 0)
@@ -267,10 +268,11 @@ PORT=3000
       expect(result).toEqual({
         repo: "test-user/test-repo",
         path: mockPath,
-        serverMode: "polling"
+        serverMode: "polling",
+        instanceOwners: ["alice", "bob"]
       });
 
-      expect(mockAskQuestion).toHaveBeenCalledTimes(2);
+      expect(mockAskQuestion).toHaveBeenCalledTimes(3);
       expect(mockAskChoice).toHaveBeenCalledTimes(1);
     });
 
@@ -279,7 +281,8 @@ PORT=3000
         .mockResolvedValueOnce("invalid-repo")         // invalid (no slash)
         .mockResolvedValueOnce("user/")               // invalid (empty repo)
         .mockResolvedValueOnce("valid-user/valid-repo") // valid
-        .mockResolvedValueOnce(mockPath);             // valid path
+        .mockResolvedValueOnce(mockPath)              // valid path
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode
@@ -309,7 +312,8 @@ PORT=3000
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")           // valid repo
         .mockResolvedValueOnce(invalidPath)           // invalid path (doesn't exist)
-        .mockResolvedValueOnce(mockPath);              // valid path
+        .mockResolvedValueOnce(mockPath)              // valid path
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(1); // webhook mode (index 1)
@@ -328,7 +332,8 @@ PORT=3000
       const mockAskQuestion = vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")           // valid repo
         .mockResolvedValueOnce(nonExistentPath)       // invalid path
-        .mockResolvedValueOnce(mockPath);             // valid path (after clone suggestion)
+        .mockResolvedValueOnce(mockPath)              // valid path (after clone suggestion)
+        .mockResolvedValueOnce("alice");              // instance owners
 
       const mockAskChoice = vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0); // polling mode
@@ -367,7 +372,8 @@ PORT=3000
       // Test polling mode (choice 0)
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(mockPath);
+        .mockResolvedValueOnce(mockPath)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(0);  // polling mode (index 0)
@@ -381,7 +387,8 @@ PORT=3000
       // Test webhook mode (choice 1)
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(mockPath);
+        .mockResolvedValueOnce(mockPath)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice")
         .mockResolvedValue(1);  // webhook mode (index 1)
@@ -394,7 +401,8 @@ PORT=3000
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")    // valid repo
         .mockResolvedValueOnce("")             // empty path - triggers non-existence error
-        .mockResolvedValueOnce(mockPath);      // valid path
+        .mockResolvedValueOnce(mockPath)       // valid path
+        .mockResolvedValueOnce("alice");       // instance owners
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(0);
 
@@ -498,7 +506,8 @@ PORT=3000
     it("should write config and return early for polling mode", async () => {
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(testDir);  // testDir already exists
+        .mockResolvedValueOnce(testDir)        // testDir already exists
+        .mockResolvedValueOnce("alice");       // instance owners
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(0); // polling
 
@@ -508,12 +517,14 @@ PORT=3000
       expect(existsSync(configPath)).toBe(true);
       const content = readFileSync(configPath, "utf-8");
       expect(content).toContain("user/repo");
+      expect(content).toContain("alice");
     });
 
     it("should continue to smee/webhook steps for webhook mode", async () => {
       vi.spyOn(promptUtils, "askQuestion")
         .mockResolvedValueOnce("user/repo")
-        .mockResolvedValueOnce(testDir);
+        .mockResolvedValueOnce(testDir)
+        .mockResolvedValueOnce("alice");
 
       vi.spyOn(promptUtils, "askChoice").mockResolvedValue(1); // webhook
 


### PR DESCRIPTION
## Summary
첫 설치자가 부딪히는 블로커 + 콘텐츠 모드 처리 체인 + 운영 UX 개선 11건 + 1라운드 리뷰 피드백 반영분(PR #863)을 묶은 패치 릴리스.

## 포함된 PR (develop)

| PR | 영역 | 변경 |
|----|------|------|
| #851 | install.sh | 기본 모드 npm → git, mktemp BSD 호환 |
| #852 | setup-wizard | instanceOwners 강제 입력 |
| #853 | defaults.ts | review/simplify promptTemplate를 파일명으로 |
| #854 | core-loop | content 모드에서 test/lint 명령 스킵 |
| #855 | core-loop | content 모드에서 baseline 캡처 스킵 |
| #856 | pipeline-phases | content 모드에서 review/simplify 스킵 |
| #857 | pipeline-setup | 첫 체크포인트 mode 하드코딩 제거 |
| #858 | pipeline-setup | aq-mode:* 라벨이 resumeMode보다 우선 |
| #859 | cli.ts | aqm run --target → config.projects[].path 폴백 |
| #860 | bin/aqm | foreground 시작도 PID 파일 작성 |
| #861 | orchestrator | 파이프라인 60s heartbeat 로그 |
| #863 | review-round1 | bin/aqm tee server.log + 단순화 묶음 |

## 검증
- \`npx tsc --noEmit\` 통과 (0 errors)
- \`npx vitest run tests/\` 3438 passed (7 skipped, 0 failed)
- \`bash -n bin/aqm\` 통과
- 자동 code-reviewer 2라운드 — 회귀 없음 (1라운드 후 픽스 반영, 2라운드는 cosmetic MEDIUM 1건만 잔존, 가치 대비 spec drift 위험으로 미반영)
- 자동 code-simplifier 2라운드 — 추가 단순화 기회 없음

## 머지 후 후속
1. main → develop back-merge 필수
2. 사용자 환경에서 AQM 재설치 → 첫 설치자 블로커 해소 검증